### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ A simple C++ library for terminal based user interface.
 - [Starter example project](https://github.com/ArthurSonzogni/ftxui-starter)
 - [Documentation](https://arthursonzogni.github.io/FTXUI/)
 - [Examples (WebAssembly)](https://arthursonzogni.com/FTXUI/examples/)
-- [Build using CMake](https://arthursonzogni.com/FTXUI/doc/#build-using-cmake)
-- [Build using nxxm](https://arthursonzogni.com/FTXUI/doc/#build-using-cmake)
+- [Build using CMake](https://github.com/ArthurSonzogni/FTXUI/blob/master/doc/mainpage.md#using-cmake)
 
 ## Short gallery
 


### PR DESCRIPTION
- [Build using nxxm] is same with [Build using CMake], just remove
- fix [Build using CMake] link