### PR TITLE
Fix bug with std::raise(0)

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -205,7 +205,8 @@ void OnExit(int signal) {
     on_exit_functions.top()();
     on_exit_functions.pop();
   }
-  std::raise(signal);
+  if (signal)
+     std::raise(signal);
 }
 
 auto install_signal_handler = [](int sig, SignalHandler handler) {


### PR DESCRIPTION
A bug has been introduced in:
https://github.com/ArthurSonzogni/FTXUI/commit/478d7e8bcaea6a1afd94ea3053d4a3d495634ae2

I purposefully allowed raising the signal zero, because I thought this
was doing nothing. See the response:
https://stackoverflow.com/a/32260528/5112390

but this is different on Windows.

See:
https://github.com/ArthurSonzogni/FTXUI/issues/117