### PR TITLE
Support dynamic library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
-# Changelog
+Changelog
+=========
 
-## Current
+Unreleased (development) 
+------------------------
 
 ## Bug
 - On Unix system, fallback to {80,25} screen dimension on failure.
 
-## 0.10 (2021-09-30)
+## CMake
+Added:
+- Support for shared library, via `BUILD_SHARED_LIBS` option.
+- Add library version and symlinks.
+
+0.10 (2021-09-30)
+--------------------
 
 ## Bug
 - Fix the automated merge of borders.
@@ -17,7 +25,8 @@
  - `Maybe`: Display an component conditionnally based on a boolean.
  - `Dropdown`: A dropdown select list.
 
-## 0.9 (2021-09-26)
+0.9 (2021-09-26)
+----------------
 
 The initial release where changelog where written.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     ${FTXUI_MICROSOFT_TERMINAL_FALLBACK_HELP_TEXT} OFF)
 endif()
 
-add_library(screen STATIC
+add_library(screen
   src/ftxui/screen/box.cpp
   src/ftxui/screen/color.cpp
   src/ftxui/screen/color_info.cpp
@@ -38,7 +38,7 @@ add_library(screen STATIC
   include/ftxui/screen/string.hpp
 )
 
-add_library(dom STATIC
+add_library(dom
   include/ftxui/dom/elements.hpp
   include/ftxui/dom/node.hpp
   include/ftxui/dom/requirement.hpp
@@ -75,7 +75,7 @@ add_library(dom STATIC
   src/ftxui/dom/vbox.cpp
 )
 
-add_library(component STATIC
+add_library(component
   include/ftxui/component/captured_mouse.hpp
   include/ftxui/component/component.hpp
   include/ftxui/component/component_base.hpp
@@ -111,8 +111,12 @@ target_link_libraries(dom
 find_package(Threads)
 target_link_libraries(component
   PUBLIC dom
-  PRIVATE Threads::Threads
+  PUBLIC Threads::Threads
 )
+
+set_target_properties(screen PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(dom PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(component PROPERTIES VERSION ${PROJECT_VERSION})
 
 include(cmake/ftxui_set_options.cmake)
 ftxui_set_options(screen)
@@ -138,4 +142,3 @@ if(FTXUI_ENABLE_INSTALL)
   include(cmake/ftxui_install.cmake)
   include(cmake/ftxui_package.cmake)
 endif()
-


### PR DESCRIPTION
- Let the global `BUILD_SHARED_LIBS` dictates whether the library should
  be built statically or dynamically. The cmake's default is statically.
- Add library version and symlink.

This lead to the following install tree.
```
.
├── include
│   └── ftxui
│       ├── component [...]
│       ├── dom [...]
│       ├── screen [...]
│       └── util [...]
└── lib
    ├── cmake
    │   └── ftxui
    │       ├── ftxui-config.cmake
    │       ├── ftxui-config-version.cmake
    │       └── ftxui-config-version-noconfig.cmake
    ├── ftxui-component.so -> ftxui-component.so.0.10.369
    ├── ftxui-component.so.0.10.369
    ├── ftxui-dom.so -> ftxui-dom.so.0.10.369
    ├── ftxui-dom.so.0.10.369
    ├── ftxui-screen.so -> ftxui-screen.so.0.10.369
    └── ftxui-screen.so.0.10.369
```
Fixed: https://github.com/ArthurSonzogni/FTXUI/issues/223