### PR TITLE
Table: reset dimensions.

### DIFF
--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -174,6 +174,8 @@ Element Table::Render() {
       it = std::move(it) | size(WIDTH, EQUAL, 0) | size(HEIGHT, EQUAL, 0);
     }
   }
+  dim_x_ = 0;
+  dim_y_ = 0;
   return gridbox(std::move(elements_));
 }
 


### PR DESCRIPTION
The table is not meant to be used to render more than once. Reset the
dimensions so that, even if it is used wrongly, this is not memory
unsafe.

This was raised by:
https://github.com/ArthurSonzogni/FTXUI/issues/381