### PR TITLE
Set includes as system interface to suppress warnings for other users

### DIFF
--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -13,9 +13,11 @@ function(ftxui_set_options library)
     set_target_properties(${library}
       PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-warnings-as-errors=*"
     )
-  endif()
 
-  if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}) # check if project is stand-alone
+    # By using "PUBLIC" as opposed to "SYSTEM INTERFACE", the compiler warning
+    # are enforced on the headers. This is behind "FTXUI_CLANG_TIDY", so that it
+    # applies only when developing FTXUI and on the CI. User's of the library
+    # get only the SYSTEM INTERFACE instead.
     target_include_directories(${library}
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -30,12 +32,9 @@ function(ftxui_set_options library)
   target_include_directories(${library}
     SYSTEM INTERFACE
       $<INSTALL_INTERFACE:include>
-  )
-
-  target_include_directories(${library}
     PRIVATE
-      include
-      src
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
 
   # C++17 is used. We require fold expression at least.

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -15,11 +15,26 @@ function(ftxui_set_options library)
     )
   endif()
 
+  if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}) # check if project is stand-alone
+    target_include_directories(${library}
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+  else()
+    target_include_directories(${library}
+      SYSTEM INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+  endif()
+
   target_include_directories(${library}
-    PUBLIC
+    SYSTEM INTERFACE
       $<INSTALL_INTERFACE:include>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+
+  target_include_directories(${library}
     PRIVATE
+      include
       src
   )
 

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -23,15 +23,18 @@ function(ftxui_set_options library)
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
   else()
-    target_include_directories(${library}
-      SYSTEM INTERFACE
+    target_include_directories(${library} SYSTEM
+      INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
   endif()
 
-  target_include_directories(${library}
-    SYSTEM INTERFACE
+  target_include_directories(${library} SYSTEM
+    INTERFACE
       $<INSTALL_INTERFACE:include>
+  )
+
+  target_include_directories(${library}
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Sets the include directories as `SYSTEM INTERFACE` for users of this library to suppress compiler warnings in these header files (from e.g. -Weffc++).

To ensure that compiler warnings always appear when the project is opened stand-alone, I included a small check on the project name. This is not a perfect solution. If users of this library use FetchContent before setting their own project name, they will still get compiler warnings. However, I think it's an improvement.

I checked that the compiler warnings disappear in my other project when I FetchContent my fork, and that I still get compiler warnings when opening the fork as a stand-alone project.