### PR TITLE
Extract common struct Dimensions from Terminal

### DIFF
--- a/include/ftxui/dom/elements.hpp
+++ b/include/ftxui/dom/elements.hpp
@@ -8,6 +8,7 @@
 #include "ftxui/screen/box.hpp"
 #include "ftxui/screen/color.hpp"
 #include "ftxui/screen/screen.hpp"
+#include "ftxui/screen/terminal.hpp"
 
 namespace ftxui {
 class Node;
@@ -101,6 +102,10 @@ Element nothing(Element element);
 // Before drawing the |element| clear the pixel below. This is useful in
 // combinaison with dbox.
 Element clear_under(Element element);
+
+namespace Dimension {
+Dimensions Fit(Element&);
+}  // namespace Dimension
 
 }  // namespace ftxui
 

--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -7,10 +7,9 @@
 
 #include "ftxui/screen/box.hpp"
 #include "ftxui/screen/color.hpp"
+#include "ftxui/screen/terminal.hpp"
 
 namespace ftxui {
-class Node;
-using Element = std::shared_ptr<Node>;
 
 /// @brief A unicode character and its associated style.
 /// @ingroup screen
@@ -41,14 +40,10 @@ struct Pixel {
 
 /// @brief Define how the Screen's dimensions should look like.
 /// @ingroup screen
-struct Dimension {
-  static Dimension Fixed(int);
-  static Dimension Fit(Element&);
-  static Dimension Full();
-
-  int dimx;
-  int dimy;
-};
+namespace Dimension {
+Dimensions Fixed(int);
+Dimensions Full();
+}  // namespace Dimension
 
 /// @brief A rectangular grid of Pixel.
 /// @ingroup screen
@@ -56,8 +51,8 @@ class Screen {
  public:
   // Constructors:
   Screen(int dimx, int dimy);
-  static Screen Create(Dimension dimension);
-  static Screen Create(Dimension width, Dimension height);
+  static Screen Create(Dimensions dimension);
+  static Screen Create(Dimensions width, Dimensions height);
 
   // Node write into the screen using Screen::at.
   wchar_t& at(int x, int y);

--- a/include/ftxui/screen/terminal.hpp
+++ b/include/ftxui/screen/terminal.hpp
@@ -2,23 +2,22 @@
 #define FTXUI_CORE_TERMINAL_HPP
 
 namespace ftxui {
-
-class Terminal {
- public:
-  struct Dimensions {
-    int dimx;
-    int dimy;
-  };
-  static Dimensions Size();
-
-  enum Color {
-    Palette1,
-    Palette16,
-    Palette256,
-    TrueColor,
-  };
-  static Color ColorSupport();
+struct Dimensions {
+  int dimx;
+  int dimy;
 };
+
+namespace Terminal {
+Dimensions Size();
+
+enum Color {
+  Palette1,
+  Palette16,
+  Palette256,
+  TrueColor,
+};
+Color ColorSupport();
+}  // namespace Terminal
 
 }  // namespace ftxui
 

--- a/src/ftxui/dom/util.cpp
+++ b/src/ftxui/dom/util.cpp
@@ -59,6 +59,16 @@ Element operator|(Element element, Decorator decorator) {
   return decorator(std::move(element));
 }
 
+/// The minimal dimension that will fit the given element.
+/// @see Fixed
+/// @see Full
+Dimensions Dimension::Fit(Element& e) {
+  e->ComputeRequirement();
+  Dimensions size = Dimension::Full();
+  return {std::min(e->requirement().min_x, size.dimx),
+          std::min(e->requirement().min_y, size.dimy)};
+}
+
 }  // namespace ftxui
 
 // Copyright 2020 Arthur Sonzogni. All rights reserved.

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -2,8 +2,6 @@
 #include <iostream>  // for operator<<, basic_ostream, wstringstream, stringstream, flush, cout, ostream
 #include <sstream>   // IWYU pragma: keep
 
-#include "ftxui/dom/node.hpp"         // for Element, Node
-#include "ftxui/dom/requirement.hpp"  // for Requirement
 #include "ftxui/screen/screen.hpp"
 #include "ftxui/screen/string.hpp"    // for to_string, wchar_width
 #include "ftxui/screen/terminal.hpp"  // for Terminal::Dimensions, Terminal
@@ -93,42 +91,31 @@ void UpdatePixelStyle(std::wstringstream& ss, Pixel& previous, Pixel& next) {
 /// A fixed dimension.
 /// @see Fit
 /// @see Full
-Dimension Dimension::Fixed(int v) {
-  return Dimension{v, v};
-}
-
-/// The minimal dimension that will fit the given element.
-/// @see Fixed
-/// @see Full
-Dimension Dimension::Fit(Element& e) {
-  e->ComputeRequirement();
-  Terminal::Dimensions size = Terminal::Size();
-  return Dimension{std::min(e->requirement().min_x, size.dimx),
-                   std::min(e->requirement().min_y, size.dimy)};
+Dimensions Dimension::Fixed(int v) {
+  return {v, v};
 }
 
 /// Use the terminal dimensions.
 /// @see Fixed
 /// @see Fit
-Dimension Dimension::Full() {
-  Terminal::Dimensions size = Terminal::Size();
-  return Dimension{size.dimx, size.dimy};
+Dimensions Dimension::Full() {
+  return Terminal::Size();
 }
 
 // static
 /// Create a screen with the given dimension along the x-axis and y-axis.
-Screen Screen::Create(Dimension width, Dimension height) {
+Screen Screen::Create(Dimensions width, Dimensions height) {
   return Screen(width.dimx, height.dimy);
 }
 
 // static
 /// Create a screen with the given dimension.
-Screen Screen::Create(Dimension dimension) {
+Screen Screen::Create(Dimensions dimension) {
   return Screen(dimension.dimx, dimension.dimy);
 }
 
 Screen::Screen(int dimx, int dimy)
-    : stencil({0, dimx - 1, 0, dimy - 1}),
+    : stencil{0, dimx - 1, 0, dimy - 1},
       dimx_(dimx),
       dimy_(dimy),
       pixels_(dimy, std::vector<Pixel>(dimx)) {

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -18,7 +18,7 @@
 
 namespace ftxui {
 
-Terminal::Dimensions Terminal::Size() {
+Dimensions Terminal::Size() {
 #if defined(__EMSCRIPTEN__)
   return Dimensions{140, 43};
 #elif defined(_WIN32)


### PR DESCRIPTION
- Convert `Dimension` to namespace to allow defining `Fit` method from dom.
  - Use `Dimensions` extracted from `Terminal` as replacement `struct`.
- Convert `Terminal` to namespace as it only defines static members.
- Remove dom references from screen library (circular dependency).