### PR TITLE
ci: use gcovr 5.0 temporarily

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
           ninja: true
           clangtidy: true
           cppcheck: false
-          gcovr: true
+          gcovr: "5.0"
           opencppcoverage: true
 
       # make sure coverage is only enabled for Debug builds, since it sets -O0


### PR DESCRIPTION
Related to https://github.com/aminya/setup-cpp/issues/86