### PR TITLE
Build with -Wmissing-declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ foreach(lib screen dom component)
     target_compile_options(${lib} PRIVATE "-Wextra")
     target_compile_options(${lib} PRIVATE "-pedantic")
     target_compile_options(${lib} PRIVATE "-Werror")
+    target_compile_options(${lib} PRIVATE "-Wmissing-declarations")
     target_compile_options(${lib} PRIVATE "-Wno-sign-compare")
   endif()
 

--- a/src/ftxui/dom/separator.cpp
+++ b/src/ftxui/dom/separator.cpp
@@ -1,3 +1,4 @@
+#include "ftxui/dom/elements.hpp"
 #include "ftxui/dom/node.hpp"
 
 namespace ftxui {

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include "ftxui/dom/elements.hpp"
 #include "ftxui/dom/node.hpp"
 #include "ftxui/screen/string.hpp"
 


### PR DESCRIPTION
This flag is used to find global functions defined without a previous
declaration. Usually it spots accidental globals, but in this case it
was just missing headers.

```
Element separator()
Element separator(Pixel)
Element text(std::wstring)
Element vtext(std::wstring)
```
are all declared in `ftxui/dom/elements.hpp` which was missing from
the includes in the .cpp-files where they were defined.