### PR TITLE
Fix MSVC possible loss of data warning

### DIFF
--- a/src/ftxui/dom/linear_gradient.cpp
+++ b/src/ftxui/dom/linear_gradient.cpp
@@ -32,7 +32,7 @@ LinearGradientNormalized Normalize(LinearGradient gradient) {
 
   // Fill in the two extent, if not provided.
   if (!gradient.stops.front().position) {
-    gradient.stops.front().position = 0;
+    gradient.stops.front().position = 0.f;
   }
   if (!gradient.stops.back().position) {
     gradient.stops.back().position = 1.f;


### PR DESCRIPTION
    warning C4244: '=': conversion from '_Ty' to 'float', possible loss
    of data

Looks like the rest of the file already writes "0" like this when assigning to LinearGradient types, so probably just an oversight.