### PR TITLE
Support combining characters.

### DIFF
--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -18,9 +18,16 @@ using Element = std::shared_ptr<Node>;
 /// @brief A unicode character and its associated style.
 /// @ingroup screen
 struct Pixel {
+  // The graphemes stored into the pixel. To support combining characters,
+  // like: a⃦, this can potentially contains multiple codepoitns.
+  // Required: character.size() >= 1;
+  std::wstring character = L" ";
+
+  // Colors:
   Color background_color = Color::Default;
   Color foreground_color = Color::Default;
-  wchar_t character = U' ';
+
+  // A bit field representing the style:
   bool blink : 1;
   bool bold : 1;
   bool dim : 1;

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -29,10 +29,15 @@ class Text : public Node {
     if (y > box_.y_max)
       return;
     for (wchar_t c : text_) {
-      if (x > box_.x_max)
-        return;
-      screen.at(x, y) = c;
-      x += wchar_width(c);
+      const int width = wchar_width(c);
+      if (width >= 1) {
+        if (x > box_.x_max)
+          return;
+        screen.PixelAt(x, y).character = c;
+      } else {
+        screen.PixelAt(x - 1, y).character += c;
+      }
+      x += std::max(width, 0);
     }
   }
 

--- a/src/ftxui/dom/text_test.cpp
+++ b/src/ftxui/dom/text_test.cpp
@@ -6,6 +6,7 @@
 #include "ftxui/dom/node.hpp"       // for Render
 #include "ftxui/screen/box.hpp"     // for ftxui
 #include "ftxui/screen/screen.hpp"  // for Screen
+#include "ftxui/screen/string.hpp"  // for to_string
 #include "gtest/gtest_pred_impl.h"  // for Test, EXPECT_EQ, TEST
 
 using namespace ftxui;
@@ -84,6 +85,23 @@ TEST(TextTest, CJK_3) {
       "│测│\r\n"
       "└──┘",
       screen.ToString());
+}
+
+TEST(TextTest, CombiningCharacters) {
+  const std::wstring t =
+      // Combining above:
+      L"ā à á â ã ā a̅ ă ȧ ä ả å a̋ ǎ a̍ a̎ ȁ a̐ ȃ a̒ a̔ a̕ a̚ a̛ a̽ a̾ a̿ à á a͂ a͆ a͊ a͋ a͌ a͐ "
+      L"a͑ a͒ a͗ a͘ a͛ a͝ a͞ a͠ a͡ aͣ aͤ aͥ aͦ aͧ aͨ aͩ aͪ aͫ aͬ aͭ aͮ aͯ a᷀ a᷁ a᷃ a᷄ a᷅ a᷆ a᷇ a᷈ a᷉ a᷾ a⃐ a⃑ a⃔ "
+      L"a⃕ a⃖ a⃗ a⃛ a⃜ a⃡ a⃩ a⃰ a︠ a︡ a︢ a︣"
+      // Combining middle:
+      L"a̴ a̵ a̶ a̷ a̸ a⃒ a⃓ a⃘ a⃙ a⃚ a⃝ a⃞ a⃟ a⃥ a⃦"
+      // Combining below:
+      L"a̗ a̘ a̙ a̜ a̝ a̞ a̟ a̠ a̡ a̢ ạ ḁ a̦ a̧ ą a̩ a̪ a̫ a̬ a̭ a̮ a̯ a̰ a̱ a̲ a̳ a̹ a̺ a̻ a̼ aͅ a͇ a͈ a͉ a͍ "
+      L"a͎ a͓ a͔ a͕ a͖ a͙ a͚ a͜ a͟ a͢ a᷂ a᷊ a᷿ a⃨";
+  auto element = text(t);
+  Screen screen(290, 1);
+  Render(screen, element);
+  EXPECT_EQ(to_string(t), screen.ToString());
 }
 
 // Copyright 2020 Arthur Sonzogni. All rights reserved.

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -164,17 +164,14 @@ std::string Screen::ToString() {
     }
     for (int x = 0; x < dimx_;) {
       auto& pixel = pixels_[y][x];
-      wchar_t c = pixel.character;
       UpdatePixelStyle(ss, previous_pixel, pixel);
 
-      auto width = wchar_width(c);
-      if (width <= 0) {
-        // Avoid an infinite loop for non-printable characters
-        c = L' ';
-        width = 1;
+      int x_inc = 0;
+      for (auto& c : pixel.character) {
+        ss << c;
+        x_inc += wchar_width(c);
       }
-      ss << c;
-      x += width;
+      x += std::max(x_inc, 1);
     }
   }
 
@@ -191,7 +188,7 @@ void Screen::Print() {
 /// @param x The character position along the x-axis.
 /// @param y The character position along the y-axis.
 wchar_t& Screen::at(int x, int y) {
-  return PixelAt(x, y).character;
+  return PixelAt(x, y).character[0];
 }
 
 /// @brief Access a Pixel at a given position.


### PR DESCRIPTION
Modify the `ftxui::Pixel`. Instead of storing a `wchar_t`, store a
`std::wstring`. Now a single pixel can store multiple codepoints.
If a codepoint is of size <=0, it will be appended to the previous
pixel.

Only `ftxui::text()` is supported. `ftxui::vtext` support still needs to be
added.

This fixes: https://github.com/ArthurSonzogni/FTXUI/issues/109