### PR TITLE
screen_interactive: install_signal_handler() should call the old sign…

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -211,7 +211,10 @@ void OnExit(int signal) {
 
 auto install_signal_handler = [](int sig, SignalHandler handler) {
   auto old_signal_handler = std::signal(sig, handler);
-  on_exit_functions.push([&]() { std::signal(sig, old_signal_handler); });
+  if(old_signal_handler != SIG_ERR)
+  {
+    on_exit_functions.push([=]() { old_signal_handler(sig); });
+  }
 };
 
 std::function<void()> on_resize = [] {};


### PR DESCRIPTION
…al handler, if it isn't null, rather than reinstalling it as the old signal handler. Also lambda should capture by value not by reference.

Fixes a couple of issues:

- If there are multiple signal handlers registered on the same signal the previous code would overwrite each subsequently restored handler
  with the next handler being restored, rather than calling the handler. This means users of FTXUI that registered overlaping signals
  such as SIGINT, would require a second SIGINT to be called.

- Capture by reference was being used on a stack variable outside of the context of the lambda.

With this change:

- Multiple handlers on the same signal are called when a matching signal is received

- Lambda is capturing the stack variable by value.