### PR TITLE
Fix compilation issue on macOS(CLang compiler) 

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -11,6 +11,11 @@
 #include "ftxui/screen/string.hpp"
 #include "ftxui/screen/terminal.hpp"
 
+#if defined(__clang__) && defined (__APPLE__)
+    // Quick exit is missing in standard CLang headers
+    #define quick_exit(a) exit(a)
+#endif
+
 namespace ftxui {
 
 static const char* HIDE_CURSOR = "\e[?25l";


### PR DESCRIPTION
Fixes compilation error for macOS Clang compiler.

> '/src/ftxui/component/screen_interactive.cpp:36:5: error: use of undeclared identifier 'quick_exit'

For some reason macOS cstdlib doesn't contain definition for quick_exit()