### PR TITLE
Fix Windows mingw64 build warning "NOMINMAX" redefined

### DIFF
--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -6,7 +6,11 @@
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
+
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
+
 #include <Windows.h>
 #else
 #include <sys/ioctl.h>


### PR DESCRIPTION
```
\lib\ftxui\src\ftxui\screen\terminal.cpp:9: warning: "NOMINMAX" redefined
 #define NOMINMAX
 
In file included frommingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/x86_64-w64-mingw32/bits/c++config.h:508,
                 from mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/cstdlib:41,
                 from ftxui\src\ftxui\screen\terminal.cpp:5:
mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/x86_64-w64-mingw32/bits/os_defines.h:45: note: this is the location of the previous definition
 #define NOMINMAX 1
```