### PR TITLE
Allows components to remove a child or access to children in general

### DIFF
--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -30,6 +30,7 @@ class ComponentBase {
   ComponentBase* Parent();
   void Add(Component children);
   void Remove(Components::iterator child);
+  void Clear();
   // Renders the component.
   virtual Element Render();
 

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -32,7 +32,7 @@ class ComponentBase {
   size_t ChildCount() const;
   void Add(Component children);
   void Detach();
-  void DetachAllChild();
+  void DetachAllChildren();
 
   // Renders the component.
   virtual Element Render();

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -29,9 +29,13 @@ class ComponentBase {
   // ComponentBase hierarchy.
   ComponentBase* Parent();
   void Add(Component children);
-  void Remove(std::size_t idx);
+  void Remove(Components::iterator child);
   // Renders the component.
   virtual Element Render();
+
+  // Iterate over component children
+  Components::iterator begin();
+  Components::iterator end();
 
   // Handles an event.
   // By default, reduce on children with a lazy OR.

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -26,17 +26,16 @@ class ComponentBase {
   ComponentBase() = default;
   virtual ~ComponentBase();
 
-  // ComponentBase hierarchy.
+  // Component hierarchy:
   ComponentBase* Parent();
+  Component& ChildAt(size_t i);
+  size_t ChildCount() const;
   void Add(Component children);
-  void Remove(Components::iterator child);
-  void Clear();
+  void Detach();
+  void DetachAllChild();
+
   // Renders the component.
   virtual Element Render();
-
-  // Iterate over component children
-  Components::iterator begin();
-  Components::iterator end();
 
   // Handles an event.
   // By default, reduce on children with a lazy OR.
@@ -72,7 +71,6 @@ class ComponentBase {
 
  private:
   ComponentBase* parent_ = nullptr;
-  void Detach();
 };
 
 using Component = std::shared_ptr<ComponentBase>;

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -29,7 +29,7 @@ class ComponentBase {
   // ComponentBase hierarchy.
   ComponentBase* Parent();
   void Add(Component children);
-
+  void Remove(std::size_t idx);
   // Renders the component.
   virtual Element Render();
 

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -44,9 +44,23 @@ void ComponentBase::Add(Component child) {
 /// @brief Remove a child.
 /// @@param idx The child index to be removed.
 /// @ingroup component
-void ComponentBase::Remove(std::size_t idx) {
-  children_.erase(children_.begin()+idx);
+void ComponentBase::Remove(Components::iterator child) {
+  children_.erase(child);
 }
+
+/// @brief Obtain an iterator to the first child
+/// @ingroup component
+Components::iterator ComponentBase::begin() {
+  return children_.begin();
+}
+
+/// @brief Obtain an iterator to one after the last child
+/// @ingroup component
+Components::iterator ComponentBase::end() {
+  return children_.end();
+}
+
+
 
 /// @brief Draw the component.
 /// Build a ftxui::Element to be drawn on the ftxi::Screen representing this

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -41,6 +41,13 @@ void ComponentBase::Add(Component child) {
   children_.push_back(std::move(child));
 }
 
+/// @brief Remove a child.
+/// @@param idx The child index to be removed.
+/// @ingroup component
+void ComponentBase::Remove(std::size_t idx) {
+  children_.erase(children_.begin()+idx);
+}
+
 /// @brief Draw the component.
 /// Build a ftxui::Element to be drawn on the ftxi::Screen representing this
 /// ftxui::ComponentBase.

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -48,6 +48,12 @@ void ComponentBase::Remove(Components::iterator child) {
   children_.erase(child);
 }
 
+/// @brief Remove all children.
+/// @ingroup component
+void ComponentBase::Clear() {
+  children_.clear();
+}
+
 /// @brief Obtain an iterator to the first child
 /// @ingroup component
 Components::iterator ComponentBase::begin() {

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -40,13 +40,13 @@ Component& ComponentBase::ChildAt(size_t i) {
   return children_[i];
 }
 
-/// @brief Returns the number of child.
+/// @brief Returns the number of children.
 /// @ingroup component
 size_t ComponentBase::ChildCount() const {
   return children_.size();
 }
 
-/// @brief Add a children.
+/// @brief Add a child.
 /// @@param child The child to be attached.
 /// @ingroup component
 void ComponentBase::Add(Component child) {
@@ -55,7 +55,7 @@ void ComponentBase::Add(Component child) {
   children_.push_back(std::move(child));
 }
 
-/// @brief Detach this children from its parent.
+/// @brief Detach this child from its parent.
 /// @see Detach
 /// @see Parent
 /// @ingroup component
@@ -73,7 +73,7 @@ void ComponentBase::Detach() {
 
 /// @brief Remove all children.
 /// @ingroup component
-void ComponentBase::DetachAllChild() {
+void ComponentBase::DetachAllChildren() {
   while (!children_.empty())
     children_[0]->Detach();
 }

--- a/src/ftxui/component/component_test.cpp
+++ b/src/ftxui/component/component_test.cpp
@@ -1,8 +1,10 @@
-#include <memory>  // for shared_ptr, allocator, make_shared, __shared_ptr_access
+#include <gtest/gtest-message.h>    // for Message
+#include <gtest/gtest-test-part.h>  // for TestPartResult
+#include <memory>  // for shared_ptr, __shared_ptr_access, allocator, make_shared
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component_base.hpp"  // for ComponentBase, Component
-#include "gtest/gtest_pred_impl.h"  // for Test, SuiteApiResolver, TEST, TestFactoryImpl
+#include "gtest/gtest_pred_impl.h"  // for EXPECT_EQ, Test, SuiteApiResolver, TEST, TestFactoryImpl
 
 using namespace ftxui;
 
@@ -28,6 +30,129 @@ TEST(ContainerTest, DeleteChildFirst) {
   parent->Add(child);
   child.reset();
   parent.reset();
+}
+
+TEST(ContainerTest, Detach) {
+  auto parent = Make();
+  auto child_1 = Make();
+  auto child_2 = Make();
+  auto child_3 = Make();
+  parent->Add(child_1);
+  parent->Add(child_2);
+  parent->Add(child_3);
+
+  EXPECT_EQ(parent->ChildCount(), 3u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), parent.get());
+  EXPECT_EQ(child_3->Parent(), parent.get());
+
+  child_2->Detach();
+
+  EXPECT_EQ(parent->ChildCount(), 2u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), nullptr);
+  EXPECT_EQ(child_3->Parent(), parent.get());
+
+  child_2->Detach();
+
+  EXPECT_EQ(parent->ChildCount(), 2u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), nullptr);
+  EXPECT_EQ(child_3->Parent(), parent.get());
+
+  child_1->Detach();
+
+  EXPECT_EQ(parent->ChildCount(), 1u);
+  EXPECT_EQ(child_1->Parent(), nullptr);
+  EXPECT_EQ(child_2->Parent(), nullptr);
+  EXPECT_EQ(child_3->Parent(), parent.get());
+
+  child_3->Detach();
+
+  EXPECT_EQ(parent->ChildCount(), 0u);
+  EXPECT_EQ(child_1->Parent(), nullptr);
+  EXPECT_EQ(child_2->Parent(), nullptr);
+  EXPECT_EQ(child_3->Parent(), nullptr);
+}
+
+TEST(ContainerTest, DetachAllChild) {
+  auto parent = Make();
+  auto child_1 = Make();
+  auto child_2 = Make();
+  auto child_3 = Make();
+  parent->Add(child_1);
+  parent->Add(child_2);
+  parent->Add(child_3);
+
+  EXPECT_EQ(parent->ChildCount(), 3u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), parent.get());
+  EXPECT_EQ(child_3->Parent(), parent.get());
+
+  parent->DetachAllChild();
+
+  EXPECT_EQ(parent->ChildCount(), 0u);
+  EXPECT_EQ(child_1->Parent(), nullptr);
+  EXPECT_EQ(child_2->Parent(), nullptr);
+  EXPECT_EQ(child_3->Parent(), nullptr);
+}
+
+TEST(ContainerTest, Add) {
+  auto parent = Make();
+  auto child_1 = Make();
+  auto child_2 = Make();
+
+  EXPECT_EQ(parent->ChildCount(), 0u);
+  EXPECT_EQ(child_1->Parent(), nullptr);
+  EXPECT_EQ(child_2->Parent(), nullptr);
+
+  parent->Add(child_1);
+
+  EXPECT_EQ(parent->ChildCount(), 1u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), nullptr);
+
+  parent->Add(child_1);
+
+  EXPECT_EQ(parent->ChildCount(), 1u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), nullptr);
+
+  parent->Add(child_2);
+
+  EXPECT_EQ(parent->ChildCount(), 2u);
+  EXPECT_EQ(child_1->Parent(), parent.get());
+  EXPECT_EQ(child_2->Parent(), parent.get());
+}
+
+TEST(ContainerTest, ChildAt) {
+  auto parent = Make();
+  auto child_1 = Make();
+  auto child_2 = Make();
+
+  EXPECT_EQ(parent->ChildCount(), 0u);
+
+  parent->Add(child_1);
+
+  EXPECT_EQ(parent->ChildCount(), 1u);
+  EXPECT_EQ(parent->ChildAt(0u), child_1);
+
+  parent->Add(child_2);
+
+  EXPECT_EQ(parent->ChildCount(), 2u);
+  EXPECT_EQ(parent->ChildAt(0u), child_1);
+  EXPECT_EQ(parent->ChildAt(1u), child_2);
+
+  parent->Add(child_1);
+
+  EXPECT_EQ(parent->ChildCount(), 2u);
+  EXPECT_EQ(parent->ChildAt(0u), child_2);
+  EXPECT_EQ(parent->ChildAt(1u), child_1);
+
+  child_1->Detach();
+
+  EXPECT_EQ(parent->ChildCount(), 1u);
+  EXPECT_EQ(parent->ChildAt(0u), child_2);
 }
 
 // Copyright 2020 Arthur Sonzogni. All rights reserved.


### PR DESCRIPTION
If I create a Container with a list of children to be displayed and want to delete an entry, I would like to have a functionality corresponding to the add function. 
Furthermore, I added a begin/end function to ComponentBase to allow iteration over its children. The Remove function can then be conformant with vector::erase.