### PR TITLE
Fix focus vs flexbox interaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 current (development) 
 ---------------------
 
+### DOM
+- Bugfix: Fix `focus`/`select` when the `vbox`/`hbox`/`dbox` contains a
+  `flexbox`
+
+### Screen
+- Feature: add `Box::Union(a,b) -> Box`
+
 3.0.0
 -----
 

--- a/include/ftxui/screen/box.hpp
+++ b/include/ftxui/screen/box.hpp
@@ -10,6 +10,7 @@ struct Box {
   int y_max = 0;
 
   static auto Intersection(Box a, Box b) -> Box;
+  static auto Union(Box a, Box b) -> Box;
   bool Contain(int x, int y) const;
   bool operator==(const Box& other) const;
   bool operator!=(const Box& other) const;

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -297,8 +297,9 @@ ScreenInteractive ScreenInteractive::FitComponent() {
 void ScreenInteractive::Post(Task task) {
   // Task/Events sent toward inactive screen or screen waiting to become
   // inactive are dropped.
-  if (!task_sender_)
+  if (!task_sender_) {
     return;
+  }
 
   task_sender_->Send(std::move(task));
 }

--- a/src/ftxui/dom/dbox.cpp
+++ b/src/ftxui/dom/dbox.cpp
@@ -21,6 +21,7 @@ class DBox : public Node {
     requirement_.flex_grow_y = 0;
     requirement_.flex_shrink_x = 0;
     requirement_.flex_shrink_y = 0;
+    requirement_.selection = Requirement::NORMAL;
     for (auto& child : children_) {
       child->ComputeRequirement();
       requirement_.min_x =

--- a/src/ftxui/dom/flexbox_test.cpp
+++ b/src/ftxui/dom/flexbox_test.cpp
@@ -432,6 +432,29 @@ TEST(FlexboxTest, GapY) {
             "       ");
 }
 
+TEST(FlexboxTest, Focus) {
+  auto document = vbox({
+    paragraph("0 -"),
+    paragraph("1 -"),
+    paragraph("2 -"),
+    paragraph("3 -"),
+    paragraph("4 -"),
+    paragraph("5 -"),
+    paragraph("6 -"),
+    paragraph("7 -") | focus,
+    paragraph("8 -"),
+    paragraph("9 -"),
+  }) | yframe | flex;
+
+  Screen screen(1, 3);
+  Render(screen, document);
+  EXPECT_EQ(screen.ToString(),
+            "7\r\n"
+            "-\r\n"
+            "8"
+            );
+}
+
 }  // namespace ftxui
 
 // Copyright 2021 Arthur Sonzogni. All rights reserved.

--- a/src/ftxui/dom/hbox.cpp
+++ b/src/ftxui/dom/hbox.cpp
@@ -23,6 +23,7 @@ class HBox : public Node {
     requirement_.flex_grow_y = 0;
     requirement_.flex_shrink_x = 0;
     requirement_.flex_shrink_y = 0;
+    requirement_.selection = Requirement::NORMAL;
     for (auto& child : children_) {
       child->ComputeRequirement();
       if (requirement_.selection < child->requirement().selection) {

--- a/src/ftxui/dom/vbox.cpp
+++ b/src/ftxui/dom/vbox.cpp
@@ -23,6 +23,7 @@ class VBox : public Node {
     requirement_.flex_grow_y = 0;
     requirement_.flex_shrink_x = 0;
     requirement_.flex_shrink_y = 0;
+    requirement_.selection = Requirement::NORMAL;
     for (auto& child : children_) {
       child->ComputeRequirement();
       if (requirement_.selection < child->requirement().selection) {

--- a/src/ftxui/screen/box.cpp
+++ b/src/ftxui/screen/box.cpp
@@ -15,6 +15,18 @@ Box Box::Intersection(Box a, Box b) {
   };
 }
 
+/// @return the smallest Box containing both |a| and |b|.
+/// @ingroup screen
+// static
+Box Box::Union(Box a, Box b) {
+  return Box{
+      std::min(a.x_min, b.x_min),
+      std::max(a.x_max, b.x_max),
+      std::min(a.y_min, b.y_min),
+      std::max(a.y_max, b.y_max),
+  };
+}
+
 /// @return whether (x,y) is contained inside the box.
 /// @ingroup screen
 bool Box::Contain(int x, int y) const {

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -20,8 +20,8 @@ namespace ftxui {
 
 namespace {
 
-bool g_cached = false;
-Terminal::Color g_cached_supported_color;
+bool g_cached = false;                     // NOLINT
+Terminal::Color g_cached_supported_color;  // NOLINT
 
 Dimensions& FallbackSize() {
 #if defined(__EMSCRIPTEN__)


### PR DESCRIPTION
- Fix focus in flexbox. This required resetting the focus state at the
  beginning of the ComputeRequirement(), because it can now run several
  times.

  This resolves:https://github.com/ArthurSonzogni/FTXUI/issues/399

- Add Box::Union.

- Add a preliminary implementation of forwarding selected_box from
  within the flexbox.