### PR TITLE
Problem: components can't distinguish custom events

### DIFF
--- a/include/ftxui/component/event.hpp
+++ b/include/ftxui/component/event.hpp
@@ -31,6 +31,7 @@ struct Event {
   static Event Special(std::string);
   static Event Mouse(std::string, Mouse mouse);
   static Event CursorReporting(std::string, int x, int y);
+  static Event CustomTagged(int tag);
 
   // --- Arrow ---
   static const Event ArrowLeft;
@@ -74,8 +75,13 @@ struct Event {
 
   const std::string& input() const { return input_; }
 
-  bool operator==(const Event& other) const { return input_ == other.input_; }
+  bool operator==(const Event& other) const {
+    return type_ == Type::Custom && other.type_ == Type::Custom ? data_.custom_tag == other.data_.custom_tag : input_ == other.input_;
+  }
   bool operator!=(const Event& other) const { return !operator==(other); }
+
+  int is_custom(int tag) const { return type_ == Type::Custom && data_.custom_tag == tag; }
+  int is_custom() const { return type_ == Type::Custom; }
 
   //--- State section ----------------------------------------------------------
   ScreenInteractive* screen_ = nullptr;
@@ -88,6 +94,7 @@ struct Event {
     Character,
     Mouse,
     CursorReporting,
+    Custom,
   };
   Type type_ = Type::Unknown;
 
@@ -99,6 +106,7 @@ struct Event {
   union {
     struct Mouse mouse;
     struct Cursor cursor;
+    int custom_tag;
   } data_ = {};
 
   std::string input_;

--- a/src/ftxui/component/event.cpp
+++ b/src/ftxui/component/event.cpp
@@ -49,6 +49,15 @@ Event Event::CursorReporting(std::string input, int x, int y) {
   return event;
 }
 
+// static
+Event Event::CustomTagged(int tag) {
+  Event event;
+  event.type_ = Type::Custom;
+  event.data_.custom_tag = tag;
+  return event;
+}
+
+
 // --- Arrow ---
 const Event Event::ArrowLeft = Event::Special("\x1B[D");          // NOLINT
 const Event Event::ArrowRight = Event::Special("\x1B[C");         // NOLINT


### PR DESCRIPTION
They all look the same, which means they would have to check or poll all potential sources of change.

Solution: make custom events take an integer tag

I've kept the backwards compatibility by using `-1` for the default custom event (`Event::Custom`).

---

Discussion: https://github.com/ArthurSonzogni/FTXUI/discussions/676