### PR TITLE
Swapped order of hidding cursor and setting alternative screen

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -250,6 +250,11 @@ void ScreenInteractive::Loop(Component* component) {
   install_signal_handler(SIGWINCH, OnResize);
 #endif
 
+  if (use_alternative_screen_) {
+    std::cout << USE_ALTERNATIVE_SCREEN;
+    on_exit_functions.push([] { std::cout << USE_NORMAL_SCREEN; });
+  }
+
   // Hide the cursor and show it at exit.
   std::cout << HIDE_CURSOR;
   std::cout << DISABLE_LINE_WRAP;
@@ -263,11 +268,6 @@ void ScreenInteractive::Loop(Component* component) {
 
   auto event_listener =
       std::thread(&EventListener, &quit_, event_receiver_->MakeSender());
-
-  if (use_alternative_screen_) {
-    std::cout << USE_ALTERNATIVE_SCREEN;
-    on_exit_functions.push([] { std::cout << USE_NORMAL_SCREEN; });
-  }
 
   // The main loop.
   while (!quit_) {


### PR DESCRIPTION
Text cursor is visible when I use `ScreenInteractive::Fullscreen()`. Not sure is it reproducible on Linux but that's the case on Windows. I was using menu example and changed only screen mode:

<img src="https://user-images.githubusercontent.com/14260814/111240700-5ccf1b00-8604-11eb-8bbe-7777eaa39084.gif" alt="drawing" width="700"/>

I assume that usage of alternative screen command resets cursor hiding. Swap of those commands fixed that issue:

<img src="https://user-images.githubusercontent.com/14260814/111240843-ad467880-8604-11eb-81a9-275997102b86.gif" alt="drawing" width="700"/>

Need to check alternative screen functionality, looks like it was affected
