### PR TITLE
Add pkg-config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.11)
 project(ftxui
   LANGUAGES CXX
   VERSION 4.0.0
+  DESCRIPTION "C++ Functional Terminal User Interface."
 )
 
 option(FTXUI_BUILD_DOCS "Set to ON to build docs" ON)

--- a/cmake/ftxui_install.cmake
+++ b/cmake/ftxui_install.cmake
@@ -11,6 +11,7 @@ install(TARGETS screen dom component
 
 install(DIRECTORY include/ftxui DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+# CMake package configuration for easy use of library in CMake
 include(CMakePackageConfigHelpers)
 configure_package_config_file(ftxui-config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/ftxui-config.cmake
@@ -30,4 +31,13 @@ install(EXPORT ftxui-export
   FILE ftxui-config-version.cmake
   NAMESPACE ftxui::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ftxui
+)
+
+# pkg-config file for easy use of library in build systems other than CMake
+configure_file(ftxui.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ftxui.pc
+  @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ftxui.pc
+  DESTINATION lib/pkgconfig
 )

--- a/ftxui.pc.in
+++ b/ftxui.pc.in
@@ -1,0 +1,9 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
+includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lftxui-component -lftxui-dom -lftxui-screen


### PR DESCRIPTION
This file describes the include and lib location and makes it possible to use the library in build systems other than CMake, e.g. in basic Makefiles.