### PR TITLE
Fixed issue (#60) - Compilation failed in non-git projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 execute_process(
   COMMAND git rev-list --count HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   OUTPUT_VARIABLE git_version
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
Compilation failed if ftxui was used in projects that were not git repositories. Since, in CMakeLists.txt working directory to execute command was set as the parent directory and not the FTXUI project directory.

Changed the working directory variable to ${CMAKE_CURRENT_SOURCE_DIR}, so as to get the version of FTXUI and not that of parent project

Fixes issue #60 