### PR TITLE
Work around Windows.h breaking the Color::RGB function

### DIFF
--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -4,6 +4,12 @@
 #include <cstdint>
 #include <string>
 
+#ifdef RGB
+// Workaround for wingdi.h (via Windows.h) defining macros that break things.
+// https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-rgb
+#undef RGB
+#endif
+
 namespace ftxui {
 
 /// @brief A class representing terminal colors.


### PR DESCRIPTION
wingdi.h (included via Windows.h) defines an RGB macro that breaks
things. If a user really wants that macro in the same file as FTXUI they
can move the Windows.h include to after the inclusion of FTXUI's
headers.

Fixes #59