### PR TITLE
Fix event const correctness

### DIFF
--- a/include/ftxui/component/event.hpp
+++ b/include/ftxui/component/event.hpp
@@ -16,7 +16,6 @@ namespace ftxui {
 // https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 //
 struct Event {
- public:
   // --- Constructor section ---------------------------------------------------
   static Event Character(char);
   static Event Character(wchar_t);
@@ -27,29 +26,29 @@ struct Event {
   static void Convert(Receiver<char>& in, Sender<Event>& out, char c);
 
   // --- Arrow ---
-  static Event ArrowLeft;
-  static Event ArrowRight;
-  static Event ArrowUp;
-  static Event ArrowDown;
+  static const Event ArrowLeft;
+  static const Event ArrowRight;
+  static const Event ArrowUp;
+  static const Event ArrowDown;
 
   // --- Other ---
-  static Event Backspace;
-  static Event Delete;
-  static Event Return;
-  static Event Escape;
-  static Event Tab;
-  static Event TabReverse;
-  static Event F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12;
+  static const Event Backspace;
+  static const Event Delete;
+  static const Event Return;
+  static const Event Escape;
+  static const Event Tab;
+  static const Event TabReverse;
+  static const Event F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12;
 
   // --- Custom ---
   static Event Custom;
 
   //--- Method section ---------------------------------------------------------
-  bool is_character() { return is_character_; }
-  wchar_t character() { return character_; }
-  const std::string& input() { return input_; }
+  bool is_character() const { return is_character_; }
+  wchar_t character() const { return character_; }
+  const std::string& input() const { return input_; }
 
-  bool operator==(const Event& other) { return input_ == other.input_; }
+  bool operator==(const Event& other) const { return input_ == other.input_; }
 
   //--- State section ----------------------------------------------------------
  private:
@@ -57,6 +56,7 @@ struct Event {
   bool is_character_ = false;
   wchar_t character_ = U'?';
 };
+
 
 }  // namespace ftxui
 

--- a/src/ftxui/component/event.cpp
+++ b/src/ftxui/component/event.cpp
@@ -156,32 +156,32 @@ void Event::Convert(Receiver<char>& in, Sender<Event>& out, char c) {
 }
 
 // --- Arrow ---
-Event Event::ArrowLeft = Event::Special("\x1B[D");
-Event Event::ArrowRight = Event::Special("\x1B[C");
-Event Event::ArrowUp = Event::Special("\x1B[A");
-Event Event::ArrowDown = Event::Special("\x1B[B");
-Event Event::Backspace = Event::Special({127});
-Event Event::Delete = Event::Special("\x1B[3~");
-Event Event::Escape = Event::Special("\x1B");
+const Event Event::ArrowLeft = Event::Special("\x1B[D");
+const Event Event::ArrowRight = Event::Special("\x1B[C");
+const Event Event::ArrowUp = Event::Special("\x1B[A");
+const Event Event::ArrowDown = Event::Special("\x1B[B");
+const Event Event::Backspace = Event::Special({127});
+const Event Event::Delete = Event::Special("\x1B[3~");
+const Event Event::Escape = Event::Special("\x1B");
 #if defined(_WIN32)
-Event Event::Return = Event::Special({13});
+const Event Event::Return = Event::Special({13});
 #else
-Event Event::Return = Event::Special({10});
+const Event Event::Return = Event::Special({10});
 #endif
-Event Event::Tab = Event::Special({9});
-Event Event::TabReverse = Event::Special({27, 91, 90});
-Event Event::F1 = Event::Special("\x1B[OP");
-Event Event::F2 = Event::Special("\x1B[OQ");
-Event Event::F3 = Event::Special("\x1B[OR");
-Event Event::F4 = Event::Special("\x1B[OS");
-Event Event::F5 = Event::Special("\x1B[15~");
-Event Event::F6 = Event::Special("\x1B[17~");
-Event Event::F7 = Event::Special("\x1B[18~");
-Event Event::F8 = Event::Special("\x1B[19~");
-Event Event::F9 = Event::Special("\x1B[20~");
-Event Event::F10 = Event::Special("\x1B[21~");
-Event Event::F11 = Event::Special("\x1B[21~");  // Doesn't exist
-Event Event::F12 = Event::Special("\x1B[24~");
+const Event Event::Tab = Event::Special({9});
+const Event Event::TabReverse = Event::Special({27, 91, 90});
+const Event Event::F1 = Event::Special("\x1B[OP");
+const Event Event::F2 = Event::Special("\x1B[OQ");
+const Event Event::F3 = Event::Special("\x1B[OR");
+const Event Event::F4 = Event::Special("\x1B[OS");
+const Event Event::F5 = Event::Special("\x1B[15~");
+const Event Event::F6 = Event::Special("\x1B[17~");
+const Event Event::F7 = Event::Special("\x1B[18~");
+const Event Event::F8 = Event::Special("\x1B[19~");
+const Event Event::F9 = Event::Special("\x1B[20~");
+const Event Event::F10 = Event::Special("\x1B[21~");
+const Event Event::F11 = Event::Special("\x1B[21~");  // Doesn't exist
+const Event Event::F12 = Event::Special("\x1B[24~");
 Event Event::Custom = Event::Special({0});
 
 }  // namespace ftxui


### PR DESCRIPTION
Fixes warnings on `==` when comparing events

- Make special events const
- Add const to getters
- Add const to equality operator
