### PR TITLE
CMake: use compile_features to set min C++ standard

### DIFF
--- a/cmake/ftxui_fuzzer.cmake
+++ b/cmake/ftxui_fuzzer.cmake
@@ -14,10 +14,7 @@ function(fuzz source)
   target_link_libraries(${name} PRIVATE component)
   target_compile_options(${name} PRIVATE -fsanitize=fuzzer,address)
   target_link_libraries(${name} PRIVATE -fsanitize=fuzzer,address)
-  set_target_properties(${name} PROPERTIES
-    CXX_STANDARD 20
-    CXX_EXTENSIONS OFF
-  )
+  target_compile_features(${name} PRIVATE cxx_std_17)
 endfunction(fuzz)
 
 fuzz(terminal_input_parser_test_fuzzer)

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -43,19 +43,7 @@ function(ftxui_set_options library)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
 
-  # Play nicely if we are being consumed by another project
-  # and use their CMAKE_CXX_STANDARD. Otherwise, fall back to 17
-  # C++17 is used. We require fold expression at least.
-  if (DEFINED CMAKE_CXX_STANDARD)
-    set(CXX_STANDARD ${CMAKE_CXX_STANDARD})
-  else()
-    set(CXX_STANDARD 17)
-  endif()
-  
-  set_target_properties(${library} PROPERTIES
-    CXX_STANDARD ${CXX_STANDARD}
-    CXX_EXTENSIONS OFF
-  )
+  target_compile_features(${library} PUBLIC cxx_std_17)
 
   # Force Microsoft Visual Studio to decode sources files in UTF-8. This applies
   # to the library and the library users.

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -57,10 +57,7 @@ target_link_libraries(ftxui-tests
 target_include_directories(ftxui-tests
   PRIVATE src
 )
-set_target_properties(ftxui-tests PROPERTIES
-  CXX_STANDARD 20
-  CXX_EXTENSIONS OFF
-)
+target_compile_features(ftxui-tests PRIVATE cxx_std_17)
 
 if (FTXUI_MICROSOFT_TERMINAL_FALLBACK)
   target_compile_definitions(ftxui-tests

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -57,7 +57,7 @@ target_link_libraries(ftxui-tests
 target_include_directories(ftxui-tests
   PRIVATE src
 )
-target_compile_features(ftxui-tests PRIVATE cxx_std_17)
+target_compile_features(ftxui-tests PRIVATE cxx_std_20)
 
 if (FTXUI_MICROSOFT_TERMINAL_FALLBACK)
   target_compile_definitions(ftxui-tests

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,9 +8,7 @@ function(example name)
   target_link_libraries(ftxui_example_${name} PUBLIC ${DIRECTORY_LIB})
   file(RELATIVE_PATH dir ${EXAMPLES_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
   set_property(GLOBAL APPEND PROPERTY FTXUI::EXAMPLES ${dir}/${name})
-  set_target_properties(ftxui_example_${name} PROPERTIES
-    CXX_STANDARD 17
-  )
+  target_compile_features(ftxui_example_${name} PRIVATE cxx_std_17)
 endfunction(example)
 
 add_subdirectory(component)


### PR DESCRIPTION
As pointed out in https://github.com/ArthurSonzogni/FTXUI/pull/620#issuecomment-1555930977, compile_features is the proper way to set min C++ standard in CML of a project, specially for libraries.
Moreover compile features are propagated to CMake config file, unlike CXX_STANDARD property.

If needed, it can be overridden externally by users with CMAKE_CXX_STANDARD, which has precedence over compile feature.

I don't know exactly what is the minimum C++ standard of FTXUI libraries, tests, examples etc. There was CMAKE_CXX_STANDARD 20 for tests and fuzzers, and 17 for libraries and examples. I've assumed C++17 was the minimum standard of all targets, and I've set cxx_std_17 to all libraries and executables.