### PR TITLE
Fix crash on empty tab container

### DIFF
--- a/src/ftxui/component/container.cpp
+++ b/src/ftxui/component/container.cpp
@@ -229,7 +229,7 @@ class TabContainer : public ContainerBase {
   }
 
   bool OnMouseEvent(Event event) override {
-    return ActiveChild()->OnEvent(event);
+    return ActiveChild() && ActiveChild()->OnEvent(event);
   }
 };
 


### PR DESCRIPTION
This PR fixes a crash when a tab container is created with empty children. All other member functions already guard for this special case, but `OnMouseEvent` did not.
