### PR TITLE
Fix punctuation that affects compilation

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -243,7 +243,7 @@ void InstallSignalHandler(int sig) {
   auto old_signal_handler = std::signal(sig, RecordSignal);
   on_exit_functions.push(
       [=] { std::ignore = std::signal(sig, old_signal_handler); });
-};
+}
 
 const std::string CSI = "\x1b[";  // NOLINT
 


### PR DESCRIPTION
hi, When I compile your project, the following error has occurred
```
/home/beiklive/SDA/WorkSpace/FileStore/GitPro/FTXUI/src/ftxui/component/screen_interactive.cpp:246:2: error: extra ‘;’ [-Werror=pedantic]
  246 | };
      |  ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/component.dir/build.make:310: CMakeFiles/component.dir/src/ftxui/component/screen_interactive.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:301: CMakeFiles/component.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```
So I removed this ';'
