### PR TITLE
Miscellaneous refactoring

### DIFF
--- a/examples/component/homescreen.cpp
+++ b/examples/component/homescreen.cpp
@@ -24,26 +24,19 @@ int main(int argc, const char* argv[]) {
 
   int shift = 0;
 
-  class Graph {
-   public:
-    Graph(int* shift) : shift_(shift) {}
-    std::vector<int> operator()(int width, int height) {
-      std::vector<int> output(width);
-      for (int i = 0; i < width; ++i) {
-        float v = 0;
-        v += 0.1f * sin((i + *shift_) * 0.1f);
-        v += 0.2f * sin((i + *shift_ + 10) * 0.15f);
-        v += 0.1f * sin((i + *shift_) * 0.03f);
-        v *= height;
-        v += 0.5f * height;
-        output[i] = (int)v;
-      }
-      return output;
+  auto my_graph = [&shift](int width, int height) {
+    std::vector<int> output(width);
+    for (int i = 0; i < width; ++i) {
+      float v = 0.5f;
+      v += 0.1f * sin((i + shift) * 0.1f);
+      v += 0.2f * sin((i + shift + 10) * 0.15f);
+      v += 0.1f * sin((i + shift) * 0.03f);
+      v *= height;
+      output[i] = (int)v;
     }
-    int* shift_;
+    return output;
   };
 
-  Graph my_graph(&shift);
   auto htop = Renderer([&] {
     auto frequency = vbox({
         text(L"Frequency [Mhz]") | hcenter,
@@ -53,7 +46,7 @@ int main(int argc, const char* argv[]) {
                 filler(),
                 text(L"1200 "),
                 filler(),
-                text(L"0% "),
+                text(L"0 "),
             }),
             graph(std::ref(my_graph)) | flex,
         }) | flex,

--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -24,7 +24,6 @@ class ScreenInteractive : public Screen {
   static ScreenInteractive FitComponent();
   static ScreenInteractive TerminalOutput();
 
-  ~ScreenInteractive();
   void Loop(Component);
   std::function<void()> ExitLoopClosure();
 

--- a/include/ftxui/dom/node.hpp
+++ b/include/ftxui/dom/node.hpp
@@ -36,7 +36,7 @@ class Node {
   virtual void Render(Screen& screen);
 
  protected:
-  std::vector<Element> children_;
+  Elements children_;
   Requirement requirement_;
   Box box_;
 };

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -241,8 +241,6 @@ ScreenInteractive::ScreenInteractive(int dimx,
   event_sender_ = event_receiver_->MakeSender();
 }
 
-ScreenInteractive::~ScreenInteractive() {}
-
 // static
 ScreenInteractive ScreenInteractive::FixedSize(int dimx, int dimy) {
   return ScreenInteractive(dimx, dimy, Dimension::Fixed, false);

--- a/src/ftxui/dom/blink.cpp
+++ b/src/ftxui/dom/blink.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"        // for Element, unpack, Elements, blink
+#include "ftxui/dom/elements.hpp"        // for Element, blink
 #include "ftxui/dom/node.hpp"            // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -26,7 +26,7 @@ class Blink : public NodeDecorator {
 /// @brief The text drawn alternates in between visible and hidden.
 /// @ingroup dom
 Element blink(Element child) {
-  return std::make_shared<Blink>(unpack(std::move(child)));
+  return std::make_shared<Blink>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/dom/bold.cpp
+++ b/src/ftxui/dom/bold.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"        // for Element, unpack, Elements, bold
+#include "ftxui/dom/elements.hpp"        // for Element, bold
 #include "ftxui/dom/node.hpp"            // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -26,7 +26,7 @@ class Bold : public NodeDecorator {
 /// @brief Use a bold font, for elements with more emphasis.
 /// @ingroup dom
 Element bold(Element child) {
-  return std::make_shared<Bold>(unpack(std::move(child)));
+  return std::make_shared<Bold>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/dom/clear_under.cpp
+++ b/src/ftxui/dom/clear_under.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"  // for Element, unpack, Elements, clear_under
+#include "ftxui/dom/elements.hpp"  // for Element, clear_under
 #include "ftxui/dom/node.hpp"      // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -30,7 +30,7 @@ class ClearUnder : public NodeDecorator {
 /// @see ftxui::dbox
 /// @ingroup dom
 Element clear_under(Element child) {
-  return std::make_shared<ClearUnder>(unpack(std::move(child)));
+  return std::make_shared<ClearUnder>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/dom/color.cpp
+++ b/src/ftxui/dom/color.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"  // for Element, unpack, Decorator, Elements, bgcolor, color
+#include "ftxui/dom/elements.hpp"  // for Element, Decorator, bgcolor, color
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
 #include "ftxui/screen/color.hpp"        // for Color
@@ -11,8 +11,8 @@ namespace ftxui {
 
 class BgColor : public NodeDecorator {
  public:
-  BgColor(Elements children, Color color)
-      : NodeDecorator(std::move(children)), color_(color) {}
+  BgColor(Element child, Color color)
+      : NodeDecorator(std::move(child)), color_(color) {}
 
   void Render(Screen& screen) override {
     for (int y = box_.y_min; y <= box_.y_max; ++y) {
@@ -28,8 +28,8 @@ class BgColor : public NodeDecorator {
 
 class FgColor : public NodeDecorator {
  public:
-  FgColor(Elements children, Color color)
-      : NodeDecorator(std::move(children)), color_(color) {}
+  FgColor(Element child, Color color)
+      : NodeDecorator(std::move(child)), color_(color) {}
 
   void Render(Screen& screen) override {
     for (int y = box_.y_min; y <= box_.y_max; ++y) {
@@ -55,7 +55,7 @@ class FgColor : public NodeDecorator {
 /// Element document = color(Color::Green, text(L"Success")),
 /// ```
 Element color(Color color, Element child) {
-  return std::make_shared<FgColor>(unpack(std::move(child)), color);
+  return std::make_shared<FgColor>(std::move(child), color);
 }
 
 /// @brief Set the background color of an element.
@@ -70,7 +70,7 @@ Element color(Color color, Element child) {
 /// Element document = bgcolor(Color::Green, text(L"Success")),
 /// ```
 Element bgcolor(Color color, Element child) {
-  return std::make_shared<BgColor>(unpack(std::move(child)), color);
+  return std::make_shared<BgColor>(std::move(child), color);
 }
 
 /// @brief Decorate using a foreground color.

--- a/src/ftxui/dom/dim.cpp
+++ b/src/ftxui/dom/dim.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"        // for Element, unpack, Elements, dim
+#include "ftxui/dom/elements.hpp"        // for Element, dim
 #include "ftxui/dom/node.hpp"            // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -26,7 +26,7 @@ class Dim : public NodeDecorator {
 /// @brief Use a light font, for elements with less emphasis.
 /// @ingroup dom
 Element dim(Element child) {
-  return std::make_shared<Dim>(unpack(std::move(child)));
+  return std::make_shared<Dim>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/dom/frame.cpp
+++ b/src/ftxui/dom/frame.cpp
@@ -16,8 +16,7 @@ namespace ftxui {
 
 class Select : public Node {
  public:
-  Select(std::vector<std::shared_ptr<Node>> children)
-      : Node(std::move(children)) {}
+  Select(Elements children) : Node(std::move(children)) {}
 
   void ComputeRequirement() override {
     Node::ComputeRequirement();
@@ -31,7 +30,7 @@ class Select : public Node {
   };
 
   void SetBox(Box box) override {
-    box_ = box;
+    Node::SetBox(box);
     children_[0]->SetBox(box);
   }
 };
@@ -44,7 +43,7 @@ Element select(Element child) {
 
 class Focus : public Select {
  public:
-  Focus(std::vector<Element> children) : Select(std::move(children)) {}
+  using Select::Select;
 
   void ComputeRequirement() override {
     Select::ComputeRequirement();
@@ -85,7 +84,7 @@ Element focus(Element child) {
 
 class Frame : public Node {
  public:
-  Frame(std::vector<Element> children, bool x_frame, bool y_frame)
+  Frame(Elements children, bool x_frame, bool y_frame)
       : Node(std::move(children)), x_frame_(x_frame), y_frame_(y_frame) {}
 
   void ComputeRequirement() override {

--- a/src/ftxui/dom/inverted.cpp
+++ b/src/ftxui/dom/inverted.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"  // for Element, unpack, Elements, inverted
+#include "ftxui/dom/elements.hpp"  // for Element, inverted
 #include "ftxui/dom/node.hpp"      // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -27,7 +27,7 @@ class Inverted : public NodeDecorator {
 /// colors.
 /// @ingroup dom
 Element inverted(Element child) {
-  return std::make_shared<Inverted>(unpack(std::move(child)));
+  return std::make_shared<Inverted>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/dom/node_decorator.hpp
+++ b/src/ftxui/dom/node_decorator.hpp
@@ -3,7 +3,8 @@
 
 #include <utility>  // for move
 
-#include "ftxui/dom/node.hpp"  // for Node, Elements
+#include "ftxui/dom/elements.hpp"  // for Element, unpack
+#include "ftxui/dom/node.hpp"  // for Node
 
 namespace ftxui {
 struct Box;
@@ -11,7 +12,7 @@ struct Box;
 // Helper class.
 class NodeDecorator : public Node {
  public:
-  NodeDecorator(Elements children) : Node(std::move(children)) {}
+  NodeDecorator(Element child) : Node(unpack(std::move(child))) {}
   void ComputeRequirement() override;
   void SetBox(Box box) override;
 };

--- a/src/ftxui/dom/underlined.cpp
+++ b/src/ftxui/dom/underlined.cpp
@@ -1,7 +1,7 @@
 #include <memory>   // for make_shared
 #include <utility>  // for move
 
-#include "ftxui/dom/elements.hpp"  // for Element, unpack, Elements, underlined
+#include "ftxui/dom/elements.hpp"  // for Element, underlined
 #include "ftxui/dom/node.hpp"      // for Node
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator
 #include "ftxui/screen/box.hpp"          // for Box
@@ -26,7 +26,7 @@ class Underlined : public NodeDecorator {
 /// @brief Make the underlined element to be underlined.
 /// @ingroup dom
 Element underlined(Element child) {
-  return std::make_shared<Underlined>(unpack(std::move(child)));
+  return std::make_shared<Underlined>(std::move(child));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -38,11 +38,6 @@ static const char* MOVE_LEFT = "\r";
 static const char* MOVE_UP = "\x1B[1A";
 static const char* CLEAR_LINE = "\x1B[2K";
 
-bool In(const Box& stencil, int x, int y) {
-  return stencil.x_min <= x && x <= stencil.x_max &&  //
-         stencil.y_min <= y && y <= stencil.y_max;
-}
-
 Pixel dev_null_pixel;
 
 #if defined(_WIN32)
@@ -195,7 +190,7 @@ wchar_t& Screen::at(int x, int y) {
 /// @param x The pixel position along the x-axis.
 /// @param y The pixel position along the y-axis.
 Pixel& Screen::PixelAt(int x, int y) {
-  return In(stencil, x, y) ? pixels_[y][x] : dev_null_pixel;
+  return stencil.Contain(x, y) ? pixels_[y][x] : dev_null_pixel;
 }
 
 /// @brief Return a string to be printed in order to reset the cursor position


### PR DESCRIPTION
**ContainerBase:**
- Extract Vertical, Horizontal and Tab containers to subclasses of ContainerBase.
- Preserve specific behaviour using virtual methods.

**NodeDecorator:**
- Collect the usage of `unpack` from NodeDecorator subclasses into single constructor.

**Miscellaneous:**
- Replace Graph functor in homescreen example with lambda.
- Reduce duplication of logic for Box Contains point from `Screen::PixelAt`.