### PR TITLE
Update Input's options.

### DIFF
--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -51,9 +51,11 @@ struct InputOption {
   std::function<void()> on_enter = [] {};
 
   /// Obscure the input content using '*'.
-  bool password = false;
+  Ref<bool> password = false;
 
-  Ref<int> cursor_position = 0;
+  /// When set different from -1, this attributes is used to store the cursor
+  /// position.
+  Ref<int> cursor_position = -1;
 };
 
 /// @brief Option for the Radiobox component.

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -28,14 +28,20 @@ class WideInputBase : public ComponentBase {
                 Ref<InputOption> option)
       : content_(content), placeholder_(placeholder), option_(option) {}
 
-  int& cursor_position() { return *(option_->cursor_position); }
+  int cursor_position_internal_ = 0;
+  int& cursor_position() {
+    int& opt = option_->cursor_position();
+    if (opt != -1)
+      return opt;
+    return cursor_position_internal_;
+  }
 
   // Component implementation:
   Element Render() override {
     std::wstring password_content;
-    if (option_->password)
+    if (option_->password())
       password_content = std::wstring(content_->size(), U'•');
-    std::wstring& content = option_->password ? password_content : *content_;
+    std::wstring& content = option_->password() ? password_content : *content_;
 
     cursor_position() =
         std::max(0, std::min<int>(content.size(), cursor_position()));

--- a/src/ftxui/component/input_test.cpp
+++ b/src/ftxui/component/input_test.cpp
@@ -20,6 +20,7 @@ TEST(InputTest, Init) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   Component input = Input(&content, &placeholder, &option);
 
   EXPECT_EQ(option.cursor_position(), 0);
@@ -29,6 +30,7 @@ TEST(InputTest, Type) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   Component input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character("a"));
@@ -50,6 +52,7 @@ TEST(InputTest, TypePassword) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   option.password = true;
   Component input = Input(&content, &placeholder, &option);
 
@@ -72,6 +75,7 @@ TEST(InputTest, Arrow) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
@@ -135,6 +139,7 @@ TEST(InputTest, Home) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
@@ -154,6 +159,7 @@ TEST(InputTest, End) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
@@ -172,6 +178,7 @@ TEST(InputTest, Delete) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));
@@ -195,6 +202,7 @@ TEST(InputTest, Backspace) {
   std::string content;
   std::string placeholder;
   auto option = InputOption();
+  option.cursor_position = 0;
   auto input = Input(&content, &placeholder, &option);
 
   input->OnEvent(Event::Character('a'));


### PR DESCRIPTION
- Password is now taking a ref, allowing a shared state to be used by
  multiple passwords.

- Password cursor position is now optional. It will be used only when
  set to something different from -1.