### PR TITLE
Rgb color support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-build/
-.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(Threads)
 
 add_library(screen
   src/ftxui/screen/box.cpp
+  src/ftxui/screen/color.cpp
   src/ftxui/screen/screen.cpp
   src/ftxui/screen/string.cpp
   src/ftxui/screen/terminal.cpp
@@ -163,7 +164,7 @@ export(TARGETS screen dom component NAMESPACE ftxui::
   FILE ${PROJECT_BINARY_DIR}/ftxui-targets.cmake)
 
 
-if (FTXUI_BUILD_TESTS AND ${CMAKE_VERSION} VERSION_GREATER "3.11.4") 
+if (FTXUI_BUILD_TESTS AND ${CMAKE_VERSION} VERSION_GREATER "3.11.4")
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
   set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)

--- a/examples/dom/style_color.cpp
+++ b/examples/dom/style_color.cpp
@@ -6,50 +6,112 @@
 #include <ftxui/screen/screen.hpp>
 #include <iostream>
 
+#include "ftxui/screen/string.hpp"
+
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   // clang-format off
+  auto terminal_info =
+    vbox(
+      text(L"Basic Color support : NA"),
+      text(L"256 Color support : NA"),
+      text(L"TrueColor support : NA")
+    );
+
+  auto basic_color_display =
+    vbox(
+      text(L"Basic Color Set:"),
+      hbox(
+        vbox(
+          color(Color::Default, text(L"Default")),
+          color(Color::Black, text(L"Black")),
+          color(Color::GrayDark, text(L"GrayDark")),
+          color(Color::GrayLight, text(L"GrayLight")),
+          color(Color::White, text(L"White")),
+          color(Color::Blue, text(L"Blue")),
+          color(Color::BlueLight, text(L"BlueLight")),
+          color(Color::Cyan, text(L"Cyan")),
+          color(Color::CyanLight, text(L"CyanLight")),
+          color(Color::Green, text(L"Green")),
+          color(Color::GreenLight, text(L"GreenLight")),
+          color(Color::Magenta, text(L"Magenta")),
+          color(Color::MagentaLight, text(L"MagentaLight")),
+          color(Color::Red, text(L"Red")),
+          color(Color::RedLight, text(L"RedLight")),
+          color(Color::Yellow, text(L"Yellow")),
+          color(Color::YellowLight, text(L"YellowLight"))
+        ),
+        vbox(
+          bgcolor(Color::Default, text(L"Default")),
+          bgcolor(Color::Black, text(L"Black")),
+          bgcolor(Color::GrayDark, text(L"GrayDark")),
+          bgcolor(Color::GrayLight, text(L"GrayLight")),
+          bgcolor(Color::White, text(L"White")),
+          bgcolor(Color::Blue, text(L"Blue")),
+          bgcolor(Color::BlueLight, text(L"BlueLight")),
+          bgcolor(Color::Cyan, text(L"Cyan")),
+          bgcolor(Color::CyanLight, text(L"CyanLight")),
+          bgcolor(Color::Green, text(L"Green")),
+          bgcolor(Color::GreenLight, text(L"GreenLight")),
+          bgcolor(Color::Magenta, text(L"Magenta")),
+          bgcolor(Color::MagentaLight, text(L"MagentaLight")),
+          bgcolor(Color::Red, text(L"Red")),
+          bgcolor(Color::RedLight, text(L"RedLight")),
+          bgcolor(Color::Yellow, text(L"Yellow")),
+          bgcolor(Color::YellowLight, text(L"YellowLight"))
+        )
+      )
+    );
+
+  auto palette_256_color_display =
+    vbox(
+      text(L"256 color palette:")
+    );
+
+  int y =-1;
+  for(int i = 0; i < 256; ++i)
+  {
+    if(i%16 == 0)
+    {
+      palette_256_color_display->children.push_back(hbox());
+      ++y;
+    }
+    int color_index = y+(i%16)*16;
+    std::string number = std::to_string(color_index);
+    while(number.length() < 3)
+    {
+      number.push_back(' ');
+    }
+    palette_256_color_display->children.back()->children.push_back(bgcolor(Color::Color256(color_index),text(to_wstring(number))));
+    palette_256_color_display->children.back()->children.push_back(text(L" "));
+  }
+
+  auto true_color_display =
+    vbox(
+      text(L"a true color grandient:")
+    );
+
+  for(int i = 0; i < 17; ++i)
+  {
+    true_color_display->children.push_back(hbox());
+
+    for(int j = 0; j < 30; ++j)
+    {
+      true_color_display->children.back()->children.push_back(bgcolor(Color::ColorRGB(50+i*5,100+j, 150),text(L" ")));
+    }
+  }
+
   auto document =
-    hbox(
-      vbox(
-        color(Color::Default, text(L"Default")),
-        color(Color::Black, text(L"Black")),
-        color(Color::GrayDark, text(L"GrayDark")),
-        color(Color::GrayLight, text(L"GrayLight")),
-        color(Color::White, text(L"White")),
-        color(Color::Blue, text(L"Blue")),
-        color(Color::BlueLight, text(L"BlueLight")),
-        color(Color::Cyan, text(L"Cyan")),
-        color(Color::CyanLight, text(L"CyanLight")),
-        color(Color::Green, text(L"Green")),
-        color(Color::GreenLight, text(L"GreenLight")),
-        color(Color::Magenta, text(L"Magenta")),
-        color(Color::MagentaLight, text(L"MagentaLight")),
-        color(Color::Red, text(L"Red")),
-        color(Color::RedLight, text(L"RedLight")),
-        color(Color::Yellow, text(L"Yellow")),
-        color(Color::YellowLight, text(L"YellowLight"))
-      ),
-      vbox(
-        bgcolor(Color::Default, text(L"Default")),
-        bgcolor(Color::Black, text(L"Black")),
-        bgcolor(Color::GrayDark, text(L"GrayDark")),
-        bgcolor(Color::GrayLight, text(L"GrayLight")),
-        bgcolor(Color::White, text(L"White")),
-        bgcolor(Color::Blue, text(L"Blue")),
-        bgcolor(Color::BlueLight, text(L"BlueLight")),
-        bgcolor(Color::Cyan, text(L"Cyan")),
-        bgcolor(Color::CyanLight, text(L"CyanLight")),
-        bgcolor(Color::Green, text(L"Green")),
-        bgcolor(Color::GreenLight, text(L"GreenLight")),
-        bgcolor(Color::Magenta, text(L"Magenta")),
-        bgcolor(Color::MagentaLight, text(L"MagentaLight")),
-        bgcolor(Color::Red, text(L"Red")),
-        bgcolor(Color::RedLight, text(L"RedLight")),
-        bgcolor(Color::Yellow, text(L"Yellow")),
-        bgcolor(Color::YellowLight, text(L"YellowLight"))
-      ),
-      filler()
+    vbox(
+      terminal_info,
+      text(L""),
+      hbox(
+        basic_color_display,
+        text(L"  "),
+        palette_256_color_display,
+        text(L" "),
+        true_color_display
+      )
     );
   // clang-format on
 

--- a/examples/dom/style_color.cpp
+++ b/examples/dom/style_color.cpp
@@ -4,6 +4,7 @@
 
 #include <ftxui/dom/elements.hpp>
 #include <ftxui/screen/screen.hpp>
+#include <ftxui/screen/terminal.hpp>
 #include <iostream>
 
 #include "ftxui/screen/string.hpp"
@@ -13,9 +14,11 @@ int main(int argc, const char* argv[]) {
   // clang-format off
   auto terminal_info =
     vbox(
-      text(L"Basic Color support : NA"),
-      text(L"256 Color support : NA"),
-      text(L"TrueColor support : NA")
+      text(L"Basic Color support : unknown"),
+      text(L"256 Color support : unknown"),
+      (Terminal::CanSupportTrueColors() ?
+        text(L"TrueColor support : Yes"):
+        text(L"TrueColor support : No"))
     );
 
   auto basic_color_display =
@@ -76,14 +79,12 @@ int main(int argc, const char* argv[]) {
       palette_256_color_display->children.push_back(hbox());
       ++y;
     }
-    int color_index = y+(i%16)*16;
-    std::string number = std::to_string(color_index);
-    while(number.length() < 3)
+    std::string number = std::to_string(i);
+    while(number.length() < 4)
     {
       number.push_back(' ');
     }
-    palette_256_color_display->children.back()->children.push_back(bgcolor(Color::Color256(color_index),text(to_wstring(number))));
-    palette_256_color_display->children.back()->children.push_back(text(L" "));
+    palette_256_color_display->children.back()->children.push_back(bgcolor(Color::Color256(i),text(to_wstring(number))));
   }
 
   auto true_color_display =

--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -51,7 +51,6 @@ class Color {
   static Color YellowLight;
 
  public:
-  // --- Public Constructors ------
   static Color Color256(int index);
   static Color ColorRGB(int r, int g, int b);
 
@@ -62,10 +61,8 @@ class Color {
   std::wstring ToTerminalColorCode(bool is_background_color) const;
 
  protected:
-  // --- Protected Constructors ------
   // prefer available static instances if you want to use a basic color
   static Color ColorBasic(int index);
-  Color();
 
   ColorType type_ = ColorType::None;
   int index_ = -1;

--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -59,8 +59,7 @@ class Color {
   bool operator==(const Color& rhs) const;
   bool operator!=(const Color& rhs) const;
 
-  std::wstring ToTerminalColorCode(ColorType maximum_color_type_available,
-                                   bool is_background_color) const;
+  std::wstring ToTerminalColorCode(bool is_background_color) const;
 
  protected:
   // --- Protected Constructors ------

--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -2,39 +2,77 @@
 #define FTXUI_SCREEN_COLOR
 
 #include <cstdint>
+#include <string>
 
 namespace ftxui {
 
-/// @brief The set of supported terminal colors.
+/// @brief Enum indicating to the terminal how to interpret and display the
+/// color.
 /// @ingroup screen
-enum class Color : uint8_t {
+enum class ColorType : uint8_t {
+  None,
+  Basic,
+  Palette256,
+  TrueColor,
+};
+
+/// @brief A class representing terminal colors.
+/// @ingroup screen
+class Color {
+ public:
+  // --- Static instances representing the basic color set -----
+
   // --- Transparent -----
-  Default = 39,
+  static Color Default;
 
   // --- Grayscale -----
-  Black = 30,
-  GrayDark = 90,
-  GrayLight = 37,
-  White = 97,
+  static Color Black;
+  static Color GrayDark;
+  static Color GrayLight;
+  static Color White;
 
   // --- Hue -----
-  Blue = 34,
-  BlueLight = 94,
+  static Color Blue;
+  static Color BlueLight;
 
-  Cyan = 36,
-  CyanLight = 96,
+  static Color Cyan;
+  static Color CyanLight;
 
-  Green = 32,
-  GreenLight = 92,
+  static Color Green;
+  static Color GreenLight;
 
-  Magenta = 35,
-  MagentaLight = 95,
+  static Color Magenta;
+  static Color MagentaLight;
 
-  Red = 31,
-  RedLight = 91,
+  static Color Red;
+  static Color RedLight;
 
-  Yellow = 33,
-  YellowLight = 93,
+  static Color Yellow;
+  static Color YellowLight;
+
+ public:
+  // --- Public Constructors ------
+  static Color Color256(int index);
+  static Color ColorRGB(int r, int g, int b);
+
+  // --- Operators ------
+  bool operator==(const Color& rhs) const;
+  bool operator!=(const Color& rhs) const;
+
+  std::wstring ToTerminalColorCode(ColorType maximum_color_type_available,
+                                   bool is_background_color) const;
+
+ protected:
+  // --- Protected Constructors ------
+  // prefer available static instances if you want to use a basic color
+  static Color ColorBasic(int index);
+  Color();
+
+  ColorType type_ = ColorType::None;
+  int index_ = -1;
+  int r_ = -1;
+  int g_ = -1;
+  int b_ = -1;
 };
 
 }  // namespace ftxui

--- a/include/ftxui/screen/terminal.hpp
+++ b/include/ftxui/screen/terminal.hpp
@@ -10,6 +10,8 @@ class Terminal {
     int dimy;
   };
 
+  static bool CanSupportTrueColors();
+
   static Dimensions Size();
 };
 

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -1,0 +1,97 @@
+#include "ftxui/screen/color.hpp"
+
+#include "ftxui/screen/string.hpp"
+
+namespace ftxui {
+
+bool Color::operator==(const Color& rhs) const {
+  return type_ == rhs.type_ && index_ == rhs.index_ && r_ == rhs.r_ &&
+         g_ == rhs.g_ && b_ == rhs.b_;
+}
+
+bool Color::operator!=(const Color& rhs) const {
+  return !operator==(rhs);
+}
+
+std::wstring Color::ToTerminalColorCode(ColorType maximum_color_type_available,
+                                        bool is_background_color) const {
+  if (maximum_color_type_available < type_) {
+    // conversion will be necessary;
+  } else {
+    switch (type_) {
+      case ColorType::None:
+        return L"";
+
+      case ColorType::Basic:
+        return to_wstring(
+            std::to_string((is_background_color ? 10 : 0) + index_));
+
+      case ColorType::Palette256:
+        return L"";
+
+      case ColorType::TrueColor:
+        return L"";
+    }
+  }
+  return L"";
+}
+
+Color Color::Color256(int index) {
+  Color color;
+  color.type_ = ColorType::Palette256;
+  color.index_ = index;
+  return color;
+}
+
+Color Color::ColorRGB(int r, int g, int b) {
+  Color color;
+  color.type_ = ColorType::TrueColor;
+  color.r_ = r;
+  color.g_ = g;
+  color.b_ = b;
+  return color;
+}
+
+Color Color::ColorBasic(int index) {
+  Color color;
+  color.type_ = ColorType::Basic;
+  color.index_ = index;
+  return color;
+}
+
+Color::Color() {}
+
+// --- Static instances representing the basic color set -----
+// --- Transparent -----
+Color Color::Default = ColorBasic(39);
+
+// --- Grayscale -----
+Color Color::Black = ColorBasic(30);
+Color Color::GrayDark = ColorBasic(90);
+Color Color::GrayLight = ColorBasic(37);
+Color Color::White = ColorBasic(97);
+
+// --- Hue -----
+Color Color::Blue = ColorBasic(34);
+Color Color::BlueLight = ColorBasic(94);
+
+Color Color::Cyan = ColorBasic(36);
+Color Color::CyanLight = ColorBasic(96);
+
+Color Color::Green = ColorBasic(32);
+Color Color::GreenLight = ColorBasic(92);
+
+Color Color::Magenta = ColorBasic(35);
+Color Color::MagentaLight = ColorBasic(95);
+
+Color Color::Red = ColorBasic(31);
+Color Color::RedLight = ColorBasic(91);
+
+Color Color::Yellow = ColorBasic(33);
+Color Color::YellowLight = ColorBasic(93);
+
+}  // namespace ftxui
+
+// Copyright 2020 Arthur Sonzogni. All rights reserved.
+// Use of this source code is governed by the MIT license that can be found in
+// the LICENSE file.

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -15,31 +15,26 @@ bool Color::operator!=(const Color& rhs) const {
   return !operator==(rhs);
 }
 
-std::wstring Color::ToTerminalColorCode(ColorType maximum_color_type_available,
-                                        bool is_background_color) const {
-  if (maximum_color_type_available < type_) {
-    // conversion will be necessary;
-  } else {
-    switch (type_) {
-      case ColorType::None:
-        return L"";
+std::wstring Color::ToTerminalColorCode(bool is_background_color) const {
+  switch (type_) {
+    case ColorType::None:
+      return L"";
 
-      case ColorType::Basic:
-        return to_wstring(
-            std::to_string((is_background_color ? 10 : 0) + index_));
+    case ColorType::Basic:
+      return to_wstring(
+          std::to_string((is_background_color ? 10 : 0) + index_));
 
-      case ColorType::Palette256:
-        return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
-                          + ";5;"                                        //
-                          + std::to_string(index_));                     //
+    case ColorType::Palette256:
+      return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
+                        + ";5;"                                        //
+                        + std::to_string(index_));                     //
 
-      case ColorType::TrueColor:
-        return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
-                          + ";2;"                                        //
-                          + std::to_string(r_) + ";"                     //
-                          + std::to_string(g_) + ";"                     //
-                          + std::to_string(b_));                         //
-    }
+    case ColorType::TrueColor:
+      return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
+                        + ";2;"                                        //
+                        + std::to_string(r_) + ";"                     //
+                        + std::to_string(g_) + ";"                     //
+                        + std::to_string(b_));                         //
   }
   return L"";
 }

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -1,5 +1,7 @@
 #include "ftxui/screen/color.hpp"
 
+#include <algorithm>
+
 #include "ftxui/screen/string.hpp"
 
 namespace ftxui {
@@ -27,10 +29,16 @@ std::wstring Color::ToTerminalColorCode(ColorType maximum_color_type_available,
             std::to_string((is_background_color ? 10 : 0) + index_));
 
       case ColorType::Palette256:
-        return L"";
+        return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
+                          + ";5;"                                        //
+                          + std::to_string(index_));                     //
 
       case ColorType::TrueColor:
-        return L"";
+        return to_wstring(std::to_string(is_background_color ? 48 : 38)  //
+                          + ";2;"                                        //
+                          + std::to_string(r_) + ";"                     //
+                          + std::to_string(g_) + ";"                     //
+                          + std::to_string(b_));                         //
     }
   }
   return L"";
@@ -39,16 +47,16 @@ std::wstring Color::ToTerminalColorCode(ColorType maximum_color_type_available,
 Color Color::Color256(int index) {
   Color color;
   color.type_ = ColorType::Palette256;
-  color.index_ = index;
+  color.index_ = std::clamp(index, 0, 255);
   return color;
 }
 
 Color Color::ColorRGB(int r, int g, int b) {
   Color color;
   color.type_ = ColorType::TrueColor;
-  color.r_ = r;
-  color.g_ = g;
-  color.b_ = b;
+  color.r_ = std::clamp(r, 0, 255);
+  color.g_ = std::clamp(g, 0, 255);
+  color.b_ = std::clamp(b, 0, 255);
   return color;
 }
 

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -62,8 +62,6 @@ Color Color::ColorBasic(int index) {
   return color;
 }
 
-Color::Color() {}
-
 // --- Static instances representing the basic color set -----
 // --- Transparent -----
 Color Color::Default = ColorBasic(39);

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -86,10 +86,13 @@ void UpdatePixelStyle(std::wstringstream& ss, Pixel& previous, Pixel& next) {
   if (next.foreground_color != previous.foreground_color ||
       next.background_color != previous.background_color) {
     ss << L"\x1B[" +
-              to_wstring(std::to_string((uint8_t)next.foreground_color)) + L"m";
+              next.foreground_color                                  //
+                  .ToTerminalColorCode(ColorType::TrueColor, false)  //
+              + L"m";
     ss << L"\x1B[" +
-              to_wstring(std::to_string(10 + (uint8_t)next.background_color)) +
-              L"m";
+              next.background_color                                 //
+                  .ToTerminalColorCode(ColorType::TrueColor, true)  //
+              + L"m";
   }
 
   previous = next;
@@ -105,7 +108,7 @@ Dimension Dimension::Fixed(int v) {
 }
 
 /// The minimal dimension that will fit the given element.
-/// @see Fixed 
+/// @see Fixed
 /// @see Full
 Dimension Dimension::Fit(Element& e) {
   e->ComputeRequirement();
@@ -115,7 +118,7 @@ Dimension Dimension::Fit(Element& e) {
 }
 
 /// Use the terminal dimensions.
-/// @see Fixed 
+/// @see Fixed
 /// @see Fit
 Dimension Dimension::Full() {
   Terminal::Dimensions size = Terminal::Size();

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -85,14 +85,8 @@ void UpdatePixelStyle(std::wstringstream& ss, Pixel& previous, Pixel& next) {
 
   if (next.foreground_color != previous.foreground_color ||
       next.background_color != previous.background_color) {
-    ss << L"\x1B[" +
-              next.foreground_color                                  //
-                  .ToTerminalColorCode(ColorType::TrueColor, false)  //
-              + L"m";
-    ss << L"\x1B[" +
-              next.background_color                                 //
-                  .ToTerminalColorCode(ColorType::TrueColor, true)  //
-              + L"m";
+    ss << L"\x1B[" + next.foreground_color.ToTerminalColorCode(false) + L"m";
+    ss << L"\x1B[" + next.background_color.ToTerminalColorCode(true) + L"m";
   }
 
   previous = next;

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -2,6 +2,8 @@
 
 #include <stdio.h>
 
+#include <cstdlib>
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -31,6 +33,15 @@ Terminal::Dimensions Terminal::Size() {
   ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
   return Dimensions{w.ws_col, w.ws_row};
 #endif
+}
+
+bool Terminal::CanSupportTrueColors() {
+  const char* result = std::getenv("COLORTERM");
+  if (result == NULL) {
+    return false;
+  }
+  std::string colorterm = result;
+  return colorterm.compare("24bit") || colorterm.compare("trueColor");
 }
 
 }  // namespace ftxui


### PR DESCRIPTION
As discussed here #45 this is a pull request to support true colors in FTXUI.

I've managed to change the color enum into a class and make it support three color modes (Basic, Palette256 and TrueColors). Everything worked fine on the terminals I've tested. I've updated the `style_color.cpp` example to display the new color possibilities.

Things that may not be obvious from the github pull request page : I've moved `terminal.hpp` from `src/` to `include/`. I've created a `color.cpp` in `src/screen`. So now there's two `color.cpp` files in the repo but the other is in `src/dom` and cmake seemed okay with that.

About fallbacks and color approximations: 
*The `COLORTERM` environment variable worked fine on my terminal. True color support can thus be tested by `Terminal::CanSupportTrueColors()`. However, my understanding is that `TERM` just contains the name of the terminal and there's no way to be sure how many colors it support without looking at the Terminfo. So since I wasn't sure looking for 256 in `TERM` was enough and i wasn't able to find how to use the terminfo without ncurses there's currently no way to check for color support except for `Terminal::CanSupportTrueColors()`. 
*From what I've seen running tests on a terminal that supports only 8 colors it seemed to approximate and fallback on it's own on its 8 available colors so It didn't seemed worth it to implement an approximation in FTXUI, especially given I wasn't able to properly detect the number of color supported.