### PR TITLE
windows.h defines DrawText and shadows the function Canvas.DrawText, …

### DIFF
--- a/include/ftxui/dom/canvas.hpp
+++ b/include/ftxui/dom/canvas.hpp
@@ -9,6 +9,12 @@
 #include "ftxui/screen/color.hpp"   // for Color
 #include "ftxui/screen/screen.hpp"  // for Pixel
 
+#ifdef DrawText
+// Workaround for WinUsr.h (via Windows.h) defining macros that break things.
+// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-drawtext
+#undef DrawText
+#endif
+
 namespace ftxui {
 
 struct Canvas {


### PR DESCRIPTION
Fix based on solution #70.