### PR TITLE
Swap incorrect width/height mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ current (development)
 - Bugfix: Fix the selected/focused area. It used to be 1 cell larger/longer than
   requested
 - Bugfix: Forward the selected/focused area from the child in gridbox.
+- Bugfix: Fix incorrect Canvas computed dimensions.
 
 ### Screen
 - Feature: add `Box::Union(a,b) -> Box`

--- a/src/ftxui/dom/canvas.cpp
+++ b/src/ftxui/dom/canvas.cpp
@@ -871,8 +871,8 @@ Element canvas(int width, int height, std::function<void(Canvas&)> fn) {
     }
 
     void Render(Screen& screen) final {
-      int width = (box_.y_max - box_.y_min + 1) * 2;
-      int height = (box_.x_max - box_.x_min + 1) * 4;
+      int width = (box_.x_max - box_.x_min + 1) * 2;
+      int height = (box_.y_max - box_.y_min + 1) * 4;
       canvas_ = Canvas(width, height);
       fn_(canvas_);
       CanvasNodeBase::Render(screen);

--- a/src/ftxui/dom/canvas_test.cpp
+++ b/src/ftxui/dom/canvas_test.cpp
@@ -39,7 +39,7 @@ TEST(CanvasTest, GoldPoint) {
   });
   Screen screen(30, 10);
   Render(screen, element);
-  EXPECT_EQ(Hash(screen.ToString()), -1195891837);
+  EXPECT_EQ(Hash(screen.ToString()), 2143518726);
 }
 
 TEST(CanvasTest, GoldPointColor) {
@@ -54,7 +54,7 @@ TEST(CanvasTest, GoldPointColor) {
   });
   Screen screen(30, 10);
   Render(screen, element);
-  EXPECT_EQ(Hash(screen.ToString()), 1109533029);
+  EXPECT_EQ(Hash(screen.ToString()), 1264423298);
 }
 
 TEST(CanvasTest, GoldBlock) {
@@ -72,7 +72,7 @@ TEST(CanvasTest, GoldBlock) {
   });
   Screen screen(30, 10);
   Render(screen, element);
-  EXPECT_EQ(Hash(screen.ToString()), 817159424);
+  EXPECT_EQ(Hash(screen.ToString()), 3826174883);
 }
 
 TEST(CanvasTest, GoldBlockColor) {
@@ -87,7 +87,7 @@ TEST(CanvasTest, GoldBlockColor) {
   });
   Screen screen(30, 10);
   Render(screen, element);
-  EXPECT_EQ(Hash(screen.ToString()), 2869205941);
+  EXPECT_EQ(Hash(screen.ToString()), 3048712696);
 }
 
 TEST(CanvasTest, GoldText) {


### PR DESCRIPTION
width and height were being set using the incorrect axes resulting in incorrect canvas dimensions