### PR TITLE
Use globally set CMAKE_CXX_STANDARD, if it is set

### DIFF
--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -43,9 +43,17 @@ function(ftxui_set_options library)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
 
+  # Play nicely if we are being consumed by another project
+  # and use their CMAKE_CXX_STANDARD. Otherwise, fall back to 17
   # C++17 is used. We require fold expression at least.
+  if (DEFINED CMAKE_CXX_STANDARD)
+    set(CXX_STANDARD ${CMAKE_CXX_STANDARD})
+  else()
+    set(CXX_STANDARD 17)
+  endif()
+  
   set_target_properties(${library} PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD ${CXX_STANDARD}
     CXX_EXTENSIONS OFF
   )
 


### PR DESCRIPTION
This makes FTXUI a better citizen for things like CPM, so that you can have consistent c++ standards settings across your dependencies.