### PR TITLE
allow passing move-only parameter to Make()

### DIFF
--- a/include/ftxui/component/component.hpp
+++ b/include/ftxui/component/component.hpp
@@ -23,7 +23,7 @@ struct MenuEntryOption;
 
 template <class T, class... Args>
 std::shared_ptr<T> Make(Args&&... args) {
-  return std::make_shared<T>(args...);
+  return std::make_shared<T>(std::forward<Args>(args)...);
 }
 
 namespace Container {

--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -27,7 +27,8 @@ template <typename T>
 class Ref {
  public:
   Ref() {}
-  Ref(T t) : owned_(t) {}
+  Ref(const T& t) : owned_(t) {}
+  Ref(T&& t) : owned_(std::forward<T>(t)) {}
   Ref(T* t) : address_(t) {}
   T& operator*() { return address_ ? *address_ : owned_; }
   T& operator()() { return address_ ? *address_ : owned_; }


### PR DESCRIPTION
ftxui::Ref<> is used for passing Options, for instance, MenuOption,
to the corresponding component which is supposed to hold a strong
reference of it. and we can observe the events sent to the component
by setting callback(s) in the option instance passed to the owner
component.

but the callback function is not always copyable, despite that it
might be moveable.

in this change,

* Make<>() is updated to use the perfect forwarding to avoid
  enforcing its parameters to be copyable.
* Ref<> is also updated to take a rvalue reference, so we can
  move away from the contructor parameter when creating an
  instance of Ref<>() from it.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>