### PR TITLE
:wrench: fix nxxm deps file instructions as it is case sensitive.

### DIFF
--- a/tutorial/build-with-nxxm.md
+++ b/tutorial/build-with-nxxm.md
@@ -3,7 +3,7 @@
 .nxxm/deps
 ~~~json
 {
-  "arthursonzogni/ftxui": {}
+  "ArthurSonzogni/FTXUI": {}
 }
 ~~~
 


### PR DESCRIPTION
Hi @ArthurSonzogni,

Actually you need to write the dependency case sensitively. I could then properly compile and run the example project through nxxm as a lib consumer. (Examples or tests dirs are not scanned by default in consumption mode).

Cheers,