### PR TITLE
Fix std::ignore is in <tuple>.

### DIFF
--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>  // for uint32_t, uint8_t
 #include <locale>   // for wstring_convert
 #include <string>   // for string, basic_string, wstring
+#include <tuple>    // for std::ignore
 
 #include "ftxui/screen/deprecated.hpp"  // for wchar_width, wstring_width
 


### PR DESCRIPTION
I could not build the library because std::ignore was not found.
https://en.cppreference.com/w/cpp/utility/tuple/ignore
Its in the \<tuple\> header. I added the include.