### PR TITLE
reset pixel style for newline

### DIFF
--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -153,10 +153,13 @@ std::string Screen::ToString() {
   std::wstringstream ss;
 
   Pixel previous_pixel;
+  Pixel final_pixel;
 
   for (int y = 0; y < dimy_; ++y) {
-    if (y != 0)
+    if (y != 0) {
+      UpdatePixelStyle(ss, previous_pixel, final_pixel);
       ss << '\n';
+    }
     for (int x = 0; x < dimx_;) {
       auto& pixel = pixels_[y][x];
       wchar_t c = pixel.character;
@@ -166,7 +169,6 @@ std::string Screen::ToString() {
     }
   }
 
-  Pixel final_pixel;
   UpdatePixelStyle(ss, previous_pixel, final_pixel);
 
   return to_string(ss.str());


### PR DESCRIPTION
I observed the problem, that stepping into the next line when printing a screen fills the terminal column with the previous background color:
<img width="822" alt="Bildschirmfoto 2020-10-16 um 18 51 03" src="https://user-images.githubusercontent.com/3005300/96287078-b0035a00-0fe1-11eb-8ca9-99098194f6e1.png">

My fix yields this:
<img width="740" alt="Bildschirmfoto 2020-10-16 um 18 58 04" src="https://user-images.githubusercontent.com/3005300/96287164-cdd0bf00-0fe1-11eb-85c2-17687e382280.png">

This is my example code: 
```cpp
#include <ftxui/dom/elements.hpp>
#include <ftxui/screen/screen.hpp>
#include <iostream>

int main(void) {
  using namespace ftxui;
  Element document = graph([](int x, int y){
    std::vector<int> result(x, 0);
    for (int i{0}; i < x; ++i) {
      result[i] = ((3 * i) / 2) % y;
    }
    return result;
  }) | color(Color::Red) | border | color(Color::Green) | bgcolor(Color::DarkBlue);

  auto screen = Screen::Create(
      Dimension::Fixed(80),
      Dimension::Fixed(10)
  );
  Render(screen, document);
  std::cout << screen.ToString() << '\n';
}
```

Btw. this library is really great! I love its API and power. I've been looking for a lib like this for some time. :)
