### PR TITLE
Fix: Add separator(Pixel) back.

### DIFF
--- a/src/ftxui/dom/separator.cpp
+++ b/src/ftxui/dom/separator.cpp
@@ -58,22 +58,182 @@ class SeparatorWithPixel : public Separator {
   Pixel pixel_;
 };
 
+/// @brief Draw a vertical or horizontal separator in between two elements.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Element document = vbox({
+///   text("Up"),
+///   separator(),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+/// ────
+/// Down
+/// ```
 Element separator() {
   return std::make_shared<Separator>(LIGHT);
 }
 
+/// @brief Draw a vertical or horizontal separator in between two elements.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Element document = vbox({
+///   text("Up"),
+///   separatorStyled(BorderStyle::LIGHT),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+/// ────
+/// Down
+/// ```
 Element separatorStyled(BorderStyle style) {
   return std::make_shared<Separator>(style);
 }
 
+/// @brief Draw a vertical or horizontal light separator in between two
+/// elements.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Element document = vbox({
+///   text("Up"),
+///   separatorLight(),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+/// ────
+/// Down
+/// ```
 Element separatorLight() {
   return std::make_shared<Separator>(LIGHT);
 }
+
+/// @brief Draw a vertical or horizontal heavy separator in between two
+/// elements.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Element document = vbox({
+///   text("Up"),
+///   separatorHeavy(),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+/// ━━━━
+/// Down
+/// ```
 Element separatorHeavy() {
   return std::make_shared<Separator>(HEAVY);
 }
+
+/// @brief Draw a vertical or horizontal double separator in between two
+/// elements.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Element document = vbox({
+///   text("Up"),
+///   separatorDouble(),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+/// ════
+/// Down
+/// ```
 Element separatorDouble() {
   return std::make_shared<Separator>(DOUBLE);
+}
+
+/// @brief Draw a separator in between two element filled with a given pixel.
+/// @ingroup dom
+/// @see separator
+/// @see separatorLight
+/// @see separatorHeavy
+/// @see separatorDouble
+/// @see separatorStyled
+///
+/// ### Example
+///
+/// ```cpp
+/// Pixel empty;
+/// Element document = vbox({
+///   text("Up"),
+///   separator(empty),
+///   text("Down"),
+/// })
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// Up
+///
+/// Down
+/// ```
+Element separator(Pixel pixel) {
+  return std::make_shared<SeparatorWithPixel>(pixel);
 }
 
 }  // namespace ftxui


### PR DESCRIPTION
It was removed by mistacke previously.
Take the opportunity to create new documentation.