### PR TITLE
Modify CMake usage to enable C++17

### DIFF
--- a/cmake/ftxui_benchmark.cmake
+++ b/cmake/ftxui_benchmark.cmake
@@ -16,5 +16,4 @@ if (NOT WIN32)
   target_include_directories(ftxui_benchmark
     PRIVATE src
   )
-  set_property(TARGET ftxui_benchmark PROPERTY CXX_STANDARD 17)
 endif()

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -10,8 +10,8 @@ function(ftxui_set_options library)
       src
   )
 
-  # C++17 is used. We requires fold expression at least.
-  set_property(TARGET ${library} PROPERTY CXX_STANDARD 17)
+  # C++17 is used. We require fold expression at least.
+  target_compile_features(${library} PUBLIC cxx_std_17)
 
   # Force Microsoft Visual Studio to decode sources files in UTF-8. This applies
   # to the library and the library users.

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -36,7 +36,6 @@ target_include_directories(tests
 )
 target_compile_options(tests PRIVATE -fsanitize=address)
 target_link_libraries(tests PRIVATE -fsanitize=address)
-set_property(TARGET tests PROPERTY CXX_STANDARD 17)
 
 if (NOT MSVC)
   include(cmake/ftxui_benchmark.cmake)

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -83,9 +83,6 @@ target_link_libraries(ftxui-starter
   PRIVATE ftxui::component # Not needed for this example.
 )
 
-# C++17 is used. We requires fold expressions at least.
-set_target_properties(ftxui-starter PROPERTIES CXX_STANDARD 17)
-
 ~~~
 
 Build

--- a/examples/component/CMakeLists.txt
+++ b/examples/component/CMakeLists.txt
@@ -1,7 +1,6 @@
 function(example name)
   add_executable(${name} ${name}.cpp)
   target_link_libraries(${name} PUBLIC component)
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD 17)
 endfunction(example)
 
 example(button)

--- a/examples/dom/CMakeLists.txt
+++ b/examples/dom/CMakeLists.txt
@@ -1,7 +1,6 @@
 function(example name)
   add_executable(${name} ${name}.cpp)
   target_link_libraries(${name} PUBLIC dom)
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD 17)
 endfunction(example)
 
 example(border)

--- a/examples/util/CMakeLists.txt
+++ b/examples/util/CMakeLists.txt
@@ -1,7 +1,6 @@
 function(example name)
   add_executable(${name} ${name}.cpp)
   target_link_libraries(${name} PUBLIC component)
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD 17)
 endfunction(example)
 
 example(print_key_press)


### PR DESCRIPTION
The `target_compile_features` command allows setting PUBLIC compile features for the library, making it implicit for the applications linking it. This reduces the CMake boilerplate required to set up a dependent project (eg. ftxui-starter).