### PR TITLE
Add API to set terminal fallback size

### DIFF
--- a/include/ftxui/screen/terminal.hpp
+++ b/include/ftxui/screen/terminal.hpp
@@ -9,6 +9,7 @@ struct Dimensions {
 
 namespace Terminal {
 Dimensions Size();
+void SetFallbackSize(const Dimensions& fallbackSize);
 
 enum Color {
   Palette1,


### PR DESCRIPTION
In case of embedded systems, the terminal size may not always be detectable (e.g. in case of serial output).
Allow application to set up the default size in case autodetection fails.  On platform such as Emscripten, there is only "fallback" size. The use case is to allow application to start correcly both on serial terminal and via ssh session to the embedded system. Related to PR #224 
