### PR TITLE
Avoid making new allocation to clear the screen.

### DIFF
--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -487,8 +487,11 @@ std::string Screen::ResetPosition(bool clear) const {
 
 /// @brief Clear all the pixel from the screen.
 void Screen::Clear() {
-  pixels_ = std::vector<std::vector<Pixel>>(dimy_,
-                                            std::vector<Pixel>(dimx_, Pixel()));
+  for (auto& line : pixels_) {
+    for (auto& cell : line) {
+      cell = Pixel();
+    }
+  }
   cursor_.x = dimx_ - 1;
   cursor_.y = dimy_ - 1;
 }


### PR DESCRIPTION
Previously, a new 2D vector was allocated for every new frame. This
caused a lot of temporary allocation to be made.

This patch modify "Screen::Clear" so that it do make a new allocation,
but clear the existing one instead.

Bug:https://github.com/ArthurSonzogni/FTXUI/issues/290#issuecomment-1153327251