### PR TITLE
Fixes #441

### DIFF
--- a/src/ftxui/dom/canvas.cpp
+++ b/src/ftxui/dom/canvas.cpp
@@ -802,6 +802,7 @@ void Canvas::DrawText(int x,
                       const Stylizer& style) {
   for (const auto& it : Utf8ToGlyphs(value)) {
     if (!IsIn(x, y)) {
+      x += 2;
       continue;
     }
     Cell& cell = storage_[XY{x / 2, y / 4}];


### PR DESCRIPTION
Fix for Canvas::DrawText() draws nothing if the start coordinate is out of bounds.