### PR TITLE
Fix Windows builds not being in Release mode

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,7 +117,7 @@ jobs:
           -DFTXUI_BUILD_TESTS=OFF
           -DFTXUI_BUILD_TESTS_FUZZER=OFF
           -DFTXUI_ENABLE_INSTALL=ON;
-          cmake --build . --target package;
+          cmake --build . --config Release --target package;
       - uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}


### PR DESCRIPTION
Currently, the Windows libs in the releases are Debug builds.
This adds `--config Release` to the GitHub build workflow so Release builds are generated on Windows.

Truthfully, both debug and release builds would be useful for development (since one can't build in Release mode with Debug libs, and vice versa), but I'm still figuring out how to do both, along with 32-bit builds in GitHub actions.