### PR TITLE
Delete copy constructor and copy operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ current (development)
 - Feature: Support `ResizableSplit` with customizable separator.
 - Breaking: MenuDirection enum is renamed Direction
 - Fix: Remove useless new line when using an alternative screen.
+- Breaking/Fix: Remove `ComponentBase` copy constructor/assignment.
 
 ### Dom
 - Feature: Add the dashed style for border and separator.

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -29,6 +29,12 @@ class ComponentBase {
   // virtual Destructor.
   virtual ~ComponentBase();
 
+  ComponentBase() = default;
+
+  // Deleted methods
+  ComponentBase(const ComponentBase&) = delete;
+  void operator =(const ComponentBase&) = delete;
+
   // Component hierarchy:
   ComponentBase* Parent() const;
   Component& ChildAt(size_t i);

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -31,9 +31,9 @@ class ComponentBase {
 
   ComponentBase() = default;
 
-  // Deleted methods
+  // A component is not copiable.
   ComponentBase(const ComponentBase&) = delete;
-  void operator =(const ComponentBase&) = delete;
+  void operator=(const ComponentBase&) = delete;
 
   // Component hierarchy:
   ComponentBase* Parent() const;


### PR DESCRIPTION
Delete copy constructor and copy operator to prevent odd behavior during object deletion. #637 