### PR TITLE
Fixed dim and bold not mixing well

### DIFF
--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -55,21 +55,20 @@ void UpdatePixelStyle(std::stringstream& ss,
   if (next == previous) {
     return;
   }
+  
+  if ((!next.bold && previous.bold) ||
+      (!next.dim && previous.dim)) {
+    ss << "\x1B[22m";  // BOLD_RESET and DIM_RESET
+  }
 
-  if (next.bold && !previous.bold) {
+  if ((next.bold && !previous.bold) ||
+      (previous.bold && !next.dim && previous.dim)) {
     ss << "\x1B[1m";  // BOLD_SET
   }
 
-  if (!next.bold && previous.bold) {
-    ss << "\x1B[22m";  // BOLD_RESET
-  }
-
-  if (next.dim && !previous.dim) {
+  if ((next.dim && !previous.dim) ||
+      (previous.dim && !next.bold && previous.bold)) {
     ss << "\x1B[2m";  // DIM_SET
-  }
-
-  if (!next.dim && previous.dim) {
-    ss << "\x1B[22m";  // DIM_RESET
   }
 
   if (next.underlined && !previous.underlined) {

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -56,18 +56,21 @@ void UpdatePixelStyle(std::stringstream& ss,
     return;
   }
   
-  if ((!next.bold && previous.bold) ||
+  if ((!next.bold && previous.bold) ||  //
       (!next.dim && previous.dim)) {
     ss << "\x1B[22m";  // BOLD_RESET and DIM_RESET
+    // We might have wrongfully reset dim or bold because they share the same
+    // resetter. Take it into account so that the side effect will cause it to
+    // be set again below.
+    previous.bold = false;
+    previous.dim = false;
   }
 
-  if ((next.bold && !previous.bold) ||
-      (previous.bold && !next.dim && previous.dim)) {
+  if ((next.bold && !previous.bold)) {
     ss << "\x1B[1m";  // BOLD_SET
   }
 
-  if ((next.dim && !previous.dim) ||
-      (previous.dim && !next.bold && previous.bold)) {
+  if ((next.dim && !previous.dim)) {
     ss << "\x1B[2m";  // DIM_SET
   }
 

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -70,7 +70,7 @@ void UpdatePixelStyle(std::stringstream& ss,
     ss << "\x1B[1m";  // BOLD_SET
   }
 
-  if ((next.dim && !previous.dim)) {
+  if (next.dim && !previous.dim) {
     ss << "\x1B[2m";  // DIM_SET
   }
 

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -66,7 +66,7 @@ void UpdatePixelStyle(std::stringstream& ss,
     previous.dim = false;
   }
 
-  if ((next.bold && !previous.bold)) {
+  if (next.bold && !previous.bold) {
     ss << "\x1B[1m";  // BOLD_SET
   }
 


### PR DESCRIPTION
One single reset code controls both the dim and bold properties. Mixing both led to one of the properties being wrongly reset.