### PR TITLE
Add an UDL for combined hex RGB colors

### DIFF
--- a/examples/dom/style_color.cpp
+++ b/examples/dom/style_color.cpp
@@ -28,7 +28,8 @@ int main(int argc, const char* argv[]) {
         color(Color::Red, text("Red")),
         color(Color::RedLight, text("RedLight")),
         color(Color::Yellow, text("Yellow")),
-        color(Color::YellowLight, text("YellowLight"))
+        color(Color::YellowLight, text("YellowLight")),
+        color(0x66ff66_rgb, text("Phosphor"))
       ),
       vbox(
         bgcolor(Color::Default, text("Default")),
@@ -47,7 +48,8 @@ int main(int argc, const char* argv[]) {
         bgcolor(Color::Red, text("Red")),
         bgcolor(Color::RedLight, text("RedLight")),
         bgcolor(Color::Yellow, text("Yellow")),
-        bgcolor(Color::YellowLight, text("YellowLight"))
+        bgcolor(Color::YellowLight, text("YellowLight")),
+        bgcolor(0x66ff66_rgb, text("Phosphor"))
       ),
       filler()
     );

--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -1,9 +1,8 @@
 #ifndef FTXUI_SCREEN_COLOR
 #define FTXUI_SCREEN_COLOR
 
-#include <cassert>
 #include <stdint.h>  // for uint8_t
-#include <string>    // for wstring
+#include <string>  // for wstring
 
 #ifdef RGB
 // Workaround for wingdi.h (via Windows.h) defining macros that break things.
@@ -325,17 +324,11 @@ class Color {
 
 inline namespace literals {
 
-/// @brief Creates a color from a combined hex RGB representation, e.g. 0x808000_rgb
-inline Color operator""_rgb(unsigned long long int combined)
-{
-    assert(combined <= 0xffffffU);
-    auto const red = static_cast<uint8_t>(combined >> 16);
-    auto const green = static_cast<uint8_t>(combined >> 8);
-    auto const blue = static_cast<uint8_t>(combined);
-    return Color(red, green, blue);
-}
+/// @brief Creates a color from a combined hex RGB representation, 
+/// e.g. 0x808000_rgb
+Color operator""_rgb(unsigned long long int combined);
 
-}
+}  // namespace literals
 
 }  // namespace ftxui
 

--- a/include/ftxui/screen/color.hpp
+++ b/include/ftxui/screen/color.hpp
@@ -1,6 +1,7 @@
 #ifndef FTXUI_SCREEN_COLOR
 #define FTXUI_SCREEN_COLOR
 
+#include <cassert>
 #include <stdint.h>  // for uint8_t
 #include <string>    // for wstring
 
@@ -321,6 +322,20 @@ class Color {
   uint8_t green_ = 0;
   uint8_t blue_ = 0;
 };
+
+inline namespace literals {
+
+/// @brief Creates a color from a combined hex RGB representation, e.g. 0x808000_rgb
+inline Color operator""_rgb(unsigned long long int combined)
+{
+    assert(combined <= 0xffffffU);
+    auto const red = static_cast<uint8_t>(combined >> 16);
+    auto const green = static_cast<uint8_t>(combined >> 8);
+    auto const blue = static_cast<uint8_t>(combined);
+    return Color(red, green, blue);
+}
+
+}
 
 }  // namespace ftxui
 

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -1,5 +1,7 @@
 #include "ftxui/screen/color.hpp"
 
+#include <cassert>
+
 #include "ftxui/screen/color_info.hpp"  // for GetColorInfo, ColorInfo
 #include "ftxui/screen/terminal.hpp"  // for Terminal, Terminal::Color, Terminal::Palette256, Terminal::TrueColor
 
@@ -142,6 +144,18 @@ Color Color::HSV(uint8_t h, uint8_t s, uint8_t v) {
 
   return Color(0, 0, 0);
 }
+
+inline namespace literals {
+
+Color operator""_rgb(unsigned long long int combined) {
+  assert(combined <= 0xffffffU);
+  auto const red = static_cast<uint8_t>(combined >> 16);
+  auto const green = static_cast<uint8_t>(combined >> 8);
+  auto const blue = static_cast<uint8_t>(combined);
+  return Color(red, green, blue);
+}
+
+}  // namespace literals
 
 }  // namespace ftxui
 


### PR DESCRIPTION
This is a little helper function I found myself longing for while using the library. It makes defining RGB colors in the common hex format quite convenient:

```c++
auto theme_carbon_grey90() -> theme
{
    using namespace ftxui::literals;
    return theme{.ui_background = 0x262626_rgb,

                 .interactive_01 = 0x0f'62'fe_rgb,
                 .interactive_02 = 0x6f'6f'6f_rgb,
```

In order to allow using the literal on its own it has been put into the
inline namespace `literals`.