### PR TITLE
Fix Windows UTF16 char.

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -26,6 +26,7 @@
 #include "ftxui/component/terminal_input_parser.hpp"  // for TerminalInputParser
 #include "ftxui/dom/node.hpp"                         // for Node, Render
 #include "ftxui/dom/requirement.hpp"                  // for Requirement
+#include "ftxui/screen/string.hpp"
 #include "ftxui/screen/terminal.hpp"                  // for Size, Dimensions
 
 #if defined(_WIN32)
@@ -104,7 +105,11 @@ void EventListener(std::atomic<bool>* quit, Sender<Task> out) {
           // ignore UP key events
           if (key_event.bKeyDown == FALSE)
             continue;
-          parser.Add((char)key_event.uChar.UnicodeChar);
+          std::wstring wstring;
+          wstring += key_event.uChar.UnicodeChar;
+          for(auto it : to_string(wstring)) {
+            parser.Add(it);
+          }
         } break;
         case WINDOW_BUFFER_SIZE_EVENT:
           out->Send(Event::Special({0}));


### PR DESCRIPTION
Windows output UTF16 unicode char, but FTXUI works using UTF8. Do the conversion.

This resolves:
https://github.com/ArthurSonzogni/FTXUI/issues/495