### PR TITLE
Fixed P conversion

### DIFF
--- a/src/ftxui/component/event.cpp
+++ b/src/ftxui/component/event.cpp
@@ -142,9 +142,6 @@ void Event::Convert(Receiver<char>& in, Sender<Event>& out, char c) {
     case 26:  // SUB
       return;
 
-    case 'P':
-      return ParseDCS(in, out, input);
-
     case '\x1B':
       return ParseESC(in, out, input);
   }


### PR DESCRIPTION
Simply removing the 'P' case the conversion works fine. I didn't get the intention behind this case so feel free to reject the pull request if this fix isn't suitable.