### PR TITLE
Set git_version when .git folder is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 find_package(Git QUIET)
-if (Git_FOUND)
+if (Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   message("git found")
   execute_process(
     COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD


### PR DESCRIPTION
If we download the FTXUI source archive from the GitHub website, then the `.git` folder will be missing.
In such case, CMake configuration will fail:
> git found
> fatal: not a git repository (or any of the parent directories): .git
> CMake Error at CMakeLists.txt:21 (project):
>   VERSION "0.6." format invalid.