### PR TITLE
Fixed infinite loop in Screen::ToString() for non-printable chars

### DIFF
--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -164,8 +164,15 @@ std::string Screen::ToString() {
       auto& pixel = pixels_[y][x];
       wchar_t c = pixel.character;
       UpdatePixelStyle(ss, previous_pixel, pixel);
+
+      auto width = wchar_width(c);
+      if (width <= 0) {
+          // Avoid an infinite loop for non-printable characters
+          c = L' ';
+          width = 1;
+      }
       ss << c;
-      x += wchar_width(c);
+      x += width;
     }
   }
 


### PR DESCRIPTION
I decided to replace the non-printable character with a `space` and continue over a hang or throwing an exception: a CPU-burning hang is not nice and the rest of the code seems to not use exceptions.