### PR TITLE
Bugfix Input use std::string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ unreleased (development)
 ------------------------
 
 ### Features:
+
+#### DOM:
 - Support `flexbox` dom elements. This is build symmetrically to the HTML one.
   All the following attributes are supported: direction, wrap, justify-content,
   align-items, align-content, gap
@@ -16,12 +18,15 @@ unreleased (development)
   - `paragraphAlignJustify`
 - Add the helper elements based on `flexbox`: `hflow()`, `vflow()`.
 
+### Bug
+
+#### Component 
+- `Input` shouldn't take focus when hovered by the mouse.
+- Modifying `Input`'s during on_enter/on_change event is now working correctly.
+
 ### Breaking changes:
 - The behavior of `paragraph` has been modified. It now returns en Element,
-    instead of a list of elements.
-
-### Bug
-- Input shouldn't take focus when hovered by the mouse.
+  instead of a list of elements.
 
 0.11.1
 ------

--- a/include/ftxui/screen/string.hpp
+++ b/include/ftxui/screen/string.hpp
@@ -14,7 +14,20 @@ std::wstring to_wstring(T s) {
 }
 
 int string_width(const std::string&);
+// Split the string into a its glyphs. An empty one is inserted ater fullwidth
+// ones.
 std::vector<std::string> Utf8ToGlyphs(const std::string& input);
+// If |input| was an array of glyphs, this returns the number of char to eat
+// before reaching the glyph at index |glyph_index|.
+int GlyphPosition(const std::string& input,
+                  size_t glyph_index,
+                  size_t start = 0);
+// Returns the number of glyphs in |input|.
+int GlyphCount(const std::string& input);
+
+// Map every cells drawn by |input| to their corresponding Glyphs. Half-size
+// Glyphs takes one cell, full-size Glyphs take two cells.
+std::vector<int> CellToGlyphIndex(const std::string& input);
 
 }  // namespace ftxui
 

--- a/src/ftxui/component/input_test.cpp
+++ b/src/ftxui/component/input_test.cpp
@@ -226,6 +226,151 @@ TEST(InputTest, Backspace) {
   EXPECT_EQ(option.cursor_position(), 0u);
 }
 
+TEST(InputTest, MouseClick) {
+  std::string content;
+  std::string placeholder;
+  auto option = InputOption();
+  option.cursor_position = 0;
+  auto input = Input(&content, &placeholder, &option);
+
+  input->OnEvent(Event::Character("a"));
+  input->OnEvent(Event::Character("b"));
+  input->OnEvent(Event::Character("c"));
+  input->OnEvent(Event::Character("d"));
+
+  EXPECT_EQ(option.cursor_position(), 4u);
+
+  auto render = [&] {
+    auto document = input->Render();
+    auto screen = Screen::Create(Dimension::Fixed(10), Dimension::Fixed(1));
+    Render(screen, document);
+  };
+  render();
+
+  Mouse mouse;
+  mouse.button = Mouse::Button::Left;
+  mouse.motion = Mouse::Motion::Pressed;
+  mouse.y = 0;
+  mouse.shift = false;
+  mouse.meta = false;
+  mouse.control = false;
+
+  mouse.x = 0;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 2;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 2u);
+
+  mouse.x = 2;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 2u);
+
+  mouse.x = 1;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 1u);
+
+  mouse.x = 3;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 3u);
+
+  mouse.x = 4;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 4u);
+
+  mouse.x = 5;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 4u);
+}
+
+TEST(InputTest, MouseClickComplex) {
+  std::string content;
+  std::string placeholder;
+  auto option = InputOption();
+  option.cursor_position = 0;
+  auto input = Input(&content, &placeholder, &option);
+
+  input->OnEvent(Event::Character("测"));
+  input->OnEvent(Event::Character("试"));
+  input->OnEvent(Event::Character("a⃒"));
+  input->OnEvent(Event::Character("ā"));
+
+  EXPECT_EQ(option.cursor_position(), 4u);
+
+  auto render = [&] {
+    auto document = input->Render();
+    auto screen = Screen::Create(Dimension::Fixed(10), Dimension::Fixed(1));
+    Render(screen, document);
+  };
+  render();
+
+  Mouse mouse;
+  mouse.button = Mouse::Button::Left;
+  mouse.motion = Mouse::Motion::Pressed;
+  mouse.y = 0;
+  mouse.shift = false;
+  mouse.meta = false;
+  mouse.control = false;
+
+  mouse.x = 0;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 0;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 1;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 1;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 2;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 1u);
+
+  mouse.x = 2;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 1u);
+
+  mouse.x = 1;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 0u);
+
+  mouse.x = 4;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 2u);
+
+  mouse.x = 5;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 3u);
+
+  mouse.x = 6;
+  input->OnEvent(Event::Mouse("", mouse));
+  render();
+  EXPECT_EQ(option.cursor_position(), 4u);
+}
+
 // Copyright 2021 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.

--- a/src/ftxui/screen/string_test.cpp
+++ b/src/ftxui/screen/string_test.cpp
@@ -42,6 +42,85 @@ TEST(StringTest, Utf8ToGlyphs) {
   EXPECT_EQ(Utf8ToGlyphs("a\1a"), T({"a", "a"}));
 }
 
+TEST(StringTest, GlyphCount) {
+  // Basic:
+  EXPECT_EQ(GlyphCount(""), 0);
+  EXPECT_EQ(GlyphCount("a"), 1);
+  EXPECT_EQ(GlyphCount("ab"), 2);
+  // Fullwidth glyphs:
+  EXPECT_EQ(GlyphCount("测"), 1);
+  EXPECT_EQ(GlyphCount("测试"), 2);
+  // Combining characters:
+  EXPECT_EQ(GlyphCount("ā"), 1);
+  EXPECT_EQ(GlyphCount("a⃒"), 1);
+  EXPECT_EQ(GlyphCount("a̗"), 1);
+  // Control characters:
+  EXPECT_EQ(GlyphCount("\1"), 0);
+  EXPECT_EQ(GlyphCount("a\1a"), 2);
+}
+
+
+TEST(StringTest, GlyphPosition) {
+  // Basic:
+  EXPECT_EQ(GlyphPosition("", -1), 0);
+  EXPECT_EQ(GlyphPosition("", 0), 0);
+  EXPECT_EQ(GlyphPosition("", 1), 0);
+  EXPECT_EQ(GlyphPosition("a", 0), 0);
+  EXPECT_EQ(GlyphPosition("a", 1), 1);
+  EXPECT_EQ(GlyphPosition("ab", 0), 0);
+  EXPECT_EQ(GlyphPosition("ab", 1), 1);
+  EXPECT_EQ(GlyphPosition("ab", 2), 2);
+  EXPECT_EQ(GlyphPosition("abc", 0), 0);
+  EXPECT_EQ(GlyphPosition("abc", 1), 1);
+  EXPECT_EQ(GlyphPosition("abc", 2), 2);
+  EXPECT_EQ(GlyphPosition("abc", 3), 3);
+  // Fullwidth glyphs:
+  EXPECT_EQ(GlyphPosition("测", 0), 0);
+  EXPECT_EQ(GlyphPosition("测", 1), 3);
+  EXPECT_EQ(GlyphPosition("测试", 0), 0);
+  EXPECT_EQ(GlyphPosition("测试", 1), 3);
+  EXPECT_EQ(GlyphPosition("测试", 2), 6);
+  EXPECT_EQ(GlyphPosition("测试", 1, 3), 6);
+  EXPECT_EQ(GlyphPosition("测试", 1, 0), 3);
+  // Combining characters:
+  EXPECT_EQ(GlyphPosition("ā", 0), 0);
+  EXPECT_EQ(GlyphPosition("ā", 1), 3);
+  EXPECT_EQ(GlyphPosition("a⃒a̗ā", 0), 0);
+  EXPECT_EQ(GlyphPosition("a⃒a̗ā", 1), 4);
+  EXPECT_EQ(GlyphPosition("a⃒a̗ā", 2), 7);
+  EXPECT_EQ(GlyphPosition("a⃒a̗ā", 3), 10);
+  // Control characters:
+  EXPECT_EQ(GlyphPosition("\1", 0), 0);
+  EXPECT_EQ(GlyphPosition("\1", 1), 1);
+  EXPECT_EQ(GlyphPosition("a\1a", 0), 0);
+  EXPECT_EQ(GlyphPosition("a\1a", 1), 2);
+  EXPECT_EQ(GlyphPosition("a\1a", 2), 3);
+}
+
+TEST(StringTest, CellToGlyphIndex) {
+  // Basic:
+  auto basic = CellToGlyphIndex("abc");
+  ASSERT_EQ(basic.size(), 3);
+  EXPECT_EQ(basic[0], 0);
+  EXPECT_EQ(basic[1], 1);
+  EXPECT_EQ(basic[2], 2);
+
+  // Fullwidth glyphs:
+  auto fullwidth = CellToGlyphIndex("测试");
+  ASSERT_EQ(fullwidth.size(), 4);
+  EXPECT_EQ(fullwidth[0], 0);
+  EXPECT_EQ(fullwidth[1], 0);
+  EXPECT_EQ(fullwidth[2], 1);
+  EXPECT_EQ(fullwidth[3], 1);
+
+  // Combining characters:
+  auto combining = CellToGlyphIndex("a⃒a̗ā");
+  ASSERT_EQ(combining.size(), 3);
+  EXPECT_EQ(combining[0], 0);
+  EXPECT_EQ(combining[1], 1);
+  EXPECT_EQ(combining[2], 2);
+}
+
 // Copyright 2020 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.


### PR DESCRIPTION
Use std::string by default for the implementation of FTXUI's input
component.

Along the way:
- Give a correct implementation for fullwidth characters.
- Add tests
- Modify the way the cursor is drawn.