### PR TITLE
Include <algorithm> for std::max for msvc 2017,

### DIFF
--- a/src/ftxui/dom/scroll_indicator.cpp
+++ b/src/ftxui/dom/scroll_indicator.cpp
@@ -1,3 +1,5 @@
+#include <algorithm> // For std::max
+
 #include "ftxui/dom/elements.hpp"
 #include "ftxui/dom/node.hpp"
 #include "ftxui/dom/node_decorator.hpp"  // for NodeDecorator


### PR DESCRIPTION
Msvc defined its own (lowercase) macros for min/max. Because of this, the std::min and std::max functions need to be explicitly included or otherwise are not availible.
In the msvc 2019 compiler this issue seems fixed. However, on msvc 2017 not including <algorithm> causes compilation errors. Adding the include is a simple fix that does not hurt the other platforms and enables compilation on msvc 2017.