### PR TITLE
Fix crash on unset environment variable.

### DIFF
--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -36,7 +36,11 @@ Terminal::Dimensions Terminal::Size() {
 }
 
 bool Terminal::CanSupportTrueColors() {
-  std::string COLORTERM = std::getenv("COLORTERM");
+  char *COLORTERM_RAW = std::getenv("COLORTERM");
+  if (nullptr == COLORTERM_RAW) {
+    return false;
+  }
+  std::string COLORTERM = COLORTERM_RAW;
   return COLORTERM.compare("24bit") || COLORTERM.compare("trueColor");
 }
 


### PR DESCRIPTION
My environment doesn't have the variable COLORTERM set. Assigning nullptr to a std::string causes the following exception:
```
a terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```