### PR TITLE
Fix border charset array being to large

### DIFF
--- a/src/ftxui/dom/border.cpp
+++ b/src/ftxui/dom/border.cpp
@@ -14,7 +14,7 @@
 namespace ftxui {
 
 using Charset = std::array<std::string, 6>;  // NOLINT
-using Charsets = std::array<Charset, 6>;     // NOLINT
+using Charsets = std::array<Charset, 5>;     // NOLINT
 // NOLINTNEXTLINE
 static Charsets simple_border_charset = {
     Charset{"┌", "┐", "└", "┘", "─", "│"},

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -14,7 +14,7 @@ bool IsCell(int x, int y) {
 }
 
 // NOLINTNEXTLINE
-static std::string charset[6][6] = {
+static std::string charset[5][6] = {
     {"┌", "┐", "└", "┘", "─", "│"},  //
     {"┏", "┓", "┗", "┛", "━", "┃"},  //
     {"╔", "╗", "╚", "╝", "═", "║"},  //


### PR DESCRIPTION
This for some reason caused the clang compiler to crash, while also
being incorrect as the tables are actually only 5x6.

See the LLVM issue here:
https://github.com/llvm/llvm-project/issues/56016

This patch was suggested by @tbaederr