### PR TITLE
Fix typo in 'codepoints' on line 21 of screen.hpp

### DIFF
--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -18,7 +18,7 @@ struct Pixel {
   bool operator==(const Pixel& other) const;
 
   // The graphemes stored into the pixel. To support combining characters,
-  // like: a⃦, this can potentially contains multiple codepoitns.
+  // like: a⃦, this can potentially contain multiple codepoints.
   std::string character = " ";
 
   // The hyperlink associated with the pixel.


### PR DESCRIPTION
This pull request changes the word 'codepoitns' to 'codepoints' on line 21 of screen.hpp.