### PR TITLE
add dependency to Threads into generated cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,16 +150,24 @@ if(FTXUI_ENABLE_INSTALL)
   install(DIRECTORY include/ftxui DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   include(CMakePackageConfigHelpers)
+  configure_package_config_file(ftxui-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/ftxui-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/ftxui/cmake
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+  )
   write_basic_package_version_file(
-    ftxui-config.cmake
+    ftxui-config-version.cmake
     VERSION ${PACKAGE_VERSION}
     COMPATIBILITY AnyNewerVersion
   )
 
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ftxui-config.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
+  )
   install(EXPORT ftxui-export
-    FILE ftxui-config.cmake
-	  NAMESPACE ftxui::
-	  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
+          FILE ftxui-config-version.cmake
+          NAMESPACE ftxui::
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,12 +162,12 @@ if(FTXUI_ENABLE_INSTALL)
   )
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ftxui-config.cmake
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
   )
   install(EXPORT ftxui-export
-          FILE ftxui-config-version.cmake
-          NAMESPACE ftxui::
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
+    FILE ftxui-config-version.cmake
+    NAMESPACE ftxui::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
   )
 endif()
 

--- a/ftxui-config.cmake.in
+++ b/ftxui-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)


### PR DESCRIPTION
When using FTXUI in my own program with CMake after `find_package(ftxui)` I had to `find_package(Threads)` which indicated, that the cmake config scripts of ftxui didn't model that dependency. I modified the generation of the cmake scripts to yield that dependency.