### PR TITLE
Readme.md: change vcpk.info to vcpkgx.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ endif()
 ```
 
 If you don't, the following packages have been created:
-- [vcpkg](https://vcpkg.info/port/ftxui)
+- [vcpkg](https://vcpkgx.com/details.html?package=ftxui)
 - [Arch Linux PKGBUILD](https://aur.archlinux.org/packages/ftxui-git/).
 - [conan.io](https://conan.io/center/ftxui)
 


### PR DESCRIPTION
The vcpkg.info site is now defunct.
[vcpkgx.com](https://github.com/vcpkgx/vcpkgx.github.io) provides a similar if not identical service to what vcpkg.info used to provide.