### PR TITLE
#487 Handled Space and Enter events for Radiobox

### DIFF
--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -103,8 +103,8 @@ class RadioboxBase : public ComponentBase {
 
     if (event == Event::Character(' ') || event == Event::Return) {
       *selected_ = hovered_;
-      //*selected_ = focused_entry();
       option_->on_change();
+      return true;
     }
 
     return false;

--- a/src/ftxui/component/radiobox_test.cpp
+++ b/src/ftxui/component/radiobox_test.cpp
@@ -11,139 +11,205 @@
 
 namespace ftxui {
 
-TEST(RadioboxTest, Navigation) {
+TEST(RadioboxTest, NavigationArrow) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
   auto radiobox = Radiobox(&entries, &selected);
 
-  // With arrow key.
+  // Down + Return
   EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
   EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
   EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
 
-  // With vim like characters.
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::Character('j'));
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::Character('j'));
-  radiobox->OnEvent(Event::Return);
+  // Up + Return
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
   EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::Character('j'));
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::Character('k'));
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
   EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::Character('k'));
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::Character('k'));
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
-
-  // With more entries
-  entries = {"1", "2", "3"};
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
   EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
   EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::ArrowUp);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowUp));
   EXPECT_EQ(selected, 0);
-
-  // With tab.
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
   EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::Tab);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::Tab);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::Tab);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::Tab);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::Tab);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::TabReverse);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::TabReverse);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 0);
-  radiobox->OnEvent(Event::TabReverse);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 2);
-  radiobox->OnEvent(Event::TabReverse);
-  radiobox->OnEvent(Event::Return);
-  EXPECT_EQ(selected, 1);
-  radiobox->OnEvent(Event::TabReverse);
-  radiobox->OnEvent(Event::Return);
 }
 
-TEST(RadioboxTest, EventHandling) {
+TEST(RadioboxTest, NavigationArrowVim) {
   int selected = 0;
-  std::vector<std::string> entries = {"1", "2"};
+  std::vector<std::string> entries = {"1", "2", "3"};
   auto radiobox = Radiobox(&entries, &selected);
-  ASSERT_EQ(selected, 0);
 
-  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
-  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowDown))
-      << "Should not handle ArrowDown when we are on last item";
-  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
-  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowUp))
-      << "Should not handle ArrowUp when we are on first item";
-
-  EXPECT_TRUE(radiobox->OnEvent(Event::End));
-  EXPECT_FALSE(radiobox->OnEvent(Event::End))
-      << "Should not handle End when we are on last item";
-  EXPECT_TRUE(radiobox->OnEvent(Event::Home));
-  EXPECT_FALSE(radiobox->OnEvent(Event::Home))
-      << "Should not handle Home when we are on first item";
-
-  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
-  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')));
-  ASSERT_EQ(selected, 1);
-  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')))
-      << "Should handle Space even when focused item is already selected";
-
-  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
+  // J + Return
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character('j')));
+  EXPECT_EQ(selected, 0);
   EXPECT_TRUE(radiobox->OnEvent(Event::Return));
-  ASSERT_EQ(selected, 0);
-  EXPECT_TRUE(radiobox->OnEvent(Event::Return))
-      << "Should handle Return even when focused item is already selected";
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character('j')));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_FALSE(radiobox->OnEvent(Event::Character('j')));
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+
+  // K + Return
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character('k')));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character('k')));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+  EXPECT_FALSE(radiobox->OnEvent(Event::Character('k')));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+}
+
+TEST(RadioboxTest, NavigationTab) {
+  int selected = 0;
+  std::vector<std::string> entries = {"1", "2", "3"};
+  auto radiobox = Radiobox(&entries, &selected);
+
+  // Tab + Return
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Tab));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Tab));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Tab));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Tab));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Tab));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+
+  // TabReverse + Return
+  EXPECT_TRUE(radiobox->OnEvent(Event::TabReverse));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::TabReverse));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::TabReverse));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::TabReverse));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::TabReverse));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+}
+
+TEST(RadioboxTest, NavigationHome) {
+  int selected = 0;
+  std::vector<std::string> entries = {"1", "2", "3"};
+  auto radiobox = Radiobox(&entries, &selected);
+
+  selected = 0;
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home));
+  EXPECT_EQ(selected, 0);
+
+  selected = 1;
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+
+  selected = 2;
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 0);
+}
+
+TEST(RadioboxTest, NavigationEnd) {
+  int selected = 0;
+  std::vector<std::string> entries = {"1", "2", "3"};
+  auto radiobox = Radiobox(&entries, &selected);
+
+  selected = 0;
+  EXPECT_TRUE(radiobox->OnEvent(Event::End));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_FALSE(radiobox->OnEvent(Event::End));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+
+  selected = 1;
+  EXPECT_FALSE(radiobox->OnEvent(Event::End));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+  EXPECT_FALSE(radiobox->OnEvent(Event::End));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+
+  selected = 2;
+  EXPECT_FALSE(radiobox->OnEvent(Event::End));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  EXPECT_EQ(selected, 2);
+}
+
+TEST(RadioboxTest, EventSpace) {
+  int selected = 0;
+  std::vector<std::string> entries = {"1", "2", "3"};
+  auto radiobox = Radiobox(&entries, &selected);
+
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')));
+  EXPECT_EQ(selected, 2);
+  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_EQ(selected, 2);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')));
+  EXPECT_EQ(selected, 2);
 }
 
 TEST(RadioboxTest, RemoveEntries) {
@@ -157,9 +223,9 @@ TEST(RadioboxTest, RemoveEntries) {
   EXPECT_EQ(selected, 0);
   EXPECT_EQ(focused_entry, 0);
 
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::ArrowDown);
-  radiobox->OnEvent(Event::Return);
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
 
   EXPECT_EQ(selected, 2);
   EXPECT_EQ(focused_entry, 2);

--- a/src/ftxui/component/radiobox_test.cpp
+++ b/src/ftxui/component/radiobox_test.cpp
@@ -113,6 +113,39 @@ TEST(RadioboxTest, Navigation) {
   radiobox->OnEvent(Event::Return);
 }
 
+TEST(RadioboxTest, EventHandling) {
+  int selected = 0;
+  std::vector<std::string> entries = {"1", "2"};
+  auto radiobox = Radiobox(&entries, &selected);
+  ASSERT_EQ(selected, 0);
+
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowDown))
+      << "Should not handle ArrowDown when we are on last item";
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
+  EXPECT_FALSE(radiobox->OnEvent(Event::ArrowUp))
+      << "Should not handle ArrowUp when we are on first item";
+
+  EXPECT_TRUE(radiobox->OnEvent(Event::End));
+  EXPECT_FALSE(radiobox->OnEvent(Event::End))
+      << "Should not handle End when we are on last item";
+  EXPECT_TRUE(radiobox->OnEvent(Event::Home));
+  EXPECT_FALSE(radiobox->OnEvent(Event::Home))
+      << "Should not handle Home when we are on first item";
+
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowDown));
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')));
+  ASSERT_EQ(selected, 1);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Character(' ')))
+      << "Should handle Space even when focused item is already selected";
+
+  EXPECT_TRUE(radiobox->OnEvent(Event::ArrowUp));
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return));
+  ASSERT_EQ(selected, 0);
+  EXPECT_TRUE(radiobox->OnEvent(Event::Return))
+      << "Should handle Return even when focused item is already selected";
+}
+
 TEST(RadioboxTest, RemoveEntries) {
   int focused_entry = 0;
   int selected = 0;


### PR DESCRIPTION
Handled Space and Enter events for Radiobox, added tests for other event handling in radiobox. 
Is there any easy way to initialize `RadioboxBase::box_ ` in testing context? It is required to test PageUp, PageDown, Tab and TabReverse events.