### PR TITLE
Improve UNIX signal handling of SIGWINCH

### DIFF
--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -66,6 +66,7 @@ class ScreenInteractive : public Screen {
 
   void HandleTask(Component component, Task& task);
   void Draw(Component component);
+  void ResetCursorPosition();
 
   void Signal(int signal);
 

--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -65,7 +65,7 @@ class ScreenInteractive : public Screen {
   void HandleTask(Component component, Task& task);
   void Draw(Component component);
 
-  void SigStop();
+  void Signal(int signal);
 
   ScreenInteractive* suspended_screen_ = nullptr;
   enum class Dimension {
@@ -106,7 +106,7 @@ class ScreenInteractive : public Screen {
  public:
   class Private {
    public:
-    static void SigStop(ScreenInteractive& s) { return s.SigStop(); }
+    static void Signal(ScreenInteractive& s, int signal) { s.Signal(signal); }
   };
   friend Private;
 };

--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -52,6 +52,8 @@ class ScreenInteractive : public Screen {
   Closure WithRestoredIO(Closure);
 
  private:
+  void ExitNow();
+
   void Install();
   void Uninstall();
 


### PR DESCRIPTION
There exists a possibility of a signal occurring during a Receiver::Receive(), while a lock is held on its mutex.  The lock is not released during the signal handler.  If we then redraw the screen inside the signal handler via the same Sender, then we try to acquire a lock on that same mutex, which effectively halts the program.

Let's move the code from inside the signal handler to outside of it.  A simple boolean flag should be fine.  We can then check for this flag in the ScreenInteractive's EventListener and perform the action there.

NOTE: The only reason this was noticed is because I changed my project's use of FTXUI from muti-threaded to a single-threaded, custom event loop.  Windows hasn't shown me this issue.