### PR TITLE
Replace std::clamp with util::clamp and reformat the code

### DIFF
--- a/examples/component/with_restored_io.cpp
+++ b/examples/component/with_restored_io.cpp
@@ -1,5 +1,13 @@
-#include "ftxui/component/component.hpp"           // for Menu
+#include <cstdlib>   // for system, EXIT_SUCCESS
+#include <iostream>  // for operator<<, basic_ostream, basic_ostream::operator<<, cout, endl, flush, ostream, basic_ostream<>::__ostream_type, cin
+#include <memory>    // for shared_ptr, __shared_ptr_access, allocator
+#include <string>    // for getline, string
+
+#include "ftxui/component/captured_mouse.hpp"  // for ftxui
+#include "ftxui/component/component.hpp"  // for Button, Horizontal, Renderer
+#include "ftxui/component/component_base.hpp"      // for ComponentBase
 #include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
+#include "ftxui/dom/elements.hpp"  // for operator|, filler, Element, borderEmpty, hbox, size, paragraph, vbox, LESS_THAN, border, center, HEIGHT, WIDTH
 
 int main() {
   using namespace ftxui;
@@ -10,14 +18,14 @@ int main() {
   // temporarily uninstall the terminal hook and execute the provided callback
   // function. This allow running the application in a non-interactive mode.
   auto btn_run = Button("Execute with restored IO", screen.WithRestoredIO([] {
-        std::system("bash");
+    std::system("bash");
     std::cout << "This is a child program using stdin/stdout." << std::endl;
     for (int i = 0; i < 10; ++i) {
       std::cout << "Please enter 10 strings (" << i << "/10)" << std::flush;
       std::string input;
       std::getline(std::cin, input);
     }
-        std::system("bash");
+    std::system("bash");
   }));
 
   auto btn_quit = Button("Quit", screen.ExitLoopClosure());

--- a/include/ftxui/dom/table.hpp
+++ b/include/ftxui/dom/table.hpp
@@ -5,7 +5,7 @@
 #include <string>  // for string
 #include <vector>  // for vector
 
-#include "ftxui/dom/elements.hpp"  // for BorderStyle, LIGHT, Element, Decorator
+#include "ftxui/dom/elements.hpp"  // for Element, BorderStyle, LIGHT, Decorator
 
 namespace ftxui {
 

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -35,8 +35,8 @@ class CheckboxBase : public ComponentBase {
     bool is_focused = Focused();
     bool is_active = Active();
     auto style = (is_focused || hovered_) ? option_->style_selected_focused
-                                          : is_active ? option_->style_selected
-                                                      : option_->style_normal;
+                 : is_active              ? option_->style_selected
+                                          : option_->style_normal;
     auto focus_management = is_focused ? focus : is_active ? select : nothing;
     return hbox({
                text(*state_ ? option_->style_checked

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -35,8 +35,8 @@ class CheckboxBase : public ComponentBase {
     bool is_focused = Focused();
     bool is_active = Active();
     auto style = (is_focused || hovered_) ? option_->style_selected_focused
-                 : is_active              ? option_->style_selected
-                                          : option_->style_normal;
+                                          : is_active ? option_->style_selected
+                                                      : option_->style_normal;
     auto focus_management = is_focused ? focus : is_active ? select : nothing;
     return hbox({
                text(*state_ ? option_->style_checked

--- a/src/ftxui/component/component_fuzzer.cpp
+++ b/src/ftxui/component/component_fuzzer.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <cassert>
+#include <iostream>
 #include <vector>
 #include "ftxui/component/component.hpp"
 #include "ftxui/component/terminal_input_parser.hpp"

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -1,5 +1,5 @@
 #include <stddef.h>    // for size_t
-#include <algorithm>   // for clamp, max, min
+#include <algorithm>   // for max, min
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, allocator
 #include <string>      // for string, wstring
@@ -17,6 +17,7 @@
 #include "ftxui/dom/elements.hpp"  // for operator|, text, Element, reflect, inverted, Decorator, flex, focus, hbox, size, bold, dim, frame, select, EQUAL, HEIGHT
 #include "ftxui/screen/box.hpp"    // for Box
 #include "ftxui/screen/string.hpp"  // for GlyphPosition, GlyphCount, to_string, CellToGlyphIndex, to_wstring
+#include "ftxui/screen/util.hpp"  // for clamp
 #include "ftxui/util/ref.hpp"  // for StringRef, Ref, WideStringRef, ConstStringRef
 
 namespace ftxui {
@@ -189,7 +190,7 @@ class InputBase : public ComponentBase {
 
     auto mapping = CellToGlyphIndex(*content_);
     int original_glyph = cursor_position();
-    original_glyph = std::clamp(original_glyph, 0, int(mapping.size()));
+    original_glyph = util::clamp(original_glyph, 0, int(mapping.size()));
     int original_cell = 0;
     for (size_t i = 0; i < mapping.size(); i++) {
       if (mapping[i] == original_glyph) {
@@ -202,7 +203,7 @@ class InputBase : public ComponentBase {
     int target_cell = original_cell + event.mouse().x - cursor_box_.x_min;
     int target_glyph = target_cell < (int)mapping.size() ? mapping[target_cell]
                                                          : (int)mapping.size();
-    target_glyph = std::clamp(target_glyph, 0, GlyphCount(*content_));
+    target_glyph = util::clamp(target_glyph, 0, GlyphCount(*content_));
     if (cursor_position() != target_glyph) {
       cursor_position() = target_glyph;
       option_->on_change();

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>   // for clamp, max
+#include <algorithm>   // for max
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, allocator_traits<>::value_type
 #include <string>      // for operator+, string
@@ -13,9 +13,9 @@
 #include "ftxui/component/mouse.hpp"  // for Mouse, Mouse::Left, Mouse::Released, Mouse::WheelDown, Mouse::WheelUp, Mouse::None
 #include "ftxui/component/screen_interactive.hpp"  // for Component
 #include "ftxui/dom/elements.hpp"  // for operator|, Element, reflect, text, nothing, select, vbox, Elements, focus
-#include "ftxui/screen/box.hpp"  // for Box
-#include "ftxui/screen/util.hpp"
-#include "ftxui/util/ref.hpp"  // for Ref, ConstStringListRef, ConstStringRef
+#include "ftxui/screen/box.hpp"   // for Box
+#include "ftxui/screen/util.hpp"  // for clamp
+#include "ftxui/util/ref.hpp"     // for Ref, ConstStringListRef, ConstStringRef
 
 namespace ftxui {
 

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -38,9 +38,8 @@ class MenuBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management = !is_selected      ? nothing
-                              : is_menu_focused ? focus
-                                                : select;
+      auto focus_management =
+          !is_selected ? nothing : is_menu_focused ? focus : select;
       auto icon = is_selected ? "> " : "  ";
       elements.push_back(text(icon + entries_[i]) | style | focus_management |
                          reflect(boxes_[i]));

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -38,8 +38,9 @@ class MenuBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management =
-          !is_selected ? nothing : is_menu_focused ? focus : select;
+      auto focus_management = !is_selected      ? nothing
+                              : is_menu_focused ? focus
+                                                : select;
       auto icon = is_selected ? "> " : "  ";
       elements.push_back(text(icon + entries_[i]) | style | focus_management |
                          reflect(boxes_[i]));

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -15,7 +15,7 @@
 #include "ftxui/dom/elements.hpp"  // for operator|, reflect, text, Element, hbox, vbox, Elements, focus, nothing, select
 #include "ftxui/screen/box.hpp"    // for Box
 #include "ftxui/screen/util.hpp"   // for clamp
-#include "ftxui/util/ref.hpp"  // for Ref, ConstStringListRef
+#include "ftxui/util/ref.hpp"      // for Ref, ConstStringListRef
 
 namespace ftxui {
 
@@ -53,9 +53,8 @@ class RadioboxBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management = !is_selected      ? nothing
-                              : is_menu_focused ? focus
-                                                : select;
+      auto focus_management =
+          !is_selected ? nothing : is_menu_focused ? focus : select;
 
       const std::string& symbol =
           *selected_ == i ? option_->style_checked : option_->style_unchecked;

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>   // for clamp, max
+#include <algorithm>   // for max
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, allocator_traits<>::value_type
 #include <string>      // for string
@@ -14,7 +14,7 @@
 #include "ftxui/component/screen_interactive.hpp"  // for Component
 #include "ftxui/dom/elements.hpp"  // for operator|, reflect, text, Element, hbox, vbox, Elements, focus, nothing, select
 #include "ftxui/screen/box.hpp"    // for Box
-#include "ftxui/screen/util.hpp"
+#include "ftxui/screen/util.hpp"   // for clamp
 #include "ftxui/util/ref.hpp"  // for Ref, ConstStringListRef
 
 namespace ftxui {

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -53,8 +53,9 @@ class RadioboxBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management =
-          !is_selected ? nothing : is_menu_focused ? focus : select;
+      auto focus_management = !is_selected      ? nothing
+                              : is_menu_focused ? focus
+                                                : select;
 
       const std::string& symbol =
           *selected_ == i ? option_->style_checked : option_->style_unchecked;

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -277,7 +277,6 @@ CapturedMouse ScreenInteractive::CaptureMouse() {
 }
 
 void ScreenInteractive::Loop(Component component) {
-
   // Suspend previously active screen:
   if (g_active_screen) {
     std::swap(suspended_screen_, g_active_screen);

--- a/src/ftxui/component/toggle.cpp
+++ b/src/ftxui/component/toggle.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>   // for clamp, max
+#include <algorithm>   // for max
 #include <functional>  // for function
 #include <memory>      // for shared_ptr, allocator_traits<>::value_type
 #include <utility>     // for move
@@ -12,8 +12,8 @@
 #include "ftxui/component/mouse.hpp"  // for Mouse, Mouse::Left, Mouse::Pressed
 #include "ftxui/dom/elements.hpp"  // for operator|, Element, Elements, hbox, reflect, separator, text, focus, nothing, select
 #include "ftxui/screen/box.hpp"    // for Box
-#include "ftxui/screen/util.hpp"
-#include "ftxui/util/ref.hpp"  // for Ref, ConstStringListRef
+#include "ftxui/screen/util.hpp"   // for clamp
+#include "ftxui/util/ref.hpp"      // for Ref, ConstStringListRef
 
 namespace ftxui {
 

--- a/src/ftxui/component/toggle.cpp
+++ b/src/ftxui/component/toggle.cpp
@@ -45,8 +45,9 @@ class ToggleBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management =
-          !is_selected ? nothing : is_toggle_focused ? focus : select;
+      auto focus_management = !is_selected        ? nothing
+                              : is_toggle_focused ? focus
+                                                  : select;
       children.push_back(text(entries_[i]) | style | focus_management |
                          reflect(boxes_[i]));
     }

--- a/src/ftxui/component/toggle.cpp
+++ b/src/ftxui/component/toggle.cpp
@@ -45,9 +45,8 @@ class ToggleBase : public ComponentBase {
                                              : option_->style_selected)
                                : (is_focused ? option_->style_focused
                                              : option_->style_normal);
-      auto focus_management = !is_selected        ? nothing
-                              : is_toggle_focused ? focus
-                                                  : select;
+      auto focus_management =
+          !is_selected ? nothing : is_toggle_focused ? focus : select;
       children.push_back(text(entries_[i]) | style | focus_management |
                          reflect(boxes_[i]));
     }

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -41,10 +41,10 @@ Table::Table() {
 
 Table::Table(std::vector<std::vector<std::string>> input) {
   std::vector<std::vector<Element>> output;
-  for(auto& row : input) {
+  for (auto& row : input) {
     output.push_back({});
     auto& output_row = output.back();
-    for(auto& cell : row) {
+    for (auto& cell : row) {
       output_row.push_back(text(cell));
     }
   }


### PR DESCRIPTION
I've gotten a build error complaining about there being no `clamp` identifier in `std` namespace.
Snooping around showed me that `std::clamp` caused some issues and was replaced. These two lines were left out, this should fix my build issues and clean up the removal of `std::clamp`.
Also, `clang-format`-ed the source.