### PR TITLE
Update examples to use std::string.

### DIFF
--- a/examples/component/button.cpp
+++ b/examples/component/button.cpp
@@ -6,7 +6,6 @@
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/component_options.hpp"   // for ButtonOption
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
 #include "ftxui/dom/elements.hpp"  // for separator, gauge, Element, operator|, vbox, border
 
 using namespace ftxui;
@@ -27,7 +26,7 @@ int main(int argc, const char* argv[]) {
   // Modify the way to render them on screen:
   auto component = Renderer(buttons, [&] {
     return vbox({
-               text(L"value = " + std::to_wstring(value)),
+               text("value = " + std::to_string(value)),
                separator(),
                gauge(value * 0.01f),
                separator(),

--- a/examples/component/checkbox_in_frame.cpp
+++ b/examples/component/checkbox_in_frame.cpp
@@ -1,13 +1,12 @@
-#include <memory>  // for __shared_ptr_access, allocator_traits<>::value_type, shared_ptr
-#include <string>  // for operator+
+#include <memory>  // for shared_ptr, __shared_ptr_access, allocator_traits<>::value_type
+#include <string>  // for operator+, to_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"  // for Checkbox, Renderer, Vertical
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/elements.hpp"  // for Element, operator|, size, border, frame, HEIGHT, LESS_THAN
-#include "ftxui/screen/string.hpp"  // for to_wstring
+#include "ftxui/dom/elements.hpp"  // for operator|, Element, size, border, frame, HEIGHT, LESS_THAN
 
 using namespace ftxui;
 
@@ -21,7 +20,8 @@ int main(int argc, const char* argv[]) {
   auto container = Container::Vertical({});
   for (int i = 0; i < size; ++i) {
     states[i].checked = false;
-    container->Add(Checkbox(L"Checkbox" + to_wstring(i), &states[i].checked));
+    container->Add(
+        Checkbox("Checkbox" + std::to_string(i), &states[i].checked));
   }
 
   auto component = Renderer(container, [&] {

--- a/examples/component/composition.cpp
+++ b/examples/component/composition.cpp
@@ -1,13 +1,12 @@
 #include <memory>  // for allocator, shared_ptr, __shared_ptr_access
-#include <string>  // for operator+, to_wstring
+#include <string>  // for operator+, to_string
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"  // for Button, Horizontal, Renderer
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/component_options.hpp"   // for ButtonOption
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for separator, Element, operator|, vbox, border
+#include "ftxui/dom/elements.hpp"  // for text, separator, Element, operator|, vbox, border
 
 using namespace ftxui;
 
@@ -38,9 +37,9 @@ int main(int argc, const char* argv[]) {
   // children reacts to events is maintained.
   auto leftpane = Renderer(left_buttons, [&] {
     return vbox({
-               text(L"This is the left control"),
+               text("This is the left control"),
                separator(),
-               text(L"Left button count: " + std::to_wstring(left_count)),
+               text("Left button count: " + std::to_string(left_count)),
                left_buttons->Render(),
            }) |
            border;
@@ -48,9 +47,9 @@ int main(int argc, const char* argv[]) {
 
   auto rightpane = Renderer(right_buttons, [&] {
     return vbox({
-               text(L"This is the right control"),
+               text("This is the right control"),
                separator(),
-               text(L"Right button count: " + std::to_wstring(right_count)),
+               text("Right button count: " + std::to_string(right_count)),
                right_buttons->Render(),
            }) |
            border;

--- a/examples/component/gallery.cpp
+++ b/examples/component/gallery.cpp
@@ -1,20 +1,18 @@
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, allocator, __shared_ptr_access
-#include <string>      // for wstring, basic_string
+#include <string>      // for string, basic_string
 #include <vector>      // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
-#include "ftxui/component/component.hpp"  // for Slider, Checkbox, Vertical, Renderer, Button, Menu, Radiobox, Toggle
+#include "ftxui/component/component.hpp"  // for Slider, Checkbox, Vertical, Renderer, Button, Input, Menu, Radiobox, Toggle
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
-#include "ftxui/component/deprecated.hpp"      // for Input
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for separator, operator|, Element, size, xflex, WIDTH, hbox, vbox, EQUAL, border, GREATER_THAN
+#include "ftxui/dom/elements.hpp"  // for separator, operator|, Element, size, xflex, text, WIDTH, hbox, vbox, EQUAL, border, GREATER_THAN
 
 using namespace ftxui;
 
 // Display a component nicely with a title on the left.
-Component Wrap(std::wstring name, Component component) {
+Component Wrap(std::string name, Component component) {
   return Renderer(component, [name, component] {
     return hbox({
                text(name) | size(WIDTH, EQUAL, 8),
@@ -30,24 +28,24 @@ int main(int argc, const char* argv[]) {
 
   // -- Menu
   // ----------------------------------------------------------------------
-  const std::vector<std::wstring> menu_entries = {
-      L"Menu 1",
-      L"Menu 2",
-      L"Menu 3",
-      L"Menu 4",
+  const std::vector<std::string> menu_entries = {
+      "Menu 1",
+      "Menu 2",
+      "Menu 3",
+      "Menu 4",
   };
   int menu_selected = 0;
   auto menu = Menu(&menu_entries, &menu_selected);
-  menu = Wrap(L"Menu", menu);
+  menu = Wrap("Menu", menu);
 
   // -- Toggle------------------------------------------------------------------
   int toggle_selected = 0;
-  std::vector<std::wstring> toggle_entries = {
-      L"Toggle_1",
-      L"Toggle_2",
+  std::vector<std::string> toggle_entries = {
+      "Toggle_1",
+      "Toggle_2",
   };
   auto toggle = Toggle(&toggle_entries, &toggle_selected);
-  toggle = Wrap(L"Toggle", toggle);
+  toggle = Wrap("Toggle", toggle);
 
   // -- Checkbox ---------------------------------------------------------------
   bool checkbox_1_selected = false;
@@ -57,40 +55,40 @@ int main(int argc, const char* argv[]) {
       Checkbox("checkbox1", &checkbox_1_selected),
       Checkbox("checkbox2", &checkbox_2_selected),
   });
-  checkboxes = Wrap(L"Checkbox", checkboxes);
+  checkboxes = Wrap("Checkbox", checkboxes);
 
   // -- Radiobox ---------------------------------------------------------------
   int radiobox_selected = 0;
-  std::vector<std::wstring> radiobox_entries = {
-      L"Radiobox 1",
-      L"Radiobox 2",
-      L"Radiobox 3",
-      L"Radiobox 4",
+  std::vector<std::string> radiobox_entries = {
+      "Radiobox 1",
+      "Radiobox 2",
+      "Radiobox 3",
+      "Radiobox 4",
   };
   auto radiobox = Radiobox(&radiobox_entries, &radiobox_selected);
-  radiobox = Wrap(L"Radiobox", radiobox);
+  radiobox = Wrap("Radiobox", radiobox);
 
   // -- Input ------------------------------------------------------------------
-  std::wstring input_label;
-  auto input = Input(&input_label, L"placeholder");
-  input = Wrap(L"Input", input);
+  std::string input_label;
+  auto input = Input(&input_label, "placeholder");
+  input = Wrap("Input", input);
 
   // -- Button -----------------------------------------------------------------
-  std::wstring button_label = L"Quit";
+  std::string button_label = "Quit";
   std::function<void()> on_button_clicked_;
   auto button = Button(&button_label, screen.ExitLoopClosure());
-  button = Wrap(L"Button", button);
+  button = Wrap("Button", button);
 
   // -- Slider -----------------------------------------------------------------
   int slider_value_1 = 12;
   int slider_value_2 = 56;
   int slider_value_3 = 128;
   auto sliders = Container::Vertical({
-      Slider(L"R:", &slider_value_1, 0, 256, 1),
-      Slider(L"G:", &slider_value_2, 0, 256, 1),
-      Slider(L"B:", &slider_value_3, 0, 256, 1),
+      Slider("R:", &slider_value_1, 0, 256, 1),
+      Slider("G:", &slider_value_2, 0, 256, 1),
+      Slider("B:", &slider_value_3, 0, 256, 1),
   });
-  sliders = Wrap(L"Slider", sliders);
+  sliders = Wrap("Slider", sliders);
 
   // -- Layout -----------------------------------------------------------------
   auto layout = Container::Vertical({

--- a/examples/component/homescreen.cpp
+++ b/examples/component/homescreen.cpp
@@ -3,7 +3,7 @@
 #include <cmath>       // for sin
 #include <functional>  // for ref, reference_wrapper, function
 #include <memory>      // for allocator, shared_ptr, __shared_ptr_access
-#include <string>  // for wstring, basic_string, operator+, char_traits, to_wstring
+#include <string>  // for string, basic_string, operator+, char_traits, to_string
 #include <thread>   // for sleep_for, thread
 #include <utility>  // for move
 #include <vector>   // for vector
@@ -12,10 +12,8 @@
 #include "ftxui/component/component.hpp"  // for Checkbox, Renderer, Horizontal, Vertical, Menu, Radiobox, Tab, Toggle
 #include "ftxui/component/component_base.hpp"     // for ComponentBase
 #include "ftxui/component/component_options.hpp"  // for InputOption
-#include "ftxui/component/deprecated.hpp"         // for Input
 #include "ftxui/component/event.hpp"              // for Event, Event::Custom
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
 #include "ftxui/dom/elements.hpp"  // for operator|, color, bgcolor, filler, Element, size, vbox, flex, hbox, graph, separator, EQUAL, WIDTH, hcenter, bold, border, window, HEIGHT, Elements, hflow, flex_grow, frame, gauge, LESS_THAN, spinner, dim, GREATER_THAN
 #include "ftxui/screen/color.hpp"  // for Color, Color::BlueLight, Color::RedLight, Color::Black, Color::Blue, Color::Cyan, Color::CyanLight, Color::GrayDark, Color::GrayLight, Color::Green, Color::GreenLight, Color::Magenta, Color::MagentaLight, Color::Red, Color::White, Color::Yellow, Color::YellowLight, Color::Default
 
@@ -41,42 +39,42 @@ int main(int argc, const char* argv[]) {
 
   auto htop = Renderer([&] {
     auto frequency = vbox({
-        text(L"Frequency [Mhz]") | hcenter,
+        text("Frequency [Mhz]") | hcenter,
         hbox({
             vbox({
-                text(L"2400 "),
+                text("2400 "),
                 filler(),
-                text(L"1200 "),
+                text("1200 "),
                 filler(),
-                text(L"0 "),
+                text("0 "),
             }),
             graph(std::ref(my_graph)) | flex,
         }) | flex,
     });
 
     auto utilization = vbox({
-        text(L"Utilization [%]") | hcenter,
+        text("Utilization [%]") | hcenter,
         hbox({
             vbox({
-                text(L"100 "),
+                text("100 "),
                 filler(),
-                text(L"50 "),
+                text("50 "),
                 filler(),
-                text(L"0 "),
+                text("0 "),
             }),
             graph(std::ref(my_graph)) | color(Color::RedLight),
         }) | flex,
     });
 
     auto ram = vbox({
-        text(L"Ram [Mo]") | hcenter,
+        text("Ram [Mo]") | hcenter,
         hbox({
             vbox({
-                text(L"8192"),
+                text("8192"),
                 filler(),
-                text(L"4096 "),
+                text("4096 "),
                 filler(),
-                text(L"0 "),
+                text("0 "),
             }),
             graph(std::ref(my_graph)) | color(Color::BlueLight),
         }) | flex,
@@ -94,56 +92,56 @@ int main(int argc, const char* argv[]) {
            flex | border;
   });
 
-  const std::vector<std::wstring> compiler_entries = {
-      L"gcc",
-      L"clang",
-      L"emcc",
-      L"game_maker",
-      L"Ada compilers",
-      L"ALGOL 60 compilers",
-      L"ALGOL 68 compilers",
-      L"Assemblers (Intel *86)",
-      L"Assemblers (Motorola 68*)",
-      L"Assemblers (Zilog Z80)",
-      L"Assemblers (other)",
-      L"BASIC Compilers",
-      L"BASIC interpreters",
-      L"Batch compilers",
-      L"C compilers",
-      L"Source-to-source compilers",
-      L"C++ compilers",
-      L"C# compilers",
-      L"COBOL compilers",
-      L"Common Lisp compilers",
-      L"D compilers",
-      L"DIBOL/DBL compilers",
-      L"ECMAScript interpreters",
-      L"Eiffel compilers",
-      L"Fortran compilers",
-      L"Go compilers",
-      L"Haskell compilers",
-      L"Java compilers",
-      L"Pascal compilers",
-      L"Perl Interpreters",
-      L"PHP compilers",
-      L"PL/I compilers",
-      L"Python compilers",
-      L"Scheme compilers and interpreters",
-      L"Smalltalk compilers",
-      L"Tcl Interpreters",
-      L"VMS Interpreters",
-      L"Rexx Interpreters",
-      L"CLI compilers",
+  const std::vector<std::string> compiler_entries = {
+      "gcc",
+      "clang",
+      "emcc",
+      "game_maker",
+      "Ada compilers",
+      "ALGOL 60 compilers",
+      "ALGOL 68 compilers",
+      "Assemblers (Intel *86)",
+      "Assemblers (Motorola 68*)",
+      "Assemblers (Zilog Z80)",
+      "Assemblers (other)",
+      "BASIC Compilers",
+      "BASIC interpreters",
+      "Batch compilers",
+      "C compilers",
+      "Source-to-source compilers",
+      "C++ compilers",
+      "C# compilers",
+      "COBOL compilers",
+      "Common Lisp compilers",
+      "D compilers",
+      "DIBOL/DBL compilers",
+      "ECMAScript interpreters",
+      "Eiffel compilers",
+      "Fortran compilers",
+      "Go compilers",
+      "Haskell compilers",
+      "Java compilers",
+      "Pascal compilers",
+      "Perl Interpreters",
+      "PHP compilers",
+      "PL/I compilers",
+      "Python compilers",
+      "Scheme compilers and interpreters",
+      "Smalltalk compilers",
+      "Tcl Interpreters",
+      "VMS Interpreters",
+      "Rexx Interpreters",
+      "CLI compilers",
   };
 
   int compiler_selected = 0;
   Component compiler = Radiobox(&compiler_entries, &compiler_selected);
 
-  std::array<std::wstring, 4> options_label = {
-      L"-Wall",
-      L"-Werror",
-      L"-lpthread",
-      L"-O3",
+  std::array<std::string, 4> options_label = {
+      "-Wall",
+      "-Werror",
+      "-lpthread",
+      "-O3",
   };
   std::array<bool, 4> options_state = {
       false,
@@ -152,19 +150,19 @@ int main(int argc, const char* argv[]) {
       false,
   };
 
-  std::vector<std::wstring> input_entries;
+  std::vector<std::string> input_entries;
   int input_selected = 0;
   Component input = Menu(&input_entries, &input_selected);
 
   auto input_option = InputOption();
-  std::wstring input_add_content;
+  std::string input_add_content;
   input_option.on_enter = [&] {
     input_entries.push_back(input_add_content);
-    input_add_content = L"";
+    input_add_content = "";
   };
   Component input_add = Input(&input_add_content, "input files", input_option);
 
-  std::wstring executable_content_ = L"";
+  std::string executable_content_ = "";
   Component executable_ = Input(&executable_content_, "executable");
 
   Component flags = Container::Vertical({
@@ -193,33 +191,33 @@ int main(int argc, const char* argv[]) {
     // flags
     for (int i = 0; i < 4; ++i) {
       if (options_state[i]) {
-        line.push_back(text(L" "));
+        line.push_back(text(" "));
         line.push_back(text(options_label[i]) | dim);
       }
     }
     // Executable
     if (!executable_content_.empty()) {
-      line.push_back(text(L" -o ") | bold);
+      line.push_back(text(" -o ") | bold);
       line.push_back(text(executable_content_) | color(Color::BlueLight) |
                      bold);
     }
     // Input
     for (auto& it : input_entries) {
-      line.push_back(text(L" " + it) | color(Color::RedLight));
+      line.push_back(text(" " + it) | color(Color::RedLight));
     }
     return line;
   };
 
   auto compiler_renderer = Renderer(compiler_component, [&] {
-    auto compiler_win = window(text(L"Compiler"), compiler->Render() | frame);
-    auto flags_win = window(text(L"Flags"), flags->Render());
-    auto executable_win = window(text(L"Executable:"), executable_->Render());
+    auto compiler_win = window(text("Compiler"), compiler->Render() | frame);
+    auto flags_win = window(text("Flags"), flags->Render());
+    auto executable_win = window(text("Executable:"), executable_->Render());
     auto input_win =
-        window(text(L"Input"),
+        window(text("Input"),
                hbox({
                    vbox({
                        hbox({
-                           text(L"Add: "),
+                           text("Add: "),
                            input_add->Render(),
                        }) | size(WIDTH, EQUAL, 20) |
                            size(HEIGHT, EQUAL, 1),
@@ -255,42 +253,42 @@ int main(int argc, const char* argv[]) {
   auto color_tab_renderer = Renderer([] {
     return hbox({
                vbox({
-                   color(Color::Default, text(L"Default")),
-                   color(Color::Black, text(L"Black")),
-                   color(Color::GrayDark, text(L"GrayDark")),
-                   color(Color::GrayLight, text(L"GrayLight")),
-                   color(Color::White, text(L"White")),
-                   color(Color::Blue, text(L"Blue")),
-                   color(Color::BlueLight, text(L"BlueLight")),
-                   color(Color::Cyan, text(L"Cyan")),
-                   color(Color::CyanLight, text(L"CyanLight")),
-                   color(Color::Green, text(L"Green")),
-                   color(Color::GreenLight, text(L"GreenLight")),
-                   color(Color::Magenta, text(L"Magenta")),
-                   color(Color::MagentaLight, text(L"MagentaLight")),
-                   color(Color::Red, text(L"Red")),
-                   color(Color::RedLight, text(L"RedLight")),
-                   color(Color::Yellow, text(L"Yellow")),
-                   color(Color::YellowLight, text(L"YellowLight")),
+                   color(Color::Default, text("Default")),
+                   color(Color::Black, text("Black")),
+                   color(Color::GrayDark, text("GrayDark")),
+                   color(Color::GrayLight, text("GrayLight")),
+                   color(Color::White, text("White")),
+                   color(Color::Blue, text("Blue")),
+                   color(Color::BlueLight, text("BlueLight")),
+                   color(Color::Cyan, text("Cyan")),
+                   color(Color::CyanLight, text("CyanLight")),
+                   color(Color::Green, text("Green")),
+                   color(Color::GreenLight, text("GreenLight")),
+                   color(Color::Magenta, text("Magenta")),
+                   color(Color::MagentaLight, text("MagentaLight")),
+                   color(Color::Red, text("Red")),
+                   color(Color::RedLight, text("RedLight")),
+                   color(Color::Yellow, text("Yellow")),
+                   color(Color::YellowLight, text("YellowLight")),
                }),
                vbox({
-                   bgcolor(Color::Default, text(L"Default")),
-                   bgcolor(Color::Black, text(L"Black")),
-                   bgcolor(Color::GrayDark, text(L"GrayDark")),
-                   bgcolor(Color::GrayLight, text(L"GrayLight")),
-                   bgcolor(Color::White, text(L"White")),
-                   bgcolor(Color::Blue, text(L"Blue")),
-                   bgcolor(Color::BlueLight, text(L"BlueLight")),
-                   bgcolor(Color::Cyan, text(L"Cyan")),
-                   bgcolor(Color::CyanLight, text(L"CyanLight")),
-                   bgcolor(Color::Green, text(L"Green")),
-                   bgcolor(Color::GreenLight, text(L"GreenLight")),
-                   bgcolor(Color::Magenta, text(L"Magenta")),
-                   bgcolor(Color::MagentaLight, text(L"MagentaLight")),
-                   bgcolor(Color::Red, text(L"Red")),
-                   bgcolor(Color::RedLight, text(L"RedLight")),
-                   bgcolor(Color::Yellow, text(L"Yellow")),
-                   bgcolor(Color::YellowLight, text(L"YellowLight")),
+                   bgcolor(Color::Default, text("Default")),
+                   bgcolor(Color::Black, text("Black")),
+                   bgcolor(Color::GrayDark, text("GrayDark")),
+                   bgcolor(Color::GrayLight, text("GrayLight")),
+                   bgcolor(Color::White, text("White")),
+                   bgcolor(Color::Blue, text("Blue")),
+                   bgcolor(Color::BlueLight, text("BlueLight")),
+                   bgcolor(Color::Cyan, text("Cyan")),
+                   bgcolor(Color::CyanLight, text("CyanLight")),
+                   bgcolor(Color::Green, text("Green")),
+                   bgcolor(Color::GreenLight, text("GreenLight")),
+                   bgcolor(Color::Magenta, text("Magenta")),
+                   bgcolor(Color::MagentaLight, text("MagentaLight")),
+                   bgcolor(Color::Red, text("Red")),
+                   bgcolor(Color::RedLight, text("RedLight")),
+                   bgcolor(Color::Yellow, text("Yellow")),
+                   bgcolor(Color::YellowLight, text("YellowLight")),
                }),
            }) |
            hcenter | border;
@@ -299,7 +297,7 @@ int main(int argc, const char* argv[]) {
   auto render_gauge = [&shift](int delta) {
     float progress = (shift + delta) % 1000 / 1000.f;
     return hbox({
-        text(std::to_wstring(int(progress * 100)) + L"% ") |
+        text(std::to_string(int(progress * 100)) + "% ") |
             size(WIDTH, EQUAL, 5),
         gauge(progress),
     });
@@ -329,8 +327,8 @@ int main(int argc, const char* argv[]) {
   });
 
   int tab_index = 0;
-  std::vector<std::wstring> tab_entries = {
-      L"htop", L"color", L"spinner", L"gauge", L"compiler",
+  std::vector<std::string> tab_entries = {
+      "htop", "color", "spinner", "gauge", "compiler",
   };
   auto tab_selection = Toggle(&tab_entries, &tab_index);
   auto tab_content = Container::Tab(
@@ -350,7 +348,7 @@ int main(int argc, const char* argv[]) {
 
   auto main_renderer = Renderer(main_container, [&] {
     return vbox({
-        text(L"FTXUI Demo") | bold | hcenter,
+        text("FTXUI Demo") | bold | hcenter,
         tab_selection->Render() | hcenter,
         tab_content->Render() | flex,
     });

--- a/examples/component/input.cpp
+++ b/examples/component/input.cpp
@@ -5,17 +5,15 @@
 #include "ftxui/component/component.hpp"          // for Renderer, Vertical
 #include "ftxui/component/component_base.hpp"     // for ComponentBase
 #include "ftxui/component/component_options.hpp"  // for InputOption
-#include "ftxui/component/deprecated.hpp"         // for Input
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
 #include "ftxui/dom/elements.hpp"  // for hbox, separator, Element, operator|, vbox, border
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
 
-  std::wstring first_name;
-  std::wstring last_name;
-  std::wstring password;
+  std::string first_name;
+  std::string last_name;
+  std::string password;
 
   Component input_first_name = Input(&first_name, "first name");
   Component input_last_name = Input(&last_name, "last name");
@@ -32,11 +30,11 @@ int main(int argc, const char* argv[]) {
 
   auto renderer = Renderer(component, [&] {
     return vbox({
-               text(L"Hello " + first_name + L" " + last_name),
+               text("Hello " + first_name + " " + last_name),
                separator(),
-               hbox(text(L" First name : "), input_first_name->Render()),
-               hbox(text(L" Last name  : "), input_last_name->Render()),
-               hbox(text(L" Password   : "), input_password->Render()),
+               hbox(text(" First name : "), input_first_name->Render()),
+               hbox(text(" Last name  : "), input_last_name->Render()),
+               hbox(text(" Password   : "), input_password->Render()),
            }) |
            border;
   });

--- a/examples/component/menu.cpp
+++ b/examples/component/menu.cpp
@@ -1,6 +1,6 @@
 #include <functional>  // for function
 #include <iostream>  // for basic_ostream::operator<<, operator<<, endl, basic_ostream, basic_ostream<>::__ostream_type, cout, ostream
-#include <string>    // for wstring, basic_string, allocator
+#include <string>    // for string, basic_string, allocator
 #include <vector>    // for vector
 
 #include "ftxui/component/captured_mouse.hpp"      // for ftxui
@@ -12,10 +12,10 @@ int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto screen = ScreenInteractive::TerminalOutput();
 
-  std::vector<std::wstring> entries = {
-      L"entry 1",
-      L"entry 2",
-      L"entry 3",
+  std::vector<std::string> entries = {
+      "entry 1",
+      "entry 2",
+      "entry 3",
   };
   int selected = 0;
 

--- a/examples/component/menu2.cpp
+++ b/examples/component/menu2.cpp
@@ -1,6 +1,6 @@
 #include <functional>  // for function
 #include <memory>      // for allocator, __shared_ptr_access
-#include <string>      // for wstring, basic_string, operator+, to_string
+#include <string>      // for string, basic_string, operator+, to_string
 #include <vector>      // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
@@ -8,21 +8,17 @@
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
 #include "ftxui/component/component_options.hpp"  // for MenuOption
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for separator, bold, hcenter, vbox, hbox, gauge, Element, operator|, border
-#include "ftxui/screen/string.hpp"  // for to_wstring
+#include "ftxui/dom/elements.hpp"  // for text, separator, bold, hcenter, vbox, hbox, gauge, Element, operator|, border
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto screen = ScreenInteractive::TerminalOutput();
 
-  std::vector<std::wstring> left_menu_entries = {
-      L"0%",  L"10%", L"20%", L"30%", L"40%",
-      L"50%", L"60%", L"70%", L"80%", L"90%",
+  std::vector<std::string> left_menu_entries = {
+      "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%",
   };
-  std::vector<std::wstring> right_menu_entries = {
-      L"0%", L"1%", L"2%", L"3%", L"4%",  L"5%",
-      L"6%", L"7%", L"8%", L"9%", L"10%",
+  std::vector<std::string> right_menu_entries = {
+      "0%", "1%", "2%", "3%", "4%", "5%", "6%", "7%", "8%", "9%", "10%",
   };
 
   auto menu_option = MenuOption();
@@ -47,14 +43,14 @@ int main(int argc, const char* argv[]) {
                hbox({
                    // -------- Left Menu --------------
                    vbox({
-                       hcenter(bold(text(L"Percentage by 10%"))),
+                       hcenter(bold(text("Percentage by 10%"))),
                        separator(),
                        left_menu_->Render(),
                    }),
                    separator(),
                    // -------- Right Menu --------------
                    vbox({
-                       hcenter(bold(text(L"Percentage by 1%"))),
+                       hcenter(bold(text("Percentage by 1%"))),
                        separator(),
                        right_menu_->Render(),
                    }),
@@ -64,12 +60,12 @@ int main(int argc, const char* argv[]) {
                // -------- Bottom panel --------------
                vbox({
                    hbox({
-                       text(L" gauge : "),
+                       text(" gauge : "),
                        gauge(sum / 100.0),
                    }),
                    hbox({
-                       text(L"  text : "),
-                       text(to_wstring(std::to_string(sum) + " %")),
+                       text("  text : "),
+                       text(std::to_string(sum) + " %"),
                    }),
                }),
            }) |

--- a/examples/component/menu_multiple.cpp
+++ b/examples/component/menu_multiple.cpp
@@ -1,19 +1,17 @@
 #include <stdlib.h>  // for EXIT_SUCCESS
 #include <memory>    // for allocator, __shared_ptr_access
-#include <string>    // for wstring, operator+, basic_string, char_traits
-#include <vector>    // for vector, __alloc_traits<>::value_type
+#include <string>  // for string, operator+, basic_string, to_string, char_traits
+#include <vector>  // for vector, __alloc_traits<>::value_type
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"  // for Menu, Renderer, Horizontal, Vertical
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for Element, operator|, window, flex, vbox
-#include "ftxui/screen/string.hpp"  // for to_wstring
+#include "ftxui/dom/elements.hpp"  // for text, Element, operator|, window, flex, vbox
 
 using namespace ftxui;
 
-Component Window(std::wstring title, Component component) {
+Component Window(std::string title, Component component) {
   return Renderer(component, [component, title] {  //
     return window(text(title), component->Render()) | flex;
   });
@@ -21,46 +19,46 @@ Component Window(std::wstring title, Component component) {
 
 int main(int argc, const char* argv[]) {
   int menu_selected[] = {0, 0, 0};
-  std::vector<std::vector<std::wstring>> menu_entries = {
+  std::vector<std::vector<std::string>> menu_entries = {
       {
-          L"Ananas",
-          L"Raspberry",
-          L"Citrus",
+          "Ananas",
+          "Raspberry",
+          "Citrus",
       },
       {
-          L"Potatoes",
-          L"Weat",
-          L"Rise",
+          "Potatoes",
+          "Weat",
+          "Rise",
       },
       {
-          L"Carrot",
-          L"Lettuce",
-          L"Tomato",
+          "Carrot",
+          "Lettuce",
+          "Tomato",
       },
   };
 
   int menu_selected_global = 0;
   auto menu_global = Container::Vertical(
       {
-          Window(L"Menu 1", Menu(&menu_entries[0], &menu_selected[0])),
-          Window(L"Menu 2", Menu(&menu_entries[1], &menu_selected[1])),
-          Window(L"Menu 3", Menu(&menu_entries[2], &menu_selected[2])),
+          Window("Menu 1", Menu(&menu_entries[0], &menu_selected[0])),
+          Window("Menu 2", Menu(&menu_entries[1], &menu_selected[1])),
+          Window("Menu 3", Menu(&menu_entries[2], &menu_selected[2])),
       },
       &menu_selected_global);
 
   auto info = Renderer([&] {
     int g = menu_selected_global;
-    std::wstring value = menu_entries[g][menu_selected[g]];
-    return window(text(L"Content"),  //
+    std::string value = menu_entries[g][menu_selected[g]];
+    return window(text("Content"),  //
                   vbox({
-                      text(L"menu_selected_global = " + to_wstring(g)),
-                      text(L"menu_selected[0]     = " +
-                           to_wstring(menu_selected[0])),
-                      text(L"menu_selected[1]     = " +
-                           to_wstring(menu_selected[1])),
-                      text(L"menu_selected[2]     = " +
-                           to_wstring(menu_selected[2])),
-                      text(L"Value                = " + value),
+                      text("menu_selected_global = " + std::to_string(g)),
+                      text("menu_selected[0]     = " +
+                           std::to_string(menu_selected[0])),
+                      text("menu_selected[1]     = " +
+                           std::to_string(menu_selected[1])),
+                      text("menu_selected[2]     = " +
+                           std::to_string(menu_selected[2])),
+                      text("Value                = " + value),
                   })) |
            flex;
   });

--- a/examples/component/menu_style.cpp
+++ b/examples/component/menu_style.cpp
@@ -1,6 +1,6 @@
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, __shared_ptr_access, allocator
-#include <string>      // for wstring, basic_string
+#include <string>      // for string, basic_string
 #include <vector>      // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
@@ -15,8 +15,8 @@ int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto screen = ScreenInteractive::TerminalOutput();
 
-  std::vector<std::wstring> entries = {
-      L"Monkey", L"Dog", L"Cat", L"Bird", L"Elephant",
+  std::vector<std::string> entries = {
+      "Monkey", "Dog", "Cat", "Bird", "Elephant",
   };
   int menu_1_selected_ = 0;
   int menu_2_selected_ = 0;

--- a/examples/component/modal_dialog.cpp
+++ b/examples/component/modal_dialog.cpp
@@ -1,13 +1,12 @@
 #include <memory>  // for allocator, shared_ptr, __shared_ptr_access
-#include <string>  // for wstring, basic_string, char_traits, operator+
+#include <string>  // for string, basic_string, char_traits, operator+
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"  // for Button, Renderer, Horizontal, Tab
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for operator|, Element, filler, hbox, separator, center, vbox, bold, border, clear_under, dbox, size, GREATER_THAN, HEIGHT
+#include "ftxui/dom/elements.hpp"  // for operator|, Element, filler, text, hbox, separator, center, vbox, bold, border, clear_under, dbox, size, GREATER_THAN, HEIGHT
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
@@ -17,7 +16,7 @@ int main(int argc, const char* argv[]) {
   int depth = 0;
 
   // The current rating of FTXUI.
-  std::wstring rating = L"3/5 stars";
+  std::string rating = "3/5 stars";
 
   // At depth=0, two buttons. One for rating FTXUI and one for quitting.
   auto button_rate_ftxui = Button("Rate FTXUI", [&] { depth = 1; });
@@ -29,9 +28,9 @@ int main(int argc, const char* argv[]) {
   });
   auto depth_0_renderer = Renderer(depth_0_container, [&] {
     return vbox({
-               text(L"Modal dialog example"),
+               text("Modal dialog example"),
                separator(),
-               text(L"☆☆☆ FTXUI:" + rating + L" ☆☆☆") | bold,
+               text("☆☆☆ FTXUI:" + rating + " ☆☆☆") | bold,
                filler(),
                hbox({
                    button_rate_ftxui->Render(),
@@ -43,10 +42,10 @@ int main(int argc, const char* argv[]) {
   });
 
   // At depth=1, The "modal" window.
-  std::vector<std::wstring> rating_labels = {
-      L"1/5 stars", L"2/5 stars", L"3/5 stars", L"4/5 stars", L"5/5 stars",
+  std::vector<std::string> rating_labels = {
+      "1/5 stars", "2/5 stars", "3/5 stars", "4/5 stars", "5/5 stars",
   };
-  auto on_rating = [&](std::wstring new_rating) {
+  auto on_rating = [&](std::string new_rating) {
     rating = new_rating;
     depth = 0;
   };
@@ -60,7 +59,7 @@ int main(int argc, const char* argv[]) {
 
   auto depth_1_renderer = Renderer(depth_1_container, [&] {
     return vbox({
-               text(L"Do you like FTXUI?"),
+               text("Do you like FTXUI?"),
                separator(),
                hbox(depth_1_container->Render()),
            }) |

--- a/examples/component/radiobox.cpp
+++ b/examples/component/radiobox.cpp
@@ -1,4 +1,4 @@
-#include <string>  // for wstring, allocator, basic_string
+#include <string>  // for string, allocator, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"      // for ftxui
@@ -8,11 +8,11 @@
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
-  std::vector<std::wstring> radiobox_list = {
-      L"Use gcc",
-      L"Use clang",
-      L"Use emscripten",
-      L"Use tcc",
+  std::vector<std::string> radiobox_list = {
+      "Use gcc",
+      "Use clang",
+      "Use emscripten",
+      "Use tcc",
   };
   int selected = 0;
 

--- a/examples/component/radiobox_in_frame.cpp
+++ b/examples/component/radiobox_in_frame.cpp
@@ -1,22 +1,21 @@
-#include <memory>  // for __shared_ptr_access, shared_ptr
-#include <string>  // for wstring, operator+
+#include <memory>  // for shared_ptr, __shared_ptr_access
+#include <string>  // for string, basic_string, operator+, to_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"      // for ftxui
 #include "ftxui/component/component.hpp"           // for Radiobox, Renderer
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/elements.hpp"  // for Element, operator|, size, border, frame, HEIGHT, LESS_THAN
-#include "ftxui/screen/string.hpp"  // for to_wstring
+#include "ftxui/dom/elements.hpp"  // for operator|, Element, size, border, frame, HEIGHT, LESS_THAN
 
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
-  std::vector<std::wstring> entries;
+  std::vector<std::string> entries;
   int selected = 0;
 
   for (int i = 0; i < 30; ++i)
-    entries.push_back(L"RadioBox " + to_wstring(i));
+    entries.push_back("RadioBox " + std::to_string(i));
   auto radiobox = Radiobox(&entries, &selected);
   auto renderer = Renderer(radiobox, [&] {
     return radiobox->Render() | frame | size(HEIGHT, LESS_THAN, 10) | border;

--- a/examples/component/renderer.cpp
+++ b/examples/component/renderer.cpp
@@ -4,8 +4,7 @@
 #include "ftxui/component/component.hpp"       // for Renderer, Button, Vertical
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for operator|, Element, bold, border, center, color
+#include "ftxui/dom/elements.hpp"  // for operator|, Element, text, bold, border, center, color
 #include "ftxui/screen/color.hpp"  // for Color, Color::Red
 
 int main(int argc, const char* argv[]) {
@@ -18,18 +17,18 @@ int main(int argc, const char* argv[]) {
   // 1. Example of focusable renderer:
   auto renderer_focusable = Renderer([](bool focused) {
     if (focused)
-      return text(L"FOCUSABLE RENDERER()") | center | bold | border;
+      return text("FOCUSABLE RENDERER()") | center | bold | border;
     else
-      return text(L" Focusable renderer() ") | center | border;
+      return text(" Focusable renderer() ") | center | border;
   });
 
   // 2. Examples of a non focusable renderer.
   auto renderer_non_focusable = Renderer([&] {
-    return text(L"~~~~~ Non Focusable renderer() ~~~~~");  //
+    return text("~~~~~ Non Focusable renderer() ~~~~~");  //
   });
 
   // 3. Renderer can wrap other components to redefine their Render() function.
-  auto button = Button(L"Wrapped quit button", screen.ExitLoopClosure());
+  auto button = Button("Wrapped quit button", screen.ExitLoopClosure());
   auto renderer_wrap = Renderer(button, [&] {
     if (button->Focused())
       return button->Render() | bold | color(Color::Red);

--- a/examples/component/resizable_split.cpp
+++ b/examples/component/resizable_split.cpp
@@ -4,19 +4,18 @@
 #include "ftxui/component/component.hpp"  // for Renderer, ResizableSplitBottom, ResizableSplitLeft, ResizableSplitRight, ResizableSplitTop
 #include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for Element, operator|, center, border
+#include "ftxui/dom/elements.hpp"  // for Element, operator|, text, center, border
 
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
   auto screen = ScreenInteractive::Fullscreen();
 
-  auto middle = Renderer([] { return text(L"middle") | center; });
-  auto left = Renderer([] { return text(L"Left") | center; });
-  auto right = Renderer([] { return text(L"right") | center; });
-  auto top = Renderer([] { return text(L"top") | center; });
-  auto bottom = Renderer([] { return text(L"bottom") | center; });
+  auto middle = Renderer([] { return text("middle") | center; });
+  auto left = Renderer([] { return text("Left") | center; });
+  auto right = Renderer([] { return text("right") | center; });
+  auto top = Renderer([] { return text("top") | center; });
+  auto bottom = Renderer([] { return text("bottom") | center; });
 
   int left_size = 20;
   int right_size = 20;

--- a/examples/component/slider.cpp
+++ b/examples/component/slider.cpp
@@ -7,7 +7,7 @@ using namespace ftxui;
 int main(int argc, const char* argv[]) {
   auto screen = ScreenInteractive::TerminalOutput();
   int value = 50;
-  auto slider = Slider(L"Value:", &value, 0, 100, 1);
+  auto slider = Slider("Value:", &value, 0, 100, 1);
   screen.Loop(slider);
 }
 

--- a/examples/component/slider_rgb.cpp
+++ b/examples/component/slider_rgb.cpp
@@ -1,26 +1,25 @@
 #include <memory>  // for allocator, shared_ptr, __shared_ptr_access
-#include <string>  // for char_traits, operator+, to_wstring
+#include <string>  // for char_traits, operator+, to_string
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"       // for Slider, Renderer, Vertical
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"  // for separator, operator|, Element, size, vbox, xflex, bgcolor, hbox, GREATER_THAN, WIDTH, border, HEIGHT, LESS_THAN
+#include "ftxui/dom/elements.hpp"  // for separator, operator|, Element, size, text, vbox, xflex, bgcolor, hbox, GREATER_THAN, WIDTH, border, HEIGHT, LESS_THAN
 #include "ftxui/screen/color.hpp"  // for Color
 
 using namespace ftxui;
 
 Element ColorTile(int red, int green, int blue) {
-  return text(L"") | size(WIDTH, GREATER_THAN, 14) |
+  return text("") | size(WIDTH, GREATER_THAN, 14) |
          size(HEIGHT, GREATER_THAN, 7) | bgcolor(Color::RGB(red, green, blue));
 }
 
 Element ColorString(int red, int green, int blue) {
-  return text(L"RGB = (" +                     //
-              std::to_wstring(red) + L"," +    //
-              std::to_wstring(green) + L"," +  //
-              std::to_wstring(blue) + L")"     //
+  return text("RGB = (" +                    //
+              std::to_string(red) + "," +    //
+              std::to_string(green) + "," +  //
+              std::to_string(blue) + ")"     //
   );
 }
 
@@ -28,9 +27,9 @@ int main(int argc, const char* argv[]) {
   int red = 128;
   int green = 25;
   int blue = 100;
-  auto slider_red = Slider(L"Red  :", &red, 0, 255, 1);
-  auto slider_green = Slider(L"Green:", &green, 0, 255, 1);
-  auto slider_blue = Slider(L"Blue :", &blue, 0, 255, 1);
+  auto slider_red = Slider("Red  :", &red, 0, 255, 1);
+  auto slider_green = Slider("Green:", &green, 0, 255, 1);
+  auto slider_blue = Slider("Blue :", &blue, 0, 255, 1);
 
   auto container = Container::Vertical({
       slider_red,

--- a/examples/component/tab_horizontal.cpp
+++ b/examples/component/tab_horizontal.cpp
@@ -1,5 +1,5 @@
 #include <memory>  // for allocator, __shared_ptr_access, shared_ptr
-#include <string>  // for wstring, basic_string
+#include <string>  // for string, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
@@ -11,33 +11,33 @@
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
-  std::vector<std::wstring> tab_values{
-      L"tab_1",
-      L"tab_2",
-      L"tab_3",
+  std::vector<std::string> tab_values{
+      "tab_1",
+      "tab_2",
+      "tab_3",
   };
   int tab_selected = 0;
   auto tab_toggle = Toggle(&tab_values, &tab_selected);
 
-  std::vector<std::wstring> tab_1_entries{
-      L"Forest",
-      L"Water",
-      L"I don't know",
+  std::vector<std::string> tab_1_entries{
+      "Forest",
+      "Water",
+      "I don't know",
   };
   int tab_1_selected = 0;
 
-  std::vector<std::wstring> tab_2_entries{
-      L"Hello",
-      L"Hi",
-      L"Hay",
+  std::vector<std::string> tab_2_entries{
+      "Hello",
+      "Hi",
+      "Hay",
   };
   int tab_2_selected = 0;
 
-  std::vector<std::wstring> tab_3_entries{
-      L"Table",
-      L"Nothing",
-      L"Is",
-      L"Empty",
+  std::vector<std::string> tab_3_entries{
+      "Table",
+      "Nothing",
+      "Is",
+      "Empty",
   };
   int tab_3_selected = 0;
   auto tab_container = Container::Tab(

--- a/examples/component/tab_vertical.cpp
+++ b/examples/component/tab_vertical.cpp
@@ -1,5 +1,5 @@
 #include <memory>  // for allocator, __shared_ptr_access, shared_ptr
-#include <string>  // for wstring, basic_string
+#include <string>  // for string, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
@@ -11,33 +11,33 @@
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
-  std::vector<std::wstring> tab_values{
-      L"tab_1",
-      L"tab_2",
-      L"tab_3",
+  std::vector<std::string> tab_values{
+      "tab_1",
+      "tab_2",
+      "tab_3",
   };
   int tab_selected = 0;
   auto tab_menu = Menu(&tab_values, &tab_selected);
 
-  std::vector<std::wstring> tab_1_entries{
-      L"Forest",
-      L"Water",
-      L"I don't know",
+  std::vector<std::string> tab_1_entries{
+      "Forest",
+      "Water",
+      "I don't know",
   };
   int tab_1_selected = 0;
 
-  std::vector<std::wstring> tab_2_entries{
-      L"Hello",
-      L"Hi",
-      L"Hay",
+  std::vector<std::string> tab_2_entries{
+      "Hello",
+      "Hi",
+      "Hay",
   };
   int tab_2_selected = 0;
 
-  std::vector<std::wstring> tab_3_entries{
-      L"Table",
-      L"Nothing",
-      L"Is",
-      L"Empty",
+  std::vector<std::string> tab_3_entries{
+      "Table",
+      "Nothing",
+      "Is",
+      "Empty",
   };
   int tab_3_selected = 0;
   auto tab_container = Container::Tab(

--- a/examples/component/toggle.cpp
+++ b/examples/component/toggle.cpp
@@ -1,33 +1,32 @@
 #include <memory>  // for allocator, __shared_ptr_access
-#include <string>  // for wstring, basic_string
+#include <string>  // for string, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
 #include "ftxui/component/component.hpp"       // for Toggle, Renderer, Vertical
 #include "ftxui/component/component_base.hpp"  // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for Component, ScreenInteractive
-#include "ftxui/dom/deprecated.hpp"                // for text
-#include "ftxui/dom/elements.hpp"                  // for hbox, vbox, Element
+#include "ftxui/dom/elements.hpp"  // for text, hbox, vbox, Element
 
 using namespace ftxui;
 
 int main(int argc, const char* argv[]) {
-  std::vector<std::wstring> toggle_1_entries = {
-      L"On",
-      L"Off",
+  std::vector<std::string> toggle_1_entries = {
+      "On",
+      "Off",
   };
-  std::vector<std::wstring> toggle_2_entries = {
-      L"Enabled",
-      L"Disabled",
+  std::vector<std::string> toggle_2_entries = {
+      "Enabled",
+      "Disabled",
   };
-  std::vector<std::wstring> toggle_3_entries = {
-      L"10€",
-      L"0€",
+  std::vector<std::string> toggle_3_entries = {
+      "10€",
+      "0€",
   };
-  std::vector<std::wstring> toggle_4_entries = {
-      L"Nothing",
-      L"One element",
-      L"Several elements",
+  std::vector<std::string> toggle_4_entries = {
+      "Nothing",
+      "One element",
+      "Several elements",
   };
 
   int toggle_1_selected = 0;
@@ -48,12 +47,12 @@ int main(int argc, const char* argv[]) {
 
   auto renderer = Renderer(container, [&] {
     return vbox({
-        text(L"Choose your options:"),
-        text(L""),
-        hbox(text(L" * Poweroff on startup      : "), toggle_1->Render()),
-        hbox(text(L" * Out of process           : "), toggle_2->Render()),
-        hbox(text(L" * Price of the information : "), toggle_3->Render()),
-        hbox(text(L" * Number of elements       : "), toggle_4->Render()),
+        text("Choose your options:"),
+        text(""),
+        hbox(text(" * Poweroff on startup      : "), toggle_1->Render()),
+        hbox(text(" * Out of process           : "), toggle_2->Render()),
+        hbox(text(" * Price of the information : "), toggle_3->Render()),
+        hbox(text(" * Number of elements       : "), toggle_4->Render()),
     });
   });
 

--- a/examples/dom/border.cpp
+++ b/examples/dom/border.cpp
@@ -1,31 +1,30 @@
-#include <ftxui/dom/elements.hpp>  // for operator|, vbox, border, Element, hbox
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, vbox, border, Element, Fit, hbox
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       hbox({
           vbox({
-              text(L"Line 1"),
-              text(L"Line 2"),
-              text(L"Line 3"),
+              text("Line 1"),
+              text("Line 2"),
+              text("Line 3"),
           }) | border,
 
           vbox({
-              text(L"Line 4"),
-              text(L"Line 5"),
-              text(L"Line 6"),
+              text("Line 4"),
+              text("Line 5"),
+              text("Line 6"),
           }) | border,
 
           vbox({
-              text(L"Line 7"),
-              text(L"Line 8"),
-              text(L"Line 9"),
+              text("Line 7"),
+              text("Line 8"),
+              text("Line 9"),
           }) | border,
       });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));

--- a/examples/dom/color_gallery.cpp
+++ b/examples/dom/color_gallery.cpp
@@ -1,14 +1,13 @@
 #include <ftxui/screen/color_info.hpp>  // for ColorInfo
-#include <ftxui/screen/screen.hpp>      // for Dimension, Screen
-#include <ftxui/screen/terminal.hpp>  // for Terminal, Terminal::Color, Terminal::Palette16, Terminal::Palette256, Terminal::TrueColor
+#include <ftxui/screen/screen.hpp>      // for Full, Screen
+#include <ftxui/screen/terminal.hpp>  // for ColorSupport, Color, Palette16, Palette256, TrueColor
 #include <memory>                     // for allocator, shared_ptr
 #include <utility>                    // for move
 #include <vector>                     // for vector
 
 using namespace ftxui;
 #include "./color_info_sorted_2d.ipp"  // for ColorInfoSorted2D
-#include "ftxui/dom/deprecated.hpp"    // for text
-#include "ftxui/dom/elements.hpp"  // for bgcolor, color, vbox, hbox, separator, operator|, Elements, Element, border
+#include "ftxui/dom/elements.hpp"  // for text, bgcolor, color, vbox, hbox, separator, operator|, Elements, Element, Fit, border
 #include "ftxui/dom/node.hpp"      // for Render
 #include "ftxui/screen/color.hpp"  // for Color, Color::Black, Color::Blue, Color::BlueLight, Color::Cyan, Color::CyanLight, Color::Default, Color::GrayDark, Color::GrayLight, Color::Green, Color::GreenLight, Color::Magenta, Color::MagentaLight, Color::Red, Color::RedLight, Color::White, Color::Yellow, Color::YellowLight, Color::Palette256, ftxui
 
@@ -16,52 +15,52 @@ int main(int argc, const char* argv[]) {
   // clang-format off
   auto basic_color_display =
     vbox(
-      text(L"16 color palette:"),
+      text("16 color palette:"),
       separator(),
       hbox(
         vbox(
-          color(Color::Default, text(L"Default")),
-          color(Color::Black, text(L"Black")),
-          color(Color::GrayDark, text(L"GrayDark")),
-          color(Color::GrayLight, text(L"GrayLight")),
-          color(Color::White, text(L"White")),
-          color(Color::Blue, text(L"Blue")),
-          color(Color::BlueLight, text(L"BlueLight")),
-          color(Color::Cyan, text(L"Cyan")),
-          color(Color::CyanLight, text(L"CyanLight")),
-          color(Color::Green, text(L"Green")),
-          color(Color::GreenLight, text(L"GreenLight")),
-          color(Color::Magenta, text(L"Magenta")),
-          color(Color::MagentaLight, text(L"MagentaLight")),
-          color(Color::Red, text(L"Red")),
-          color(Color::RedLight, text(L"RedLight")),
-          color(Color::Yellow, text(L"Yellow")),
-          color(Color::YellowLight, text(L"YellowLight"))
+          color(Color::Default, text("Default")),
+          color(Color::Black, text("Black")),
+          color(Color::GrayDark, text("GrayDark")),
+          color(Color::GrayLight, text("GrayLight")),
+          color(Color::White, text("White")),
+          color(Color::Blue, text("Blue")),
+          color(Color::BlueLight, text("BlueLight")),
+          color(Color::Cyan, text("Cyan")),
+          color(Color::CyanLight, text("CyanLight")),
+          color(Color::Green, text("Green")),
+          color(Color::GreenLight, text("GreenLight")),
+          color(Color::Magenta, text("Magenta")),
+          color(Color::MagentaLight, text("MagentaLight")),
+          color(Color::Red, text("Red")),
+          color(Color::RedLight, text("RedLight")),
+          color(Color::Yellow, text("Yellow")),
+          color(Color::YellowLight, text("YellowLight"))
         ),
         vbox(
-          bgcolor(Color::Default, text(L"Default")),
-          bgcolor(Color::Black, text(L"Black")),
-          bgcolor(Color::GrayDark, text(L"GrayDark")),
-          bgcolor(Color::GrayLight, text(L"GrayLight")),
-          bgcolor(Color::White, text(L"White")),
-          bgcolor(Color::Blue, text(L"Blue")),
-          bgcolor(Color::BlueLight, text(L"BlueLight")),
-          bgcolor(Color::Cyan, text(L"Cyan")),
-          bgcolor(Color::CyanLight, text(L"CyanLight")),
-          bgcolor(Color::Green, text(L"Green")),
-          bgcolor(Color::GreenLight, text(L"GreenLight")),
-          bgcolor(Color::Magenta, text(L"Magenta")),
-          bgcolor(Color::MagentaLight, text(L"MagentaLight")),
-          bgcolor(Color::Red, text(L"Red")),
-          bgcolor(Color::RedLight, text(L"RedLight")),
-          bgcolor(Color::Yellow, text(L"Yellow")),
-          bgcolor(Color::YellowLight, text(L"YellowLight"))
+          bgcolor(Color::Default, text("Default")),
+          bgcolor(Color::Black, text("Black")),
+          bgcolor(Color::GrayDark, text("GrayDark")),
+          bgcolor(Color::GrayLight, text("GrayLight")),
+          bgcolor(Color::White, text("White")),
+          bgcolor(Color::Blue, text("Blue")),
+          bgcolor(Color::BlueLight, text("BlueLight")),
+          bgcolor(Color::Cyan, text("Cyan")),
+          bgcolor(Color::CyanLight, text("CyanLight")),
+          bgcolor(Color::Green, text("Green")),
+          bgcolor(Color::GreenLight, text("GreenLight")),
+          bgcolor(Color::Magenta, text("Magenta")),
+          bgcolor(Color::MagentaLight, text("MagentaLight")),
+          bgcolor(Color::Red, text("Red")),
+          bgcolor(Color::RedLight, text("RedLight")),
+          bgcolor(Color::Yellow, text("Yellow")),
+          bgcolor(Color::YellowLight, text("YellowLight"))
         )
       )
     );
 
   // clang-format on
-  auto palette_256_color_display = text(L"256 colors palette:");
+  auto palette_256_color_display = text("256 colors palette:");
   {
     std::vector<std::vector<ColorInfo>> info_columns = ColorInfoSorted2D();
     Elements columns;
@@ -69,7 +68,7 @@ int main(int argc, const char* argv[]) {
       Elements column_elements;
       for (auto& it : column) {
         column_elements.push_back(
-            text(L"   ") | bgcolor(Color(Color::Palette256(it.index_256))));
+            text("   ") | bgcolor(Color(Color::Palette256(it.index_256))));
       }
       columns.push_back(hbox(std::move(column_elements)));
     }
@@ -81,14 +80,14 @@ int main(int argc, const char* argv[]) {
   }
 
   // True color display.
-  auto true_color_display = text(L"TrueColors: 24bits:");
+  auto true_color_display = text("TrueColors: 24bits:");
   {
     int saturation = 255;
     Elements array;
     for (int value = 0; value < 255; value += 16) {
       Elements line;
       for (int hue = 0; hue < 255; hue += 6) {
-        line.push_back(text(L"▀")                                   //
+        line.push_back(text("▀")                                    //
                        | color(Color::HSV(hue, saturation, value))  //
                        | bgcolor(Color::HSV(hue, saturation, value + 8)));
       }
@@ -104,22 +103,22 @@ int main(int argc, const char* argv[]) {
   auto terminal_info =
       vbox({
           Terminal::ColorSupport() >= Terminal::Color::Palette16
-              ? text(L" 16 color palette support : Yes")
-              : text(L" 16 color palette support : No"),
+              ? text(" 16 color palette support : Yes")
+              : text(" 16 color palette support : No"),
           Terminal::ColorSupport() >= Terminal::Color::Palette256
-              ? text(L"256 color palette support : Yes")
-              : text(L"256 color palette support : No"),
+              ? text("256 color palette support : Yes")
+              : text("256 color palette support : No"),
           Terminal::ColorSupport() >= Terminal::Color::TrueColor
-              ? text(L"       True color support : Yes")
-              : text(L"       True color support : No"),
+              ? text("       True color support : Yes")
+              : text("       True color support : No"),
       }) |
       border;
 
   auto document = vbox({hbox({
                             basic_color_display,
-                            text(L" "),
+                            text(" "),
                             palette_256_color_display,
-                            text(L" "),
+                            text(" "),
                             true_color_display,
                         }),
                         terminal_info});

--- a/examples/dom/color_info_palette256.cpp
+++ b/examples/dom/color_info_palette256.cpp
@@ -1,15 +1,12 @@
-#include <ftxui/dom/elements.hpp>  // for bgcolor, hbox, operator|, Elements, vbox, Element
+#include <ftxui/dom/elements.hpp>  // for text, bgcolor, hbox, operator|, Elements, Fit, vbox, Element
 #include <ftxui/screen/color_info.hpp>  // for ColorInfo
-#include <ftxui/screen/screen.hpp>      // for Dimension, Screen
-#include <string>                       // for allocator, string
+#include <ftxui/screen/screen.hpp>      // for Full, Screen
 #include <utility>                      // for move
-#include <vector>                       // for vector
+#include <vector>                       // for vector, allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
-#include "ftxui/screen/color.hpp"    // for Color, Color::Palette256
-#include "ftxui/screen/string.hpp"   // for to_wstring
+#include "ftxui/dom/node.hpp"      // for Render
+#include "ftxui/screen/box.hpp"    // for ftxui
+#include "ftxui/screen/color.hpp"  // for Color, Color::Palette256
 
 using namespace ftxui;
 #include "./color_info_sorted_2d.ipp"  // for ColorInfoSorted2D
@@ -23,8 +20,8 @@ int main(int argc, const char* argv[]) {
     Elements column_elements;
     for (auto& it : column) {
       column_elements.push_back(hbox({
-          text(L"     ") | bgcolor(Color(Color::Palette256(it.index_256))),
-          text(to_wstring(std::string(it.name))),
+          text("     ") | bgcolor(Color(Color::Palette256(it.index_256))),
+          text(it.name),
       }));
     }
     columns_elements.push_back(vbox(std::move(column_elements)));

--- a/examples/dom/color_truecolor_HSV.cpp
+++ b/examples/dom/color_truecolor_HSV.cpp
@@ -1,12 +1,11 @@
-#include <ftxui/dom/elements.hpp>  // for operator|, Elements, bgcolor, color, hbox, vbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for operator|, Elements, Fit, bgcolor, color, hbox, text, vbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 #include <utility>                  // for move
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
-#include "ftxui/screen/color.hpp"    // for Color
+#include "ftxui/dom/node.hpp"      // for Render
+#include "ftxui/screen/box.hpp"    // for ftxui
+#include "ftxui/screen/color.hpp"  // for Color
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
@@ -16,7 +15,7 @@ int main(int argc, const char* argv[]) {
   for (int value = 0; value < 255; value += 20) {
     Elements line;
     for (int hue = 0; hue < 255; hue += 2) {
-      line.push_back(text(L"▀")                                   //
+      line.push_back(text("▀")                                    //
                      | color(Color::HSV(hue, saturation, value))  //
                      | bgcolor(Color::HSV(hue, saturation, value + 10)));
     }

--- a/examples/dom/color_truecolor_RGB.cpp
+++ b/examples/dom/color_truecolor_RGB.cpp
@@ -1,12 +1,11 @@
-#include <ftxui/dom/elements.hpp>  // for hbox, bgcolor, operator|, vbox, Elements, window, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for hbox, text, bgcolor, operator|, vbox, Elements, window, Element, Fit
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 #include <utility>                  // for move
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
-#include "ftxui/screen/color.hpp"    // for Color
+#include "ftxui/dom/node.hpp"      // for Render
+#include "ftxui/screen/box.hpp"    // for ftxui
+#include "ftxui/screen/color.hpp"  // for Color
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
@@ -21,26 +20,26 @@ int main(int argc, const char* argv[]) {
 
   for (int value = 0; value < 255; value += 3) {
     int v = value * value / 255;
-    red_line.push_back(text(L" ") | bgcolor(Color::RGB(v, 0, 0)));
-    green_line.push_back(text(L" ") | bgcolor(Color::RGB(0, v, 0)));
-    blue_line.push_back(text(L" ") | bgcolor(Color::RGB(0, 0, v)));
-    cyan_line.push_back(text(L" ") | bgcolor(Color::RGB(0, v, v)));
-    magenta_line.push_back(text(L" ") | bgcolor(Color::RGB(v, 0, v)));
-    yellow_line.push_back(text(L" ") | bgcolor(Color::RGB(v, v, 0)));
+    red_line.push_back(text(" ") | bgcolor(Color::RGB(v, 0, 0)));
+    green_line.push_back(text(" ") | bgcolor(Color::RGB(0, v, 0)));
+    blue_line.push_back(text(" ") | bgcolor(Color::RGB(0, 0, v)));
+    cyan_line.push_back(text(" ") | bgcolor(Color::RGB(0, v, v)));
+    magenta_line.push_back(text(" ") | bgcolor(Color::RGB(v, 0, v)));
+    yellow_line.push_back(text(" ") | bgcolor(Color::RGB(v, v, 0)));
   }
 
   auto document = vbox({
-      window(text(L"Primary colors"),
+      window(text("Primary colors"),
              vbox({
-                 hbox({text(L"Red line    :"), hbox(std::move(red_line))}),
-                 hbox({text(L"Green line  :"), hbox(std::move(green_line))}),
-                 hbox({text(L"Blue line   :"), hbox(std::move(blue_line))}),
+                 hbox({text("Red line    :"), hbox(std::move(red_line))}),
+                 hbox({text("Green line  :"), hbox(std::move(green_line))}),
+                 hbox({text("Blue line   :"), hbox(std::move(blue_line))}),
              })),
-      window(text(L"Secondary colors"),
+      window(text("Secondary colors"),
              vbox({
-                 hbox({text(L"cyan line   :"), hbox(std::move(cyan_line))}),
-                 hbox({text(L"magenta line:"), hbox(std::move(magenta_line))}),
-                 hbox({text(L"Yellow line :"), hbox(std::move(yellow_line))}),
+                 hbox({text("cyan line   :"), hbox(std::move(cyan_line))}),
+                 hbox({text("magenta line:"), hbox(std::move(magenta_line))}),
+                 hbox({text("Yellow line :"), hbox(std::move(yellow_line))}),
              })),
   });
 

--- a/examples/dom/dbox.cpp
+++ b/examples/dom/dbox.cpp
@@ -1,22 +1,21 @@
-#include <ftxui/dom/elements.hpp>  // for operator|, border, Element, vbox, center, dbox
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, border, Element, vbox, center, Fit, dbox
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document = dbox({
       vbox({
-          text(L"line_1"),
-          text(L"line_2"),
-          text(L"line_3"),
-          text(L"line_4"),
-          text(L"line_5"),
+          text("line_1"),
+          text("line_2"),
+          text("line_3"),
+          text("line_4"),
+          text("line_5"),
       }) | border,
-      text(L"overlay") | border | center,
+      text("overlay") | border | center,
   });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/gauge.cpp
+++ b/examples/dom/gauge.cpp
@@ -1,13 +1,12 @@
-#include <chrono>                   // for operator""s, chrono_literals
-#include <ftxui/dom/elements.hpp>   // for gauge, operator|, flex, hbox, Element
+#include <chrono>                  // for operator""s, chrono_literals
+#include <ftxui/dom/elements.hpp>  // for text, gauge, operator|, flex, hbox, Element
 #include <ftxui/screen/screen.hpp>  // for Screen
 #include <iostream>                 // for cout, endl, ostream
-#include <string>  // for allocator, operator+, char_traits, operator<<, to_wstring, basic_string, string, wstring
+#include <string>  // for allocator, operator+, char_traits, operator<<, string, to_string, basic_string
 #include <thread>  // for sleep_for
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
@@ -15,12 +14,12 @@ int main(int argc, const char* argv[]) {
 
   std::string reset_position;
   for (float percentage = 0.0f; percentage <= 1.0f; percentage += 0.002f) {
-    std::wstring data_downloaded =
-        std::to_wstring(int(percentage * 5000)) + L"/5000";
+    std::string data_downloaded =
+        std::to_string(int(percentage * 5000)) + "/5000";
     auto document = hbox({
-        text(L"downloading:"),
+        text("downloading:"),
         gauge(percentage) | flex,
-        text(L" " + data_downloaded),
+        text(" " + data_downloaded),
     });
     auto screen = Screen(100, 1);
     Render(screen, document);

--- a/examples/dom/hflow.cpp
+++ b/examples/dom/hflow.cpp
@@ -1,20 +1,18 @@
 #include <stddef.h>                // for size_t
-#include <ftxui/dom/elements.hpp>  // for operator|, size, Element, hcenter, Decorator, WIDTH, hflow, window, EQUAL, GREATER_THAN, HEIGHT, bold, border, dim, LESS_THAN
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
-#include <ftxui/screen/string.hpp>  // for to_wstring
+#include <ftxui/dom/elements.hpp>  // for operator|, size, Element, text, hcenter, Decorator, Fit, WIDTH, hflow, window, EQUAL, GREATER_THAN, HEIGHT, bold, border, dim, LESS_THAN
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator, shared_ptr
-#include <string>                   // for operator+, char_traits, wstring
+#include <string>  // for operator+, to_string, char_traits, string
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto make_box = [](size_t dimx, size_t dimy) {
-    std::wstring title = to_wstring(dimx) + L"x" + to_wstring(dimy);
+    std::string title = std::to_string(dimx) + "x" + std::to_string(dimy);
     return window(text(title) | hcenter | bold,
-                  text(L"content") | hcenter | dim) |
+                  text("content") | hcenter | dim) |
            size(WIDTH, EQUAL, dimx) | size(HEIGHT, EQUAL, dimy);
   };
 

--- a/examples/dom/html_like.cpp
+++ b/examples/dom/html_like.cpp
@@ -1,12 +1,11 @@
 #include <chrono>                   // for operator""s, chrono_literals
-#include <ftxui/screen/screen.hpp>  // for Screen, Dimension
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <iostream>                 // for cout, ostream
 #include <memory>                   // for allocator, shared_ptr
 #include <string>                   // for operator<<, string
 #include <thread>                   // for sleep_for
 
-#include "ftxui/dom/deprecated.hpp"  // for paragraph, text
-#include "ftxui/dom/elements.hpp"  // for operator|, Element, border, color, hflow, spinner, vbox, bold, dim, underlined
+#include "ftxui/dom/elements.hpp"  // for paragraph, text, operator|, Element, border, color, hflow, spinner, vbox, bold, dim, underlined
 #include "ftxui/dom/node.hpp"      // for Render
 #include "ftxui/screen/box.hpp"    // for ftxui
 #include "ftxui/screen/color.hpp"  // for Color, Color::Red
@@ -15,34 +14,34 @@ int main(int argc, const char* argv[]) {
   using namespace ftxui;
   using namespace std::chrono_literals;
 
-  auto img1 = []() { return text(L"img") | border; };
-  auto img2 = []() { return vbox({text(L"big"), text(L"image")}) | border; };
+  auto img1 = []() { return text("img") | border; };
+  auto img2 = []() { return vbox({text("big"), text("image")}) | border; };
 
   std::string reset_position;
   for (int i = 0;; ++i) {
     auto document =  //
         hflow(
-            paragraph(L"Hello world! Here is an image:"), img1(),
-            paragraph(L" Here is a text "), text(L"underlined ") | underlined,
-            paragraph(L" Here is a text "), text(L"bold ") | bold,
-            paragraph(L"Hello world! Here is an image:"), img2(),
+            paragraph("Hello world! Here is an image:"), img1(),
+            paragraph(" Here is a text "), text("underlined ") | underlined,
+            paragraph(" Here is a text "), text("bold ") | bold,
+            paragraph("Hello world! Here is an image:"), img2(),
             paragraph(
-                L"Le Lorem Ipsum est simplement du faux texte employé dans la "
-                L"composition et la mise en page avant impression. Le Lorem "
-                L"Ipsum est le faux texte standard de l'imprimerie depuis les "
-                L"années 1500, quand un imprimeur anonyme assembla ensemble "
-                L"des morceaux de texte pour réaliser un livre spécimen de "
-                L"polices de texte. Il n'a pas fait que survivre cinq siècles, "
-                L"mais s'est aussi adapté à la bureautique informatique, sans "
-                L"que son contenu n'en soit modifié. Il a été popularisé dans "
-                L"les années 1960 grâce à la vente de feuilles Letraset "
-                L"contenant des passages du Lorem Ipsum, et, plus récemment, "
-                L"par son inclusion dans des applications de mise en page de "
-                L"texte, comme Aldus PageMaker."),
-            paragraph(L" Here is a text "), text(L"dim ") | dim,
-            paragraph(L"Hello world! Here is an image:"), img1(),
-            paragraph(L" Here is a text "), text(L"red ") | color(Color::Red),
-            paragraph(L" A spinner "), spinner(6, i / 10)) |
+                "Le Lorem Ipsum est simplement du faux texte employé dans la "
+                "composition et la mise en page avant impression. Le Lorem "
+                "Ipsum est le faux texte standard de l'imprimerie depuis les "
+                "années 1500, quand un imprimeur anonyme assembla ensemble "
+                "des morceaux de texte pour réaliser un livre spécimen de "
+                "polices de texte. Il n'a pas fait que survivre cinq siècles, "
+                "mais s'est aussi adapté à la bureautique informatique, sans "
+                "que son contenu n'en soit modifié. Il a été popularisé dans "
+                "les années 1960 grâce à la vente de feuilles Letraset "
+                "contenant des passages du Lorem Ipsum, et, plus récemment, "
+                "par son inclusion dans des applications de mise en page de "
+                "texte, comme Aldus PageMaker."),
+            paragraph(" Here is a text "), text("dim ") | dim,
+            paragraph("Hello world! Here is an image:"), img1(),
+            paragraph(" Here is a text "), text("red ") | color(Color::Red),
+            paragraph(" A spinner "), spinner(6, i / 10)) |
         border;
 
     auto screen = Screen::Create(Dimension::Full());

--- a/examples/dom/package_manager.cpp
+++ b/examples/dom/package_manager.cpp
@@ -1,43 +1,41 @@
 #include <chrono>                  // for operator""s, chrono_literals
-#include <ftxui/dom/elements.hpp>  // for operator|, Element, hbox, bold, color, filler, separator, vbox, window, gauge, size, dim, EQUAL, WIDTH
-#include <ftxui/screen/screen.hpp>  // for Screen, Dimension
-#include <ftxui/screen/string.hpp>  // for to_wstring
+#include <ftxui/dom/elements.hpp>  // for operator|, text, Element, hbox, bold, color, filler, separator, vbox, window, gauge, Fit, size, dim, EQUAL, WIDTH
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <iostream>                 // for cout, endl, ostream
 #include <list>  // for list, operator!=, _List_iterator, _List_iterator<>::_Self
 #include <memory>   // for allocator, shared_ptr, allocator_traits<>::value_type
-#include <string>   // for wstring, operator<<, string
+#include <string>   // for string, operator<<, to_string
 #include <thread>   // for sleep_for
 #include <utility>  // for move
 #include <vector>   // for vector
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 #include "ftxui/screen/color.hpp"  // for Color, Color::Green, Color::Red, Color::RedLight
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
 
   struct Task {
-    std::wstring name;
+    std::string name;
     int number_of_threads;
     int downloaded;
     int size;
   };
 
   std::list<Task> remaining_tasks = {
-      {L"contact server       ", 10, 0, 6 * 25},
-      {L"download index.html  ", 10, 0, 9 * 25},
-      {L"download script.js   ", 1, 0, 3 * 25},
-      {L"download style.js    ", 1, 0, 4 * 25},
-      {L"download image.png   ", 1, 0, 5 * 25},
-      {L"download big_1.png   ", 1, 0, 30 * 25},
-      {L"download icon_1.png  ", 1, 0, 7 * 25},
-      {L"download icon_2.png  ", 1, 0, 8 * 25},
-      {L"download big_2.png   ", 1, 0, 30 * 25},
-      {L"download small_1.png ", 1, 0, 10 * 25},
-      {L"download small_2.png ", 1, 0, 11 * 25},
-      {L"download small_3.png ", 1, 0, 12 * 25},
+      {"contact server       ", 10, 0, 6 * 25},
+      {"download index.html  ", 10, 0, 9 * 25},
+      {"download script.js   ", 1, 0, 3 * 25},
+      {"download style.js    ", 1, 0, 4 * 25},
+      {"download image.png   ", 1, 0, 5 * 25},
+      {"download big_1.png   ", 1, 0, 30 * 25},
+      {"download icon_1.png  ", 1, 0, 7 * 25},
+      {"download icon_2.png  ", 1, 0, 8 * 25},
+      {"download big_2.png   ", 1, 0, 30 * 25},
+      {"download small_1.png ", 1, 0, 10 * 25},
+      {"download small_2.png ", 1, 0, 11 * 25},
+      {"download small_3.png ", 1, 0, 12 * 25},
   };
 
   std::list<Task> displayed_task;
@@ -49,7 +47,7 @@ int main(int argc, const char* argv[]) {
   int nb_done = 0;
 
   auto to_text = [](int number) {
-    return text(to_wstring(number)) | size(WIDTH, EQUAL, 3);
+    return text(std::to_string(number)) | size(WIDTH, EQUAL, 3);
   };
 
   auto renderTask = [&](const Task& task) {
@@ -58,7 +56,7 @@ int main(int argc, const char* argv[]) {
         text(task.name) | style,
         separator(),
         to_text(task.downloaded),
-        text(L"/"),
+        text("/"),
         to_text(task.size),
         separator(),
         gauge(task.downloaded / float(task.size)),
@@ -68,20 +66,20 @@ int main(int argc, const char* argv[]) {
   auto renderSummary = [&]() {
     auto summary = vbox({
         hbox({
-            text(L"- done:   "),
+            text("- done:   "),
             to_text(nb_done) | bold,
         }) | color(Color::Green),
         hbox({
-            text(L"- active: "),
+            text("- active: "),
             to_text(nb_active) | bold,
         }) | color(Color::RedLight),
         hbox({
-            text(L"- queue:  "),
+            text("- queue:  "),
             to_text(nb_queued) | bold,
         }) | color(Color::Red),
     });
 
-    return window(text(L" Summary "), summary);
+    return window(text(" Summary "), summary);
   };
 
   auto render = [&]() {
@@ -91,7 +89,7 @@ int main(int argc, const char* argv[]) {
 
     return vbox({
         // List of tasks.
-        window(text(L" Task "), vbox(std::move(entries))),
+        window(text(" Task "), vbox(std::move(entries))),
 
         // Summary.
         hbox({

--- a/examples/dom/paragraph.cpp
+++ b/examples/dom/paragraph.cpp
@@ -1,16 +1,15 @@
-#include <stdio.h>                 // for getchar
-#include <ftxui/dom/elements.hpp>  // for operator|, hflow, border, Element, hbox, flex, vbox
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
-#include <string>                   // for allocator, wstring
+#include <stdio.h>  // for getchar
+#include <ftxui/dom/elements.hpp>  // for operator|, hflow, paragraph, border, Element, hbox, flex, vbox
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
+#include <string>                   // for allocator, string
 
-#include "ftxui/dom/deprecated.hpp"  // for paragraph
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
-  std::wstring p =
-      LR"(In probability theory and statistics, Bayes' theorem (alternatively Bayes' law or Bayes' rule) describes the probability of an event, based on prior knowledge of conditions that might be related to the event. For example, if cancer is related to age, then, using Bayes' theorem, a person's age can be used to more accurately assess the probability that they have cancer, compared to the assessment of the probability of cancer made without knowledge of the person's age. One of the many applications of Bayes' theorem is Bayesian inference, a particular approach to statistical inference. When applied, the probabilities involved in Bayes' theorem may have different probability interpretations. With the Bayesian probability interpretation the theorem expresses how a subjective degree of belief should rationally change to account for availability of related evidence. Bayesian inference is fundamental to Bayesian statistics.)";
+  std::string p =
+      R"(In probability theory and statistics, Bayes' theorem (alternatively Bayes' law or Bayes' rule) describes the probability of an event, based on prior knowledge of conditions that might be related to the event. For example, if cancer is related to age, then, using Bayes' theorem, a person's age can be used to more accurately assess the probability that they have cancer, compared to the assessment of the probability of cancer made without knowledge of the person's age. One of the many applications of Bayes' theorem is Bayesian inference, a particular approach to statistical inference. When applied, the probabilities involved in Bayes' theorem may have different probability interpretations. With the Bayesian probability interpretation the theorem expresses how a subjective degree of belief should rationally change to account for availability of related evidence. Bayesian inference is fundamental to Bayesian statistics.)";
 
   auto document = vbox({
       hbox({

--- a/examples/dom/separator.cpp
+++ b/examples/dom/separator.cpp
@@ -1,23 +1,22 @@
-#include <ftxui/dom/elements.hpp>  // for center, separator, operator|, flex, Element, vbox, hbox, border
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, center, separator, operator|, flex, Element, vbox, Fit, hbox, border
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document = hbox({
-                      text(L"left-column"),
+                      text("left-column"),
                       separator(),
                       vbox({
-                          center(text(L"right-top")) | flex,
+                          center(text("right-top")) | flex,
                           separator(),
-                          center(text(L"bottom-bottom")),
+                          center(text("bottom-bottom")),
                       }) | flex,
                       separator(),
-                      text(L"right-column"),
+                      text("right-column"),
                   }) |
                   border;
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));

--- a/examples/dom/size.cpp
+++ b/examples/dom/size.cpp
@@ -1,24 +1,22 @@
-#include <ftxui/dom/elements.hpp>  // for operator|, Element, hcenter, hbox, size, window, Elements, bold, dim, EQUAL, WIDTH
-#include <ftxui/screen/screen.hpp>  // for Screen, Dimension
-#include <ftxui/screen/string.hpp>  // for to_wstring
+#include <ftxui/dom/elements.hpp>  // for operator|, text, Element, hcenter, Fit, hbox, size, window, Elements, bold, dim, EQUAL, WIDTH
+#include <ftxui/screen/screen.hpp>  // for Screen
 #include <memory>                   // for allocator, shared_ptr
-#include <string>                   // for wstring
+#include <string>                   // for string, to_string
 #include <utility>                  // for move
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
-  auto make_box = [](const std::wstring title) {
+  auto make_box = [](const std::string& title) {
     return window(text(title) | hcenter | bold,
-                  text(L"content") | hcenter | dim);
+                  text("content") | hcenter | dim);
   };
 
   Elements content;
   for (int x = 3; x < 30; ++x) {
-    content.push_back(make_box(to_wstring(x)) | size(WIDTH, EQUAL, x));
+    content.push_back(make_box(std::to_string(x)) | size(WIDTH, EQUAL, x));
   }
 
   auto document = hbox(std::move(content));

--- a/examples/dom/spinner.cpp
+++ b/examples/dom/spinner.cpp
@@ -1,16 +1,14 @@
 #include <chrono>                  // for operator""s, chrono_literals
-#include <ftxui/dom/elements.hpp>  // for Element, operator|, separator, filler, hbox, size, spinner, vbox, bold, border, EQUAL, WIDTH
-#include <ftxui/screen/screen.hpp>  // for Screen, Dimension
-#include <ftxui/screen/string.hpp>  // for to_wstring
+#include <ftxui/dom/elements.hpp>  // for Element, operator|, separator, filler, hbox, size, spinner, text, vbox, bold, border, Fit, EQUAL, WIDTH
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <iostream>                 // for cout, endl, ostream
-#include <string>                   // for operator<<, string
+#include <string>                   // for to_string, operator<<, string
 #include <thread>                   // for sleep_for
 #include <utility>                  // for move
 #include <vector>                   // for vector
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
@@ -24,7 +22,7 @@ int main(int argc, const char* argv[]) {
         entries.push_back(separator());
       entries.push_back(  //
           hbox({
-              text(to_wstring(i)) | size(WIDTH, EQUAL, 2),
+              text(std::to_string(i)) | size(WIDTH, EQUAL, 2),
               separator(),
               spinner(i, index) | bold,
           }));

--- a/examples/dom/style_blink.cpp
+++ b/examples/dom/style_blink.cpp
@@ -1,18 +1,17 @@
-#include <ftxui/dom/elements.hpp>   // for operator|, blink, hbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, blink, Fit, hbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       hbox({
-          text(L"This text is "),
-          text(L"blink") | blink,
-          text(L". Do you like it?"),
+          text("This text is "),
+          text("blink") | blink,
+          text(". Do you like it?"),
       });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/style_bold.cpp
+++ b/examples/dom/style_bold.cpp
@@ -1,18 +1,17 @@
-#include <ftxui/dom/elements.hpp>   // for operator|, bold, hbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, bold, Fit, hbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       hbox({
-          text(L"This text is "),
-          text(L"bold") | bold,
-          text(L". Do you like it?"),
+          text("This text is "),
+          text("bold") | bold,
+          text(". Do you like it?"),
       });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/style_color.cpp
+++ b/examples/dom/style_color.cpp
@@ -1,10 +1,9 @@
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/elements.hpp"    // for bgcolor, color, vbox, filler, hbox
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/elements.hpp"  // for text, bgcolor, color, vbox, Fit, filler, hbox
+#include "ftxui/dom/node.hpp"      // for Render
+#include "ftxui/screen/box.hpp"    // for ftxui
 #include "ftxui/screen/color.hpp"  // for Color, Color::Black, Color::Blue, Color::BlueLight, Color::Cyan, Color::CyanLight, Color::Default, Color::GrayDark, Color::GrayLight, Color::Green, Color::GreenLight, Color::Magenta, Color::MagentaLight, Color::Red, Color::RedLight, Color::White, Color::Yellow, Color::YellowLight
 
 int main(int argc, const char* argv[]) {
@@ -13,42 +12,42 @@ int main(int argc, const char* argv[]) {
   auto document =
     hbox(
       vbox(
-        color(Color::Default, text(L"Default")),
-        color(Color::Black, text(L"Black")),
-        color(Color::GrayDark, text(L"GrayDark")),
-        color(Color::GrayLight, text(L"GrayLight")),
-        color(Color::White, text(L"White")),
-        color(Color::Blue, text(L"Blue")),
-        color(Color::BlueLight, text(L"BlueLight")),
-        color(Color::Cyan, text(L"Cyan")),
-        color(Color::CyanLight, text(L"CyanLight")),
-        color(Color::Green, text(L"Green")),
-        color(Color::GreenLight, text(L"GreenLight")),
-        color(Color::Magenta, text(L"Magenta")),
-        color(Color::MagentaLight, text(L"MagentaLight")),
-        color(Color::Red, text(L"Red")),
-        color(Color::RedLight, text(L"RedLight")),
-        color(Color::Yellow, text(L"Yellow")),
-        color(Color::YellowLight, text(L"YellowLight"))
+        color(Color::Default, text("Default")),
+        color(Color::Black, text("Black")),
+        color(Color::GrayDark, text("GrayDark")),
+        color(Color::GrayLight, text("GrayLight")),
+        color(Color::White, text("White")),
+        color(Color::Blue, text("Blue")),
+        color(Color::BlueLight, text("BlueLight")),
+        color(Color::Cyan, text("Cyan")),
+        color(Color::CyanLight, text("CyanLight")),
+        color(Color::Green, text("Green")),
+        color(Color::GreenLight, text("GreenLight")),
+        color(Color::Magenta, text("Magenta")),
+        color(Color::MagentaLight, text("MagentaLight")),
+        color(Color::Red, text("Red")),
+        color(Color::RedLight, text("RedLight")),
+        color(Color::Yellow, text("Yellow")),
+        color(Color::YellowLight, text("YellowLight"))
       ),
       vbox(
-        bgcolor(Color::Default, text(L"Default")),
-        bgcolor(Color::Black, text(L"Black")),
-        bgcolor(Color::GrayDark, text(L"GrayDark")),
-        bgcolor(Color::GrayLight, text(L"GrayLight")),
-        bgcolor(Color::White, text(L"White")),
-        bgcolor(Color::Blue, text(L"Blue")),
-        bgcolor(Color::BlueLight, text(L"BlueLight")),
-        bgcolor(Color::Cyan, text(L"Cyan")),
-        bgcolor(Color::CyanLight, text(L"CyanLight")),
-        bgcolor(Color::Green, text(L"Green")),
-        bgcolor(Color::GreenLight, text(L"GreenLight")),
-        bgcolor(Color::Magenta, text(L"Magenta")),
-        bgcolor(Color::MagentaLight, text(L"MagentaLight")),
-        bgcolor(Color::Red, text(L"Red")),
-        bgcolor(Color::RedLight, text(L"RedLight")),
-        bgcolor(Color::Yellow, text(L"Yellow")),
-        bgcolor(Color::YellowLight, text(L"YellowLight"))
+        bgcolor(Color::Default, text("Default")),
+        bgcolor(Color::Black, text("Black")),
+        bgcolor(Color::GrayDark, text("GrayDark")),
+        bgcolor(Color::GrayLight, text("GrayLight")),
+        bgcolor(Color::White, text("White")),
+        bgcolor(Color::Blue, text("Blue")),
+        bgcolor(Color::BlueLight, text("BlueLight")),
+        bgcolor(Color::Cyan, text("Cyan")),
+        bgcolor(Color::CyanLight, text("CyanLight")),
+        bgcolor(Color::Green, text("Green")),
+        bgcolor(Color::GreenLight, text("GreenLight")),
+        bgcolor(Color::Magenta, text("Magenta")),
+        bgcolor(Color::MagentaLight, text("MagentaLight")),
+        bgcolor(Color::Red, text("Red")),
+        bgcolor(Color::RedLight, text("RedLight")),
+        bgcolor(Color::Yellow, text("Yellow")),
+        bgcolor(Color::YellowLight, text("YellowLight"))
       ),
       filler()
     );

--- a/examples/dom/style_dim.cpp
+++ b/examples/dom/style_dim.cpp
@@ -1,18 +1,17 @@
-#include <ftxui/dom/elements.hpp>   // for operator|, dim, hbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, dim, Fit, hbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       hbox({
-          text(L"This text is "),
-          text(L"dim") | dim,
-          text(L". Do you like it?"),
+          text("This text is "),
+          text("dim") | dim,
+          text(". Do you like it?"),
       });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/style_gallery.cpp
+++ b/examples/dom/style_gallery.cpp
@@ -1,25 +1,24 @@
-#include <ftxui/dom/elements.hpp>  // for operator|, Element, bgcolor, color, blink, bold, dim, inverted, underlined, hbox
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, Element, bgcolor, color, blink, bold, dim, inverted, underlined, Fit, hbox
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
-#include "ftxui/screen/color.hpp"    // for Color, Color::Blue
+#include "ftxui/dom/node.hpp"      // for Render
+#include "ftxui/screen/box.hpp"    // for ftxui
+#include "ftxui/screen/color.hpp"  // for Color, Color::Blue
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   // clang-format off
   auto document =
     hbox({
-      text(L"normal")                           , text(L" ") ,
-      text(L"bold")      | bold                 , text(L" ") ,
-      text(L"dim")       | dim                  , text(L" ") ,
-      text(L"inverted")  | inverted             , text(L" ") ,
-      text(L"underlined")| underlined           , text(L" ") ,
-      text(L"blink")     | blink                , text(L" ") ,
-      text(L"color")     | color(Color::Blue)   , text(L" ") ,
-      text(L"bgcolor")   | bgcolor(Color::Blue),
+      text("normal")                           , text(" ") ,
+      text("bold")      | bold                 , text(" ") ,
+      text("dim")       | dim                  , text(" ") ,
+      text("inverted")  | inverted             , text(" ") ,
+      text("underlined")| underlined           , text(" ") ,
+      text("blink")     | blink                , text(" ") ,
+      text("color")     | color(Color::Blue)   , text(" ") ,
+      text("bgcolor")   | bgcolor(Color::Blue),
     });
   // clang-format on
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));

--- a/examples/dom/style_inverted.cpp
+++ b/examples/dom/style_inverted.cpp
@@ -1,17 +1,16 @@
-#include <ftxui/dom/elements.hpp>   // for operator|, inverted, hbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, inverted, Fit, hbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document = hbox({
-      text(L"This text is "),
-      text(L"inverted") | inverted,
-      text(L". Do you like it?"),
+      text("This text is "),
+      text("inverted") | inverted,
+      text(". Do you like it?"),
   });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/style_underlined.cpp
+++ b/examples/dom/style_underlined.cpp
@@ -1,18 +1,17 @@
-#include <ftxui/dom/elements.hpp>   // for operator|, underlined, hbox, Element
-#include <ftxui/screen/screen.hpp>  // for Dimension, Screen
+#include <ftxui/dom/elements.hpp>  // for text, operator|, underlined, Fit, hbox, Element
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       hbox({
-          text(L"This text is "),
-          text(L"underlined") | underlined,
-          text(L". Do you like it?"),
+          text("This text is "),
+          text("underlined") | underlined,
+          text(". Do you like it?"),
       });
   auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(document));
   Render(screen, document);

--- a/examples/dom/vbox_hbox.cpp
+++ b/examples/dom/vbox_hbox.cpp
@@ -1,32 +1,31 @@
 #include <stdio.h>                  // for getchar
-#include <ftxui/dom/elements.hpp>   // for filler, hbox, vbox
-#include <ftxui/screen/screen.hpp>  // for Screen, Dimension
+#include <ftxui/dom/elements.hpp>   // for filler, text, hbox, vbox
+#include <ftxui/screen/screen.hpp>  // for Full, Screen
 #include <memory>                   // for allocator
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
+#include "ftxui/dom/node.hpp"    // for Render
+#include "ftxui/screen/box.hpp"  // for ftxui
 
 int main(int argc, const char* argv[]) {
   using namespace ftxui;
   auto document =  //
       vbox({
           hbox({
-              text(L"north-west"),
+              text("north-west"),
               filler(),
-              text(L"north-east"),
+              text("north-east"),
           }),
           filler(),
           hbox({
               filler(),
-              text(L"center"),
+              text("center"),
               filler(),
           }),
           filler(),
           hbox({
-              text(L"south-west"),
+              text("south-west"),
               filler(),
-              text(L"south-east"),
+              text("south-east"),
           }),
       });
   auto screen = Screen::Create(Dimension::Full());

--- a/examples/html/test.html.disabled
+++ b/examples/html/test.html.disabled
@@ -33,33 +33,33 @@
       using namespace ftxui;
       auto document =
         hbox(
-          window(text(L" main frame ") | hcenter,
+          window(text(" main frame ") | hcenter,
             vbox(
-              text(L"Line 1"),
-              text(L"Line 2"),
-              text(L"Line 3"),
+              text("Line 1"),
+              text("Line 2"),
+              text("Line 3"),
               vbox(
-                text(L"Line 4"),
-                text(L"Line 5"),
-                text(L"Line 6")
+                text("Line 4"),
+                text("Line 5"),
+                text("Line 6")
               ) | border,
               hbox(
-                window(text(L"frame 2"),
+                window(text("frame 2"),
                   vbox(
-                    text(L"Line 4"),
+                    text("Line 4"),
                     gauge(0.5) | border,
-                    text(L"Line 6")
+                    text("Line 6")
                   )
                 ),
-                window(text(L"frame 3"),
+                window(text("frame 3"),
                   vbox(
-                    text(L"Line 7"),
-                    text(L"Line 8"),
-                    text(L"Line 9")
+                    text("Line 7"),
+                    text("Line 8"),
+                    text("Line 9")
                   )
                 )
               ),
-              text(L"footer footer footer footer footer")
+              text("footer footer footer footer footer")
             )
           ),
           filler()

--- a/include/ftxui/dom/elements.hpp
+++ b/include/ftxui/dom/elements.hpp
@@ -20,7 +20,7 @@ using GraphFunction = std::function<std::vector<int>(int, int)>;
 // Pipe elements into decorator togethers.
 // For instance the next lines are equivalents:
 // -> text("ftxui") | bold | underlined
-// -> underlined(bold(text(L"FTXUI")))
+// -> underlined(bold(text("FTXUI")))
 Element operator|(Element, Decorator);
 Elements operator|(Elements, Decorator);
 Decorator operator|(Decorator, Decorator);

--- a/include/ftxui/screen/deprecated.hpp
+++ b/include/ftxui/screen/deprecated.hpp
@@ -1,0 +1,15 @@
+#ifndef FTXUI_SCREEN_DEPRECATED_HPP
+#define FTXUI_SCREEN_DEPRECATED_HPP
+
+#include <string>
+
+namespace ftxui {
+int wchar_width(wchar_t);
+int wstring_width(const std::wstring&);
+}  // namespace ftxui
+
+#endif /* end of include guard: FTXUI_SCREEN_DEPRECATED_HPP */
+
+// Copyright 2021 Arthur Sonzogni. All rights reserved.
+// Use of this source code is governed by the MIT license that can be found in
+// the LICENSE file.

--- a/include/ftxui/screen/string.hpp
+++ b/include/ftxui/screen/string.hpp
@@ -1,8 +1,8 @@
 #ifndef FTXUI_SCREEN_STRING_HPP
 #define FTXUI_SCREEN_STRING_HPP
 
-#include <string>
-#include <vector>
+#include <string>  // for string, wstring, to_string
+#include <vector>  // for vector
 
 namespace ftxui {
 std::string to_string(const std::wstring& s);
@@ -13,12 +13,12 @@ std::wstring to_wstring(T s) {
   return to_wstring(std::to_string(s));
 }
 
-int wchar_width(wchar_t);
-int wstring_width(const std::wstring&);
 int string_width(const std::string&);
 std::vector<std::string> Utf8ToGlyphs(const std::string& input);
 
 }  // namespace ftxui
+
+#include "ftxui/screen/deprecated.hpp"
 
 #endif /* end of include guard: FTXUI_SCREEN_STRING_HPP */
 

--- a/src/ftxui/component/container_test.cpp
+++ b/src/ftxui/component/container_test.cpp
@@ -11,7 +11,7 @@
 using namespace ftxui;
 
 Component Focusable() {
-  return Button(L"", [] {});
+  return Button("", [] {});
 }
 Component NonFocusable() {
   return Container::Horizontal({});

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -200,7 +200,7 @@ class InputBase : public ComponentBase {
   bool OnEvent(Event event) override {
     wrapped_content_ = to_wstring(*content_);
     if (wrapped_input_.OnEvent(event)) {
-      content_ = to_string(wrapped_content_);
+      *content_ = to_string(wrapped_content_);
       return true;
     }
     return false;

--- a/src/ftxui/component/input_test.cpp
+++ b/src/ftxui/component/input_test.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest-message.h>  // for Message
 #include <gtest/gtest-test-part.h>  // for TestPartResult, SuiteApiResolver, TestFactoryImpl
 #include <memory>  // for __shared_ptr_access, shared_ptr, allocator
-#include <string>  // for wstring
+#include <string>  // for string
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
+#include "ftxui/component/component.hpp"       // for Input
 #include "ftxui/component/component_base.hpp"  // for ComponentBase, Component
 #include "ftxui/component/component_options.hpp"  // for InputOption
-#include "ftxui/component/deprecated.hpp"         // for Input
 #include "ftxui/component/event.hpp"  // for Event, Event::ArrowLeft, Event::ArrowRight, Event::Backspace, Event::Delete, Event::End, Event::Home
 #include "ftxui/dom/elements.hpp"     // for Fit
 #include "ftxui/dom/node.hpp"         // for Render
@@ -17,8 +17,8 @@
 using namespace ftxui;
 
 TEST(InputTest, Init) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   Component input = Input(&content, &placeholder, &option);
 
@@ -26,17 +26,17 @@ TEST(InputTest, Init) {
 }
 
 TEST(InputTest, Type) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   Component input = Input(&content, &placeholder, &option);
 
-  input->OnEvent(Event::Character('a'));
-  EXPECT_EQ(content, L"a");
+  input->OnEvent(Event::Character("a"));
+  EXPECT_EQ(content, "a");
   EXPECT_EQ(option.cursor_position(), 1u);
 
   input->OnEvent(Event::Character('b'));
-  EXPECT_EQ(content, L"ab");
+  EXPECT_EQ(content, "ab");
   EXPECT_EQ(option.cursor_position(), 2u);
 
   auto document = input->Render();
@@ -47,18 +47,18 @@ TEST(InputTest, Type) {
 }
 
 TEST(InputTest, TypePassword) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   option.password = true;
   Component input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
-  EXPECT_EQ(content, L"a");
+  EXPECT_EQ(content, "a");
   EXPECT_EQ(option.cursor_position(), 1u);
 
   input->OnEvent(Event::Character('b'));
-  EXPECT_EQ(content, L"ab");
+  EXPECT_EQ(content, "ab");
   EXPECT_EQ(option.cursor_position(), 2u);
 
   auto document = input->Render();
@@ -69,8 +69,8 @@ TEST(InputTest, TypePassword) {
 }
 
 TEST(InputTest, Arrow) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   auto input = Input(&content, &placeholder, &option);
 
@@ -106,53 +106,53 @@ TEST(InputTest, Arrow) {
 }
 
 TEST(InputTest, Insert) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   Component input = Input(&content, &placeholder);
 
   input->OnEvent(Event::Character('a'));
   input->OnEvent(Event::Character('b'));
   input->OnEvent(Event::Character('c'));
-  EXPECT_EQ(content, L"abc");
+  EXPECT_EQ(content, "abc");
 
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::Character('-'));
-  EXPECT_EQ(content, L"a-bc");
+  EXPECT_EQ(content, "a-bc");
 
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::Character('-'));
-  EXPECT_EQ(content, L"a--bc");
+  EXPECT_EQ(content, "a--bc");
 
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::ArrowLeft);
   input->OnEvent(Event::Character('-'));
-  EXPECT_EQ(content, L"-a--bc");
+  EXPECT_EQ(content, "-a--bc");
 }
 
 TEST(InputTest, Home) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
   input->OnEvent(Event::Character('b'));
   input->OnEvent(Event::Character('c'));
-  EXPECT_EQ(content, L"abc");
+  EXPECT_EQ(content, "abc");
 
   EXPECT_EQ(option.cursor_position(), 3u);
   input->OnEvent(Event::Home);
   EXPECT_EQ(option.cursor_position(), 0u);
 
   input->OnEvent(Event::Character('-'));
-  EXPECT_EQ(content, L"-abc");
+  EXPECT_EQ(content, "-abc");
 }
 
 TEST(InputTest, End) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   auto input = Input(&content, &placeholder, &option);
 
@@ -169,8 +169,8 @@ TEST(InputTest, End) {
 }
 
 TEST(InputTest, Delete) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   auto input = Input(&content, &placeholder, &option);
 
@@ -179,21 +179,21 @@ TEST(InputTest, Delete) {
   input->OnEvent(Event::Character('c'));
   input->OnEvent(Event::ArrowLeft);
 
-  EXPECT_EQ(content, L"abc");
+  EXPECT_EQ(content, "abc");
   EXPECT_EQ(option.cursor_position(), 2u);
 
   input->OnEvent(Event::Delete);
-  EXPECT_EQ(content, L"ab");
+  EXPECT_EQ(content, "ab");
   EXPECT_EQ(option.cursor_position(), 2u);
 
   input->OnEvent(Event::Delete);
-  EXPECT_EQ(content, L"ab");
+  EXPECT_EQ(content, "ab");
   EXPECT_EQ(option.cursor_position(), 2u);
 }
 
 TEST(InputTest, Backspace) {
-  std::wstring content;
-  std::wstring placeholder;
+  std::string content;
+  std::string placeholder;
   auto option = InputOption();
   auto input = Input(&content, &placeholder, &option);
 
@@ -202,19 +202,19 @@ TEST(InputTest, Backspace) {
   input->OnEvent(Event::Character('c'));
   input->OnEvent(Event::ArrowLeft);
 
-  EXPECT_EQ(content, L"abc");
+  EXPECT_EQ(content, "abc");
   EXPECT_EQ(option.cursor_position(), 2u);
 
   input->OnEvent(Event::Backspace);
-  EXPECT_EQ(content, L"ac");
+  EXPECT_EQ(content, "ac");
   EXPECT_EQ(option.cursor_position(), 1u);
 
   input->OnEvent(Event::Backspace);
-  EXPECT_EQ(content, L"c");
+  EXPECT_EQ(content, "c");
   EXPECT_EQ(option.cursor_position(), 0u);
 
   input->OnEvent(Event::Backspace);
-  EXPECT_EQ(content, L"c");
+  EXPECT_EQ(content, "c");
   EXPECT_EQ(option.cursor_position(), 0u);
 }
 

--- a/src/ftxui/component/radiobox_test.cpp
+++ b/src/ftxui/component/radiobox_test.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest-message.h>  // for Message
 #include <gtest/gtest-test-part.h>  // for TestPartResult, SuiteApiResolver, TestFactoryImpl
 #include <memory>  // for __shared_ptr_access, shared_ptr, allocator
-#include <string>  // for wstring, basic_string
+#include <string>  // for string, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"  // for ftxui
@@ -14,7 +14,7 @@ using namespace ftxui;
 
 TEST(RadioboxTest, Navigation) {
   int selected = 0;
-  std::vector<std::wstring> entries = {L"1", L"2", L"3"};
+  std::vector<std::string> entries = {"1", "2", "3"};
   auto radiobox = Radiobox(&entries, &selected);
 
   // With arrow key.
@@ -60,7 +60,7 @@ TEST(RadioboxTest, Navigation) {
   EXPECT_EQ(selected, 0);
 
   // With more entries
-  entries = {L"1", L"2", L"3"};
+  entries = {"1", "2", "3"};
   EXPECT_EQ(selected, 0);
   radiobox->OnEvent(Event::ArrowDown);
   radiobox->OnEvent(Event::Return);

--- a/src/ftxui/component/screen_interactive_test.cpp
+++ b/src/ftxui/component/screen_interactive_test.cpp
@@ -4,9 +4,8 @@
 
 #include "ftxui/component/component.hpp"  // for Renderer
 #include "ftxui/component/screen_interactive.hpp"
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/elements.hpp"    // for Element
-#include "gtest/gtest_pred_impl.h"   // for Test, TEST, EXPECT_EQ
+#include "ftxui/dom/elements.hpp"   // for text, Element
+#include "gtest/gtest_pred_impl.h"  // for Test, TEST, EXPECT_EQ
 
 using namespace ftxui;
 
@@ -18,7 +17,7 @@ bool TestSignal(int signal) {
     called++;
     std::raise(signal);
     called++;
-    return text(L"");
+    return text("");
   });
 
   auto screen = ScreenInteractive::FitComponent();

--- a/src/ftxui/component/toggle_test.cpp
+++ b/src/ftxui/component/toggle_test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest-test-part.h>  // for TestPartResult, SuiteApiResolver, TestFactoryImpl
 #include <functional>               // for function
 #include <memory>  // for __shared_ptr_access, shared_ptr, allocator
-#include <string>  // for wstring, basic_string
+#include <string>  // for string, basic_string
 #include <vector>  // for vector
 
 #include "ftxui/component/captured_mouse.hpp"     // for ftxui
@@ -15,7 +15,7 @@
 using namespace ftxui;
 
 TEST(ToggleTest, leftRightArrow) {
-  std::vector<std::wstring> entries = {L"On", L"Off"};
+  std::vector<std::string> entries = {"On", "Off"};
   int selected = 0;
   auto toggle = Toggle(&entries, &selected);
 
@@ -42,7 +42,7 @@ TEST(ToggleTest, leftRightArrow) {
   EXPECT_EQ(selected, 0);
 
   // With more entries
-  entries = {L"1", L"2", L"3"};
+  entries = {"1", "2", "3"};
   EXPECT_EQ(selected, 0);
   toggle->OnEvent(Event::ArrowRight);
   EXPECT_EQ(selected, 1);
@@ -59,7 +59,7 @@ TEST(ToggleTest, leftRightArrow) {
 }
 
 TEST(ToggleTest, Tab) {
-  std::vector<std::wstring> entries = {L"1", L"2", L"3"};
+  std::vector<std::string> entries = {"1", "2", "3"};
   int selected = 0;
   auto toggle = Toggle(&entries, &selected);
 
@@ -86,7 +86,7 @@ TEST(ToggleTest, Tab) {
 }
 
 TEST(ToggleTest, OnChange) {
-  std::vector<std::wstring> entries = {L"1", L"2", L"3"};
+  std::vector<std::string> entries = {"1", "2", "3"};
   int selected = 0;
   int counter = 0;
   auto option = ToggleOption();
@@ -115,7 +115,7 @@ TEST(ToggleTest, OnChange) {
 }
 
 TEST(ToggleTest, OnEnter) {
-  std::vector<std::wstring> entries = {L"1", L"2", L"3"};
+  std::vector<std::string> entries = {"1", "2", "3"};
   int selected = 0;
   int counter = 0;
 

--- a/src/ftxui/dom/gauge.cpp
+++ b/src/ftxui/dom/gauge.cpp
@@ -9,14 +9,17 @@
 
 namespace ftxui {
 
-static std::string charset[] =
+static std::string charset[] = {
 #if defined(FTXUI_MICROSOFT_TERMINAL_FALLBACK)
     // Microsoft's terminals often use fonts not handling the 8 unicode
     // characters for representing the whole gauge. Fallback with less.
-    {" ", " ", " ", " ", "▌", "▌", "▌", "█", "█", "█"};
+    " ", " ", " ", " ", "▌", "▌", "▌", "█", "█", "█",
 #else
-    {" ", " ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"};
+    " ", " ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█",
 #endif
+    // An extra character in case when the fuzzer manage to have:
+    // int(9 * (limit - limit_int) = 9
+    "█"};
 
 class Gauge : public Node {
  public:

--- a/src/ftxui/dom/hbox_test.cpp
+++ b/src/ftxui/dom/hbox_test.cpp
@@ -3,8 +3,7 @@
 #include <string>                   // for allocator, basic_string, string
 #include <vector>                   // for vector
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/elements.hpp"  // for operator|, Element, flex_grow, flex_shrink, hbox
+#include "ftxui/dom/elements.hpp"  // for text, operator|, Element, flex_grow, flex_shrink, hbox
 #include "ftxui/dom/node.hpp"       // for Render
 #include "ftxui/screen/box.hpp"     // for ftxui
 #include "ftxui/screen/screen.hpp"  // for Screen
@@ -15,9 +14,9 @@ using namespace ftxui;
 
 TEST(HBoxTest, NoFlex_NoFlex_NoFlex) {
   auto root = hbox({
-      text(L"012"),
-      text(L"abc"),
-      text(L"ABC"),
+      text("012"),
+      text("abc"),
+      text("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -43,9 +42,9 @@ TEST(HBoxTest, NoFlex_NoFlex_NoFlex) {
 
 TEST(HBoxTest, FlexGrow_NoFlex_NoFlex) {
   auto root = hbox({
-      text(L"012") | flex_grow,
-      text(L"abc"),
-      text(L"ABC"),
+      text("012") | flex_grow,
+      text("abc"),
+      text("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -71,9 +70,9 @@ TEST(HBoxTest, FlexGrow_NoFlex_NoFlex) {
 
 TEST(HBoxTest, NoFlex_FlexGrow_NoFlex) {
   auto root = hbox({
-      text(L"012"),
-      text(L"abc") | flex_grow,
-      text(L"ABC"),
+      text("012"),
+      text("abc") | flex_grow,
+      text("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -99,9 +98,9 @@ TEST(HBoxTest, NoFlex_FlexGrow_NoFlex) {
 
 TEST(HBoxTest, NoFlex_NoFlex_FlexGrow) {
   auto root = hbox({
-      text(L"012"),
-      text(L"abc"),
-      text(L"ABC") | flex_grow,
+      text("012"),
+      text("abc"),
+      text("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -127,9 +126,9 @@ TEST(HBoxTest, NoFlex_NoFlex_FlexGrow) {
 
 TEST(HBoxTest, FlexGrow_NoFlex_FlexGrow) {
   auto root = hbox({
-      text(L"012") | flex_grow,
-      text(L"abc"),
-      text(L"ABC") | flex_grow,
+      text("012") | flex_grow,
+      text("abc"),
+      text("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -157,9 +156,9 @@ TEST(HBoxTest, FlexGrow_NoFlex_FlexGrow) {
 
 TEST(HBoxTest, FlexGrow_FlexGrow_FlexGrow) {
   auto root = hbox({
-      text(L"012") | flex_grow,
-      text(L"abc") | flex_grow,
-      text(L"ABC") | flex_grow,
+      text("012") | flex_grow,
+      text("abc") | flex_grow,
+      text("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -191,9 +190,9 @@ TEST(HBoxTest, FlexGrow_FlexGrow_FlexGrow) {
 
 TEST(HBoxTest, FlexShrink_NoFlex_NoFlex) {
   auto root = hbox({
-      text(L"012") | flex_shrink,
-      text(L"abc"),
-      text(L"ABC"),
+      text("012") | flex_shrink,
+      text("abc"),
+      text("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -219,9 +218,9 @@ TEST(HBoxTest, FlexShrink_NoFlex_NoFlex) {
 
 TEST(HBoxTest, NoFlex_FlexShrink_NoFlex) {
   auto root = hbox({
-      text(L"012"),
-      text(L"abc") | flex_shrink,
-      text(L"ABC"),
+      text("012"),
+      text("abc") | flex_shrink,
+      text("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -247,9 +246,9 @@ TEST(HBoxTest, NoFlex_FlexShrink_NoFlex) {
 
 TEST(HBoxTest, NoFlex_NoFlex_FlexShrink) {
   auto root = hbox({
-      text(L"012"),
-      text(L"abc"),
-      text(L"ABC") | flex_shrink,
+      text("012"),
+      text("abc"),
+      text("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -275,9 +274,9 @@ TEST(HBoxTest, NoFlex_NoFlex_FlexShrink) {
 
 TEST(HBoxTest, FlexShrink_NoFlex_FlexShrink) {
   auto root = hbox({
-      text(L"012") | flex_shrink,
-      text(L"abc"),
-      text(L"ABC") | flex_shrink,
+      text("012") | flex_shrink,
+      text("abc"),
+      text("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -302,9 +301,9 @@ TEST(HBoxTest, FlexShrink_NoFlex_FlexShrink) {
 
 TEST(HBoxTest, FlexShrink_FlexShrink_FlexShrink) {
   auto root = hbox({
-      text(L"012") | flex_shrink,
-      text(L"abc") | flex_shrink,
-      text(L"ABC") | flex_shrink,
+      text("012") | flex_shrink,
+      text("abc") | flex_shrink,
+      text("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -331,9 +330,9 @@ TEST(HBoxTest, FlexShrink_FlexShrink_FlexShrink) {
 
 TEST(HBoxTest, FlexGrow_NoFlex_FlewShrink) {
   auto root = hbox({
-      text(L"012") | flex_grow,
-      text(L"abc"),
-      text(L"ABC") | flex_shrink,
+      text("012") | flex_grow,
+      text("abc"),
+      text("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {

--- a/src/ftxui/dom/hflow.cpp
+++ b/src/ftxui/dom/hflow.cpp
@@ -68,8 +68,8 @@ class HFlow : public Node {
 ///
 /// ```cpp
 /// hbox({
-///   text(L"Left"),
-///   text(L"Right"),
+///   text("Left"),
+///   text("Right"),
 /// });
 /// ```
 Element hflow(Elements children) {

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -1,6 +1,7 @@
-#include <memory>  // for make_shared
-#include <string>  // for string
-#include <vector>  // for vector
+#include <algorithm>  // for min
+#include <memory>     // for make_shared
+#include <string>     // for string, wstring
+#include <vector>     // for vector
 
 #include "ftxui/dom/deprecated.hpp"   // for text, vtext
 #include "ftxui/dom/elements.hpp"     // for Element, text, vtext
@@ -87,7 +88,7 @@ Element text(std::string text) {
   return std::make_shared<Text>(text);
 }
 
-/// @brief Display a piece of UTF16 encoded unicode text.
+/// @brief Display a piece of unicode text.
 /// @ingroup dom
 /// @see ftxui::to_wstring
 ///
@@ -136,7 +137,7 @@ Element vtext(std::string text) {
   return std::make_shared<VText>(text);
 }
 
-/// @brief Display a piece of UTF16 encoded unicode text vertically.
+/// @brief Display a piece unicode text vertically.
 /// @ingroup dom
 /// @see ftxui::to_wstring
 ///

--- a/src/ftxui/dom/text_test.cpp
+++ b/src/ftxui/dom/text_test.cpp
@@ -1,19 +1,17 @@
 #include <gtest/gtest-message.h>  // for Message
 #include <gtest/gtest-test-part.h>  // for SuiteApiResolver, TestFactoryImpl, TestPartResult
-#include <string>                   // for allocator, wstring
+#include <string>                   // for allocator, string
 
-#include "ftxui/dom/deprecated.hpp"  // for text
-#include "ftxui/dom/elements.hpp"    // for operator|, border, Element
-#include "ftxui/dom/node.hpp"        // for Render
-#include "ftxui/screen/box.hpp"      // for ftxui
-#include "ftxui/screen/screen.hpp"   // for Screen
-#include "ftxui/screen/string.hpp"   // for to_string
-#include "gtest/gtest_pred_impl.h"   // for Test, EXPECT_EQ, TEST
+#include "ftxui/dom/elements.hpp"   // for text, operator|, border, Element
+#include "ftxui/dom/node.hpp"       // for Render
+#include "ftxui/screen/box.hpp"     // for ftxui
+#include "ftxui/screen/screen.hpp"  // for Screen
+#include "gtest/gtest_pred_impl.h"  // for Test, EXPECT_EQ, TEST
 
 using namespace ftxui;
 
 TEST(TextTest, ScreenHeightSmaller) {
-  auto element = text(L"test");
+  auto element = text("test");
   Screen screen(2, 0);
   Render(screen, element);
 
@@ -21,7 +19,7 @@ TEST(TextTest, ScreenHeightSmaller) {
 }
 
 TEST(TextTest, ScreenSmaller) {
-  auto element = text(L"test");
+  auto element = text("test");
   Screen screen(2, 1);
   Render(screen, element);
 
@@ -29,7 +27,7 @@ TEST(TextTest, ScreenSmaller) {
 }
 
 TEST(TextTest, ScreenFit) {
-  auto element = text(L"test");
+  auto element = text("test");
   Screen screen(4, 1);
   Render(screen, element);
 
@@ -37,7 +35,7 @@ TEST(TextTest, ScreenFit) {
 }
 
 TEST(TextTest, ScreenBigger) {
-  auto element = text(L"test");
+  auto element = text("test");
   Screen screen(6, 1);
   Render(screen, element);
 
@@ -45,7 +43,7 @@ TEST(TextTest, ScreenBigger) {
 }
 
 TEST(TextTest, ScreenBigger2) {
-  auto element = text(L"test");
+  auto element = text("test");
   Screen screen(6, 2);
   Render(screen, element);
 
@@ -54,7 +52,7 @@ TEST(TextTest, ScreenBigger2) {
 
 // See https://github.com/ArthurSonzogni/FTXUI/issues/2#issuecomment-504871456
 TEST(TextTest, CJK) {
-  auto element = text(L"测试") | border;
+  auto element = text("测试") | border;
   Screen screen(6, 3);
   Render(screen, element);
   EXPECT_EQ(
@@ -66,7 +64,7 @@ TEST(TextTest, CJK) {
 
 // See https://github.com/ArthurSonzogni/FTXUI/issues/2#issuecomment-504871456
 TEST(TextTest, CJK_2) {
-  auto element = text(L"测试") | border;
+  auto element = text("测试") | border;
   Screen screen(5, 3);
   Render(screen, element);
   EXPECT_EQ(
@@ -78,7 +76,7 @@ TEST(TextTest, CJK_2) {
 
 // See https://github.com/ArthurSonzogni/FTXUI/issues/2#issuecomment-504871456
 TEST(TextTest, CJK_3) {
-  auto element = text(L"测试") | border;
+  auto element = text("测试") | border;
   Screen screen(4, 3);
   Render(screen, element);
   EXPECT_EQ(
@@ -89,20 +87,20 @@ TEST(TextTest, CJK_3) {
 }
 
 TEST(TextTest, CombiningCharacters) {
-  const std::wstring t =
+  const std::string t =
       // Combining above:
-      L"ā à á â ã ā a̅ ă ȧ ä ả å a̋ ǎ a̍ a̎ ȁ a̐ ȃ a̒ a̔ a̕ a̚ a̛ a̽ a̾ a̿ à á a͂ a͆ a͊ a͋ a͌ a͐ "
-      L"a͑ a͒ a͗ a͘ a͛ a͝ a͞ a͠ a͡ aͣ aͤ aͥ aͦ aͧ aͨ aͩ aͪ aͫ aͬ aͭ aͮ aͯ a᷀ a᷁ a᷃ a᷄ a᷅ a᷆ a᷇ a᷈ a᷉ a᷾ a⃐ a⃑ a⃔ "
-      L"a⃕ a⃖ a⃗ a⃛ a⃜ a⃡ a⃩ a⃰ a︠ a︡ a︢ a︣"
+      "ā à á â ã ā a̅ ă ȧ ä ả å a̋ ǎ a̍ a̎ ȁ a̐ ȃ a̒ a̔ a̕ a̚ a̛ a̽ a̾ a̿ à á a͂ a͆ a͊ a͋ a͌ a͐ "
+      "a͑ a͒ a͗ a͘ a͛ a͝ a͞ a͠ a͡ aͣ aͤ aͥ aͦ aͧ aͨ aͩ aͪ aͫ aͬ aͭ aͮ aͯ a᷀ a᷁ a᷃ a᷄ a᷅ a᷆ a᷇ a᷈ a᷉ a᷾ a⃐ a⃑ a⃔ "
+      "a⃕ a⃖ a⃗ a⃛ a⃜ a⃡ a⃩ a⃰ a︠ a︡ a︢ a︣"
       // Combining middle:
-      L"a̴ a̵ a̶ a̷ a̸ a⃒ a⃓ a⃘ a⃙ a⃚ a⃝ a⃞ a⃟ a⃥ a⃦"
+      "a̴ a̵ a̶ a̷ a̸ a⃒ a⃓ a⃘ a⃙ a⃚ a⃝ a⃞ a⃟ a⃥ a⃦"
       // Combining below:
-      L"a̗ a̘ a̙ a̜ a̝ a̞ a̟ a̠ a̡ a̢ ạ ḁ a̦ a̧ ą a̩ a̪ a̫ a̬ a̭ a̮ a̯ a̰ a̱ a̲ a̳ a̹ a̺ a̻ a̼ aͅ a͇ a͈ a͉ a͍ "
-      L"a͎ a͓ a͔ a͕ a͖ a͙ a͚ a͜ a͟ a͢ a᷂ a᷊ a᷿ a⃨";
+      "a̗ a̘ a̙ a̜ a̝ a̞ a̟ a̠ a̡ a̢ ạ ḁ a̦ a̧ ą a̩ a̪ a̫ a̬ a̭ a̮ a̯ a̰ a̱ a̲ a̳ a̹ a̺ a̻ a̼ aͅ a͇ a͈ a͉ a͍ "
+      "a͎ a͓ a͔ a͕ a͖ a͙ a͚ a͜ a͟ a͢ a᷂ a᷊ a᷿ a⃨";
   auto element = text(t);
   Screen screen(290, 1);
   Render(screen, element);
-  EXPECT_EQ(to_string(t), screen.ToString());
+  EXPECT_EQ(t, screen.ToString());
 }
 
 // Copyright 2020 Arthur Sonzogni. All rights reserved.

--- a/src/ftxui/dom/vbox_test.cpp
+++ b/src/ftxui/dom/vbox_test.cpp
@@ -4,8 +4,7 @@
 #include <string>                   // for allocator, basic_string, string
 #include <vector>                   // for vector
 
-#include "ftxui/dom/deprecated.hpp"  // for vtext
-#include "ftxui/dom/elements.hpp"  // for operator|, Element, flex_grow, flex_shrink, vbox
+#include "ftxui/dom/elements.hpp"  // for vtext, operator|, Element, flex_grow, flex_shrink, vbox
 #include "ftxui/dom/node.hpp"       // for Render
 #include "ftxui/screen/box.hpp"     // for ftxui
 #include "ftxui/screen/screen.hpp"  // for Screen
@@ -22,9 +21,9 @@ std::string rotate(std::string str) {
 
 TEST(VBoxText, NoFlex_NoFlex_NoFlex) {
   auto root = vbox({
-      vtext(L"012"),
-      vtext(L"abc"),
-      vtext(L"ABC"),
+      vtext("012"),
+      vtext("abc"),
+      vtext("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -50,9 +49,9 @@ TEST(VBoxText, NoFlex_NoFlex_NoFlex) {
 
 TEST(VBoxText, FlexGrow_NoFlex_NoFlex) {
   auto root = vbox({
-      vtext(L"012") | flex_grow,
-      vtext(L"abc"),
-      vtext(L"ABC"),
+      vtext("012") | flex_grow,
+      vtext("abc"),
+      vtext("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -78,9 +77,9 @@ TEST(VBoxText, FlexGrow_NoFlex_NoFlex) {
 
 TEST(VBoxText, NoFlex_FlexGrow_NoFlex) {
   auto root = vbox({
-      vtext(L"012"),
-      vtext(L"abc") | flex_grow,
-      vtext(L"ABC"),
+      vtext("012"),
+      vtext("abc") | flex_grow,
+      vtext("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -106,9 +105,9 @@ TEST(VBoxText, NoFlex_FlexGrow_NoFlex) {
 
 TEST(VBoxText, NoFlex_NoFlex_FlexGrow) {
   auto root = vbox({
-      vtext(L"012"),
-      vtext(L"abc"),
-      vtext(L"ABC") | flex_grow,
+      vtext("012"),
+      vtext("abc"),
+      vtext("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -134,9 +133,9 @@ TEST(VBoxText, NoFlex_NoFlex_FlexGrow) {
 
 TEST(VBoxText, FlexGrow_NoFlex_FlexGrow) {
   auto root = vbox({
-      vtext(L"012") | flex_grow,
-      vtext(L"abc"),
-      vtext(L"ABC") | flex_grow,
+      vtext("012") | flex_grow,
+      vtext("abc"),
+      vtext("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -164,9 +163,9 @@ TEST(VBoxText, FlexGrow_NoFlex_FlexGrow) {
 
 TEST(VBoxText, FlexGrow_FlexGrow_FlexGrow) {
   auto root = vbox({
-      vtext(L"012") | flex_grow,
-      vtext(L"abc") | flex_grow,
-      vtext(L"ABC") | flex_grow,
+      vtext("012") | flex_grow,
+      vtext("abc") | flex_grow,
+      vtext("ABC") | flex_grow,
   });
 
   std::vector<std::string> expectations = {
@@ -198,9 +197,9 @@ TEST(VBoxText, FlexGrow_FlexGrow_FlexGrow) {
 
 TEST(VBoxText, FlexShrink_NoFlex_NoFlex) {
   auto root = vbox({
-      vtext(L"012") | flex_shrink,
-      vtext(L"abc"),
-      vtext(L"ABC"),
+      vtext("012") | flex_shrink,
+      vtext("abc"),
+      vtext("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -226,9 +225,9 @@ TEST(VBoxText, FlexShrink_NoFlex_NoFlex) {
 
 TEST(VBoxText, NoFlex_FlexShrink_NoFlex) {
   auto root = vbox({
-      vtext(L"012"),
-      vtext(L"abc") | flex_shrink,
-      vtext(L"ABC"),
+      vtext("012"),
+      vtext("abc") | flex_shrink,
+      vtext("ABC"),
   });
 
   std::vector<std::string> expectations = {
@@ -254,9 +253,9 @@ TEST(VBoxText, NoFlex_FlexShrink_NoFlex) {
 
 TEST(VBoxText, NoFlex_NoFlex_FlexShrink) {
   auto root = vbox({
-      vtext(L"012"),
-      vtext(L"abc"),
-      vtext(L"ABC") | flex_shrink,
+      vtext("012"),
+      vtext("abc"),
+      vtext("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -282,9 +281,9 @@ TEST(VBoxText, NoFlex_NoFlex_FlexShrink) {
 
 TEST(VBoxText, FlexShrink_NoFlex_FlexShrink) {
   auto root = vbox({
-      vtext(L"012") | flex_shrink,
-      vtext(L"abc"),
-      vtext(L"ABC") | flex_shrink,
+      vtext("012") | flex_shrink,
+      vtext("abc"),
+      vtext("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -309,9 +308,9 @@ TEST(VBoxText, FlexShrink_NoFlex_FlexShrink) {
 
 TEST(VBoxText, FlexShrink_FlexShrink_FlexShrink) {
   auto root = vbox({
-      vtext(L"012") | flex_shrink,
-      vtext(L"abc") | flex_shrink,
-      vtext(L"ABC") | flex_shrink,
+      vtext("012") | flex_shrink,
+      vtext("abc") | flex_shrink,
+      vtext("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {
@@ -338,9 +337,9 @@ TEST(VBoxText, FlexShrink_FlexShrink_FlexShrink) {
 
 TEST(VBoxText, FlexGrow_NoFlex_FlewShrink) {
   auto root = vbox({
-      vtext(L"012") | flex_grow,
-      vtext(L"abc"),
-      vtext(L"ABC") | flex_shrink,
+      vtext("012") | flex_grow,
+      vtext("abc"),
+      vtext("ABC") | flex_shrink,
   });
 
   std::vector<std::string> expectations = {

--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -13,6 +13,8 @@
 #include <locale>    // for wstring_convert
 #include <string>    // for string, basic_string, wstring, allocator
 
+#include "ftxui/screen/deprecated.hpp"  // for wchar_width, wstring_width
+
 namespace {
 
 struct Interval {


### PR DESCRIPTION
In examples and tests, use std::string.

In addtion:
1. Address follow-up from:
https://github.com/ArthurSonzogni/FTXUI/pull/179
2. Fix a bug when Input is used with std::string.