### PR TITLE
Doc: Fix @params vs @param

### DIFF
--- a/src/ftxui/component/collapsible.cpp
+++ b/src/ftxui/component/collapsible.cpp
@@ -12,9 +12,9 @@ namespace ftxui {
 
 /// @brief A collapsible component. It display a checkbox with an arrow. Once
 /// activated, the children is displayed.
-/// @params label The label of the checkbox.
-/// @params child The children to display.
-/// @params show Hold the state about whether the children is displayed or not.
+/// @param label The label of the checkbox.
+/// @param child The children to display.
+/// @param show Hold the state about whether the children is displayed or not.
 ///
 /// ### Example
 /// ```cpp

--- a/src/ftxui/component/maybe.cpp
+++ b/src/ftxui/component/maybe.cpp
@@ -37,7 +37,7 @@ Component Maybe(Component child, std::function<bool()> show) {
 
 /// @brief Decorate a component. It is shown only when the |show| function
 /// returns true.
-/// @params show a function returning whether the decoratorated component should
+/// @param show a function returning whether the decoratorated component should
 /// be shown.
 /// @ingroup component
 ///
@@ -54,8 +54,8 @@ ComponentDecorator Maybe(std::function<bool()> show) {
 }
 
 /// @brief Decorate a component |child|. It is shown only when |show| is true.
-/// @params child the compoennt to decorate.
-/// @params show a boolean. |child| is shown when |show| is true.
+/// @param child the compoennt to decorate.
+/// @param show a boolean. |child| is shown when |show| is true.
 /// @ingroup component
 ///
 /// ### Example
@@ -69,7 +69,7 @@ Component Maybe(Component child, const bool* show) {
 }
 
 /// @brief Decorate a component. It is shown only when |show| is true.
-/// @params show a boolean. |child| is shown when |show| is true.
+/// @param show a boolean. |child| is shown when |show| is true.
 /// @ingroup component
 ///
 /// ### Example


### PR DESCRIPTION
Fixed wrong parameter documentation name.

Taken out of:
https://github.com/ArthurSonzogni/FTXUI/pull/600