### PR TITLE
Remove Ref<XxxOption> and add new interfaces.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
 ---
 Checks: "*,
+        -*-magic-numbers,
         -*-narrowing-conversions
+        -*-unnecessary-value-param,
         -*-uppercase-literal-suffix,
         -abseil-*,
         -altera-*,
@@ -9,6 +11,7 @@ Checks: "*,
         -cppcoreguidelines-non-private-member-variables-in-classes,
         -fuchsia-*,
         -google-*,
+        -hicpp-signed-bitwise,
         -llvm*,
         -misc-no-recursion,
         -misc-non-private-member-variables-in-classes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,23 @@ current (development)
 - Breaking: GaugeDirection enum is renamed Direction
 - Breaking: Direction enum is renamed WidthOrHeight
 - Breaking: Remove `ComponentBase` copy constructor/assignment.
+- Breaking: MenuOption::entries is renamed MenuOption::entries_option.
+- Breaking: Ref<XxxOption> becomes XxxOption in component constructors.
 - Feature: `ResizeableSplit` now support arbitrary element as a separator.
 - Feature: `input` is now supporting multiple lines.
 - Feature: `input` style is now customizeable.
 - Bugfix: Support F1-F5 from OS terminal.
+- Feature: Add struct based constructor:
+  ```cpp
+  Component Button(ButtonOption options);
+  Component Checkbox(CheckboxOption options);
+  Component Input(InputOption options);
+  Component Menu(MenuOption options);
+  Component MenuEntry(MenuEntryOption options);
+  Component Radiobox(RadioboxOption options);
+  Component Slider(SliderOption<T> options);
+  Component ResizableSplit(ResizableSplitOption options);
+  ```
 
 ### Dom
 - Feature: Add `hyperlink` decorator. For instance:

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -69,4 +69,6 @@ gtest_discover_tests(ftxui-tests
   DISCOVERY_TIMEOUT 600
 )
 
-set(CMAKE_CTEST_ARGUMENTS "--rerun-failed --output-on-failure")
+#set(CMAKE_CTEST_ARGUMENTS "--rerun-failed --output-on-failure")
+#set_tests_properties(gen_init_queries PROPERTIES FIXTURES_SETUP f_init_queries)
+#set_tests_properties(test PROPERTIES  FIXTURES_REQUIRED f_init_queries)

--- a/examples/component/button_in_frame.cpp
+++ b/examples/component/button_in_frame.cpp
@@ -15,13 +15,12 @@ int main() {
   int counter = 0;
   auto on_click = [&] { counter++; };
 
-  auto button_style = ButtonOption::Animated(Color::Default, Color::GrayDark,
-                                             Color::Default, Color::White);
+  auto style = ButtonOption::Animated(Color::Default, Color::GrayDark,
+                                      Color::Default, Color::White);
 
   auto container = Container::Vertical({});
   for (int i = 0; i < 30; ++i) {
-    auto button =
-        Button("Button " + std::to_string(i), on_click, &button_style);
+    auto button = Button("Button " + std::to_string(i), on_click, style);
     container->Add(button);
   }
 

--- a/examples/component/menu.cpp
+++ b/examples/component/menu.cpp
@@ -21,7 +21,7 @@ int main() {
 
   MenuOption option;
   option.on_enter = screen.ExitLoopClosure();
-  auto menu = Menu(&entries, &selected, &option);
+  auto menu = Menu(&entries, &selected, option);
 
   screen.Loop(menu);
 

--- a/examples/component/menu2.cpp
+++ b/examples/component/menu2.cpp
@@ -27,9 +27,9 @@ int main() {
   int left_menu_selected = 0;
   int right_menu_selected = 0;
   Component left_menu_ =
-      Menu(&left_menu_entries, &left_menu_selected, &menu_option);
+      Menu(&left_menu_entries, &left_menu_selected, menu_option);
   Component right_menu_ =
-      Menu(&right_menu_entries, &right_menu_selected, &menu_option);
+      Menu(&right_menu_entries, &right_menu_selected, menu_option);
 
   Component container = Container::Horizontal({
       left_menu_,

--- a/examples/component/menu_style.cpp
+++ b/examples/component/menu_style.cpp
@@ -212,8 +212,8 @@ Component VMenu7(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu8(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries_option.animated_colors.foreground.Set(Color::Red, Color::White,
-                                                std::chrono::milliseconds(500));
+  option.entries_option.animated_colors.foreground.Set(
+      Color::Red, Color::White, std::chrono::milliseconds(500));
   return Menu(entries, selected, option);
 }
 

--- a/examples/component/menu_style.cpp
+++ b/examples/component/menu_style.cpp
@@ -110,7 +110,7 @@ int main() {
 
 Component VMenu1(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     state.label = (state.active ? "> " : "  ") + state.label;
     Element e = text(state.label);
     if (state.focused)
@@ -124,7 +124,7 @@ Component VMenu1(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu2(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     state.label += (state.active ? " <" : "  ");
     Element e = hbox(filler(), text(state.label));
     if (state.focused)
@@ -138,7 +138,7 @@ Component VMenu2(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu3(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     Element e = state.active ? text("[" + state.label + "]")
                              : text(" " + state.label + " ");
     if (state.focused)
@@ -155,7 +155,7 @@ Component VMenu3(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu4(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     if (state.active && state.focused) {
       return text(state.label) | color(Color::Yellow) | bgcolor(Color::Black) |
              bold;
@@ -175,7 +175,7 @@ Component VMenu4(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu5(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     auto element = text(state.label);
     if (state.active && state.focused) {
       return element | borderDouble;
@@ -201,18 +201,18 @@ Component VMenu6(std::vector<std::string>* entries, int* selected) {
 
 Component VMenu7(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.animated_colors.foreground.enabled = true;
-  option.entries.animated_colors.background.enabled = true;
-  option.entries.animated_colors.background.active = Color::Red;
-  option.entries.animated_colors.background.inactive = Color::Black;
-  option.entries.animated_colors.foreground.active = Color::White;
-  option.entries.animated_colors.foreground.inactive = Color::Red;
+  option.entries_option.animated_colors.foreground.enabled = true;
+  option.entries_option.animated_colors.background.enabled = true;
+  option.entries_option.animated_colors.background.active = Color::Red;
+  option.entries_option.animated_colors.background.inactive = Color::Black;
+  option.entries_option.animated_colors.foreground.active = Color::White;
+  option.entries_option.animated_colors.foreground.inactive = Color::Red;
   return Menu(entries, selected, option);
 }
 
 Component VMenu8(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::Vertical();
-  option.entries.animated_colors.foreground.Set(Color::Red, Color::White,
+  option.entries_option.animated_colors.foreground.Set(Color::Red, Color::White,
                                                 std::chrono::milliseconds(500));
   return Menu(entries, selected, option);
 }
@@ -240,7 +240,7 @@ Component HMenu5(std::vector<std::string>* entries, int* selected) {
   auto option = MenuOption::HorizontalAnimated();
   option.underline.SetAnimation(std::chrono::milliseconds(1500),
                                 animation::easing::ElasticOut);
-  option.entries.transform = [](EntryState state) {
+  option.entries_option.transform = [](EntryState state) {
     Element e = text(state.label) | hcenter | flex;
     if (state.active && state.focused)
       e = e | bold;

--- a/include/ftxui/component/component.hpp
+++ b/include/ftxui/component/component.hpp
@@ -40,37 +40,42 @@ Component Vertical(Components children, int* selector);
 Component Horizontal(Components children);
 Component Horizontal(Components children, int* selector);
 Component Tab(Components children, int* selector);
-
 }  // namespace Container
 
+Component Button(ButtonOption options);
 Component Button(ConstStringRef label,
                  std::function<void()> on_click,
-                 Ref<ButtonOption> = ButtonOption::Simple());
+                 ButtonOption options = ButtonOption::Simple());
 
+Component Checkbox(CheckboxOption options);
 Component Checkbox(ConstStringRef label,
                    bool* checked,
-                   Ref<CheckboxOption> option = CheckboxOption::Simple());
+                   CheckboxOption options = CheckboxOption::Simple());
 
-Component Input(StringRef content, Ref<InputOption> option = {});
+Component Input(InputOption options = {});
+Component Input(StringRef content, InputOption options = {});
 Component Input(StringRef content,
                 StringRef placeholder,
-                Ref<InputOption> option = {});
+                InputOption options = {});
 
+Component Menu(MenuOption options);
 Component Menu(ConstStringListRef entries,
                int* selected_,
-               Ref<MenuOption> = MenuOption::Vertical());
-Component MenuEntry(ConstStringRef label, Ref<MenuEntryOption> = {});
+               MenuOption options = MenuOption::Vertical());
+Component MenuEntry(MenuEntryOption options);
+Component MenuEntry(ConstStringRef label, MenuEntryOption options = {});
 
-Component Dropdown(ConstStringListRef entries, int* selected);
-
+Component Radiobox(RadioboxOption options);
 Component Radiobox(ConstStringListRef entries,
                    int* selected_,
-                   Ref<RadioboxOption> option = {});
+                   RadioboxOption options = {});
+
+Component Dropdown(ConstStringListRef entries, int* selected);
 Component Toggle(ConstStringListRef entries, int* selected);
 
 // General slider constructor:
 template <typename T>
-Component Slider(SliderOption<T> options = {});
+Component Slider(SliderOption<T> options);
 
 // Shorthand without the `SliderOption` constructor:
 Component Slider(ConstStringRef label,
@@ -89,11 +94,11 @@ Component Slider(ConstStringRef label,
                  ConstRef<long> max = 100l,
                  ConstRef<long> increment = 5l);
 
+Component ResizableSplit(ResizableSplitOption options);
 Component ResizableSplitLeft(Component main, Component back, int* main_size);
 Component ResizableSplitRight(Component main, Component back, int* main_size);
 Component ResizableSplitTop(Component main, Component back, int* main_size);
 Component ResizableSplitBottom(Component main, Component back, int* main_size);
-Component ResizableSplit(ResizableSplitOption options);
 
 Component Renderer(Component child, std::function<Element()>);
 Component Renderer(std::function<Element()>);

--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -72,6 +72,7 @@ struct AnimatedColorsOption {
 /// @brief Option for the MenuEntry component.
 /// @ingroup component
 struct MenuEntryOption {
+  ConstStringRef label = "MenuEntry";
   std::function<Element(const EntryState& state)> transform;
   AnimatedColorsOption animated_colors;
 };
@@ -86,9 +87,12 @@ struct MenuOption {
   static MenuOption VerticalAnimated();
   static MenuOption Toggle();
 
+  ConstStringListRef entries;  ///> The list of entries.
+  Ref<int> selected = 0;       ///> The index of the selected entry.
+
   // Style:
   UnderlineOption underline;
-  MenuEntryOption entries;
+  MenuEntryOption entries_option;
   Direction direction = Direction::Down;
   std::function<Element()> elements_prefix;
   std::function<Element()> elements_infix;
@@ -115,6 +119,9 @@ struct ButtonOption {
                                Color background_active,
                                Color foreground_active);
 
+  ConstStringRef label = "Button";
+  std::function<void()> on_click = [] {};
+
   // Style:
   std::function<Element(const EntryState&)> transform;
   AnimatedColorsOption animated_colors;
@@ -125,6 +132,10 @@ struct ButtonOption {
 struct CheckboxOption {
   // Standard constructors:
   static CheckboxOption Simple();
+
+  ConstStringRef label = "Checkbox";
+
+  Ref<bool> checked = false;
 
   // Style:
   std::function<Element(const EntryState&)> transform;
@@ -153,6 +164,9 @@ struct InputOption {
   /// @brief A white on black style with high margins:
   static InputOption Spacious();
 
+  /// The content of the input.
+  StringRef content = "";
+
   /// The content of the input when it's empty.
   StringRef placeholder = "";
 
@@ -175,6 +189,10 @@ struct InputOption {
 struct RadioboxOption {
   // Standard constructors:
   static RadioboxOption Simple();
+
+  // Content:
+  ConstStringListRef entries;
+  Ref<int> selected = 0;
 
   // Style:
   std::function<Element(const EntryState&)> transform;

--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -106,7 +106,7 @@ class Screen {
 
   // Store an hyperlink in the screen. Return the id of the hyperlink. The id is
   // used to identify the hyperlink when the user click on it.
-  uint8_t RegisterHyperlink(std::string link);
+  uint8_t RegisterHyperlink(const std::string& link);
   const std::string& Hyperlink(uint8_t id) const;
 
   Box stencil;

--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -92,6 +92,11 @@ class ConstStringRef {
     address_ = t.address_;
     return *this;
   }
+  ConstStringRef& operator=(ConstStringRef&& t) {
+    owned_ = std::move(t.owned_);
+    address_ = t.address_;
+    return *this;
+  }
   const std::string& operator()() const {
     return address_ ? *address_ : owned_;
   }

--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -13,6 +13,12 @@ class ConstRef {
   ConstRef() {}
   ConstRef(T t) : owned_(t) {}
   ConstRef(const T* t) : address_(t) {}
+  ConstRef(const ConstRef& t) : owned_(t.owned_), address_(t.address_) {}
+  ConstRef& operator=(const ConstRef& t) {
+    owned_ = t.owned_;
+    address_ = t.address_;
+    return *this;
+  }
   const T& operator*() const { return address_ ? *address_ : owned_; }
   const T& operator()() const { return address_ ? *address_ : owned_; }
   const T* operator->() const { return address_ ? address_ : &owned_; }
@@ -30,6 +36,12 @@ class Ref {
   Ref(const T& t) : owned_(t) {}
   Ref(T&& t) : owned_(std::forward<T>(t)) {}
   Ref(T* t) : owned_(), address_(t) {}
+  Ref(const Ref& t) : owned_(t.owned_), address_(t.address_) {}
+  Ref& operator=(const Ref& t) {
+    owned_ = t.owned_;
+    address_ = t.address_;
+    return *this;
+  }
   T& operator*() { return address_ ? *address_ : owned_; }
   T& operator()() { return address_ ? *address_ : owned_; }
   T* operator->() { return address_ ? address_ : &owned_; }
@@ -47,6 +59,12 @@ class StringRef {
   StringRef(std::string ref) : owned_(std::move(ref)) {}
   StringRef(const wchar_t* ref) : StringRef(to_string(std::wstring(ref))) {}
   StringRef(const char* ref) : StringRef(std::string(ref)) {}
+  StringRef(const StringRef& t) : owned_(t.owned_), address_(t.address_) {}
+  StringRef& operator=(const StringRef& t) {
+    owned_ = t.owned_;
+    address_ = t.address_;
+    return *this;
+  }
   std::string& operator*() { return address_ ? *address_ : owned_; }
   std::string& operator()() { return address_ ? *address_ : owned_; }
   std::string* operator->() { return address_ ? address_ : &owned_; }
@@ -67,6 +85,13 @@ class ConstStringRef {
   ConstStringRef(const wchar_t* ref) : ConstStringRef(std::wstring(ref)) {}
   ConstStringRef(const char* ref)
       : ConstStringRef(to_wstring(std::string(ref))) {}
+  ConstStringRef(const ConstStringRef& t)
+      : owned_(t.owned_), address_(t.address_) {}
+  ConstStringRef& operator=(const ConstStringRef& t) {
+    owned_ = t.owned_;
+    address_ = t.address_;
+    return *this;
+  }
   const std::string& operator()() const {
     return address_ ? *address_ : owned_;
   }
@@ -76,19 +101,35 @@ class ConstStringRef {
   }
 
  private:
-  const std::string owned_;
+  std::string owned_;
   const std::string* address_ = nullptr;
 };
 
 /// @brief An adapter. Reference a list of strings.
 class ConstStringListRef {
  public:
+  ConstStringListRef() = default;
   ConstStringListRef(const std::vector<std::string>* ref) : ref_(ref) {}
   ConstStringListRef(const std::vector<std::wstring>* ref) : ref_wide_(ref) {}
 
-  size_t size() const { return ref_ ? ref_->size() : ref_wide_->size(); }
+  size_t size() const {
+    if (ref_) {
+      return ref_->size();
+    }
+    if (ref_wide_) {
+      return ref_wide_->size();
+    }
+    return 0;
+  }
+
   std::string operator[](size_t i) const {
-    return ref_ ? (*ref_)[i] : to_string((*ref_wide_)[i]);
+    if (ref_) {
+      return (*ref_)[i];
+    }
+    if (ref_wide_) {
+      return to_string((*ref_wide_)[i]);
+    }
+    return "";
   }
 
  private:

--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -30,7 +30,150 @@ Element DefaultTransform(EntryState params) {  // NOLINT
   return element;
 }
 
+class ButtonBase : public ComponentBase, public ButtonOption {
+ public:
+  ButtonBase(ButtonOption option) : ButtonOption(std::move(option)) {}
+
+  // Component implementation:
+  Element Render() override {
+    const bool active = Active();
+    const bool focused = Focused();
+    const bool focused_or_hover = focused || mouse_hover_;
+
+    float target = focused_or_hover ? 1.f : 0.f;  // NOLINT
+    if (target != animator_background_.to()) {
+      SetAnimationTarget(target);
+    }
+
+    auto focus_management = focused ? focus : active ? select : nothing;
+    const EntryState state = {
+        *label,
+        false,
+        active,
+        focused_or_hover,
+    };
+
+    auto element = (transform ? transform : DefaultTransform)  //
+        (state);
+    return element | AnimatedColorStyle() | focus_management | reflect(box_);
+  }
+
+  Decorator AnimatedColorStyle() {
+    Decorator style = nothing;
+    if (animated_colors.background.enabled) {
+      style = style |
+              bgcolor(Color::Interpolate(animation_foreground_,  //
+                                         animated_colors.background.inactive,
+                                         animated_colors.background.active));
+    }
+    if (animated_colors.foreground.enabled) {
+      style =
+          style | color(Color::Interpolate(animation_foreground_,  //
+                                           animated_colors.foreground.inactive,
+                                           animated_colors.foreground.active));
+    }
+    return style;
+  }
+
+  void SetAnimationTarget(float target) {
+    if (animated_colors.foreground.enabled) {
+      animator_foreground_ = animation::Animator(
+          &animation_foreground_, target, animated_colors.foreground.duration,
+          animated_colors.foreground.function);
+    }
+    if (animated_colors.background.enabled) {
+      animator_background_ = animation::Animator(
+          &animation_background_, target, animated_colors.background.duration,
+          animated_colors.background.function);
+    }
+  }
+
+  void OnAnimation(animation::Params& p) override {
+    animator_background_.OnAnimation(p);
+    animator_foreground_.OnAnimation(p);
+  }
+
+  void OnClick() {
+    on_click();
+    animation_background_ = 0.5F;  // NOLINT
+    animation_foreground_ = 0.5F;  // NOLINT
+    SetAnimationTarget(1.F);       // NOLINT
+  }
+
+  bool OnEvent(Event event) override {
+    if (event.is_mouse()) {
+      return OnMouseEvent(event);
+    }
+
+    if (event == Event::Return) {
+      OnClick();
+      return true;
+    }
+    return false;
+  }
+
+  bool OnMouseEvent(Event event) {
+    mouse_hover_ =
+        box_.Contain(event.mouse().x, event.mouse().y) && CaptureMouse(event);
+
+    if (!mouse_hover_) {
+      return false;
+    }
+
+    if (event.mouse().button == Mouse::Left &&
+        event.mouse().motion == Mouse::Pressed) {
+      TakeFocus();
+      OnClick();
+      return true;
+    }
+
+    return false;
+  }
+
+  bool Focusable() const final { return true; }
+
+ private:
+  bool mouse_hover_ = false;
+  Box box_;
+  ButtonOption option_;
+  float animation_background_ = 0;
+  float animation_foreground_ = 0;
+  animation::Animator animator_background_ =
+      animation::Animator(&animation_background_);
+  animation::Animator animator_foreground_ =
+      animation::Animator(&animation_foreground_);
+};
+
 }  // namespace
+   //
+/// @brief Draw a button. Execute a function when clicked.
+/// @param label The label of the button.
+/// @param on_click The action to execute when clicked.
+/// @param option Additional optional parameters.
+/// @ingroup component
+/// @see ButtonBase
+///
+/// ### Example
+///
+/// ```cpp
+/// auto screen = ScreenInteractive::FitComponent();
+/// Component button = Button({
+///   .label = "Click to quit",
+///   .on_click = screen.ExitLoopClosure(),
+/// });
+/// screen.Loop(button)
+/// ```
+///
+/// ### Output
+///
+/// ```bash
+/// ┌─────────────┐
+/// │Click to quit│
+/// └─────────────┘
+/// ```
+Component Button(ButtonOption option) {
+  return Make<ButtonBase>(std::move(option));
+}
 
 /// @brief Draw a button. Execute a function when clicked.
 /// @param label The label of the button.
@@ -55,135 +198,12 @@ Element DefaultTransform(EntryState params) {  // NOLINT
 /// │Click to quit│
 /// └─────────────┘
 /// ```
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 Component Button(ConstStringRef label,
                  std::function<void()> on_click,
-                 Ref<ButtonOption> option) {
-  class Impl : public ComponentBase {
-   public:
-    Impl(ConstStringRef label,
-         std::function<void()> on_click,
-         Ref<ButtonOption> option)
-        : label_(std::move(label)),
-          on_click_(std::move(on_click)),
-          option_(std::move(option)) {}
-
-    // Component implementation:
-    Element Render() override {
-      const bool active = Active();
-      const bool focused = Focused();
-      const bool focused_or_hover = focused || mouse_hover_;
-
-      float target = focused_or_hover ? 1.f : 0.f;  // NOLINT
-      if (target != animator_background_.to()) {
-        SetAnimationTarget(target);
-      }
-
-      auto focus_management = focused ? focus : active ? select : nothing;
-      const EntryState state = {
-          *label_,
-          false,
-          active,
-          focused_or_hover,
-      };
-
-      auto element =
-          (option_->transform ? option_->transform : DefaultTransform)  //
-          (state);
-      return element | AnimatedColorStyle() | focus_management | reflect(box_);
-    }
-
-    Decorator AnimatedColorStyle() {
-      Decorator style = nothing;
-      if (option_->animated_colors.background.enabled) {
-        style = style | bgcolor(Color::Interpolate(
-                            animation_foreground_,  //
-                            option_->animated_colors.background.inactive,
-                            option_->animated_colors.background.active));
-      }
-      if (option_->animated_colors.foreground.enabled) {
-        style = style | color(Color::Interpolate(
-                            animation_foreground_,  //
-                            option_->animated_colors.foreground.inactive,
-                            option_->animated_colors.foreground.active));
-      }
-      return style;
-    }
-
-    void SetAnimationTarget(float target) {
-      if (option_->animated_colors.foreground.enabled) {
-        animator_foreground_ =
-            animation::Animator(&animation_foreground_, target,
-                                option_->animated_colors.foreground.duration,
-                                option_->animated_colors.foreground.function);
-      }
-      if (option_->animated_colors.background.enabled) {
-        animator_background_ =
-            animation::Animator(&animation_background_, target,
-                                option_->animated_colors.background.duration,
-                                option_->animated_colors.background.function);
-      }
-    }
-
-    void OnAnimation(animation::Params& p) override {
-      animator_background_.OnAnimation(p);
-      animator_foreground_.OnAnimation(p);
-    }
-
-    void OnClick() {
-      on_click_();
-      animation_background_ = 0.5F;  // NOLINT
-      animation_foreground_ = 0.5F;  // NOLINT
-      SetAnimationTarget(1.F);       // NOLINT
-    }
-
-    bool OnEvent(Event event) override {
-      if (event.is_mouse()) {
-        return OnMouseEvent(event);
-      }
-
-      if (event == Event::Return) {
-        OnClick();
-        return true;
-      }
-      return false;
-    }
-
-    bool OnMouseEvent(Event event) {
-      mouse_hover_ =
-          box_.Contain(event.mouse().x, event.mouse().y) && CaptureMouse(event);
-
-      if (!mouse_hover_) {
-        return false;
-      }
-
-      if (event.mouse().button == Mouse::Left &&
-          event.mouse().motion == Mouse::Pressed) {
-        TakeFocus();
-        OnClick();
-        return true;
-      }
-
-      return false;
-    }
-
-    bool Focusable() const final { return true; }
-
-   private:
-    ConstStringRef label_;
-    std::function<void()> on_click_;
-    bool mouse_hover_ = false;
-    Box box_;
-    Ref<ButtonOption> option_;
-    float animation_background_ = 0;
-    float animation_foreground_ = 0;
-    animation::Animator animator_background_ =
-        animation::Animator(&animation_background_);
-    animation::Animator animator_foreground_ =
-        animation::Animator(&animation_foreground_);
-  };
-
-  return Make<Impl>(std::move(label), std::move(on_click), std::move(option));
+                 ButtonOption option) {
+  option.label = std::move(label);
+  option.on_click = std::move(on_click);
+  return Make<ButtonBase>(std::move(option));
 }
 
 }  // namespace ftxui

--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -32,7 +32,7 @@ Element DefaultTransform(EntryState params) {  // NOLINT
 
 class ButtonBase : public ComponentBase, public ButtonOption {
  public:
-  ButtonBase(ButtonOption option) : ButtonOption(std::move(option)) {}
+  explicit ButtonBase(ButtonOption option) : ButtonOption(std::move(option)) {}
 
   // Component implementation:
   Element Render() override {
@@ -198,10 +198,11 @@ Component Button(ButtonOption option) {
 /// │Click to quit│
 /// └─────────────┘
 /// ```
+// NOLINTNEXTLINE
 Component Button(ConstStringRef label,
                  std::function<void()> on_click,
                  ButtonOption option) {
-  option.label = std::move(label);
+  option.label = label;
   option.on_click = std::move(on_click);
   return Make<ButtonBase>(std::move(option));
 }

--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -147,8 +147,6 @@ class ButtonBase : public ComponentBase, public ButtonOption {
 }  // namespace
    //
 /// @brief Draw a button. Execute a function when clicked.
-/// @param label The label of the button.
-/// @param on_click The action to execute when clicked.
 /// @param option Additional optional parameters.
 /// @ingroup component
 /// @see ButtonBase

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -104,9 +104,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
 /// ```bash
 /// ☐ Make a sandwitch
 /// ```
-Component Checkbox(ConstStringRef label,
-                   bool* checked,
-                   CheckboxOption option) {
+Component Checkbox(ConstStringRef label, bool* checked, CheckboxOption option) {
   option.label = std::move(label);
   option.checked = checked;
   return Make<CheckboxBase>(std::move(option));

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -16,7 +16,8 @@ namespace ftxui {
 namespace {
 class CheckboxBase : public ComponentBase, public CheckboxOption {
  public:
-  CheckboxBase(CheckboxOption option) : CheckboxOption(std::move(option)) {}
+  explicit CheckboxBase(CheckboxOption option)
+      : CheckboxOption(std::move(option)) {}
 
  private:
   // Component implementation.
@@ -104,8 +105,9 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
 /// ```bash
 /// ☐ Make a sandwitch
 /// ```
+// NOLINTNEXTLINE
 Component Checkbox(ConstStringRef label, bool* checked, CheckboxOption option) {
-  option.label = std::move(label);
+  option.label = label;
   option.checked = checked;
   return Make<CheckboxBase>(std::move(option));
 }

--- a/src/ftxui/component/collapsible.cpp
+++ b/src/ftxui/component/collapsible.cpp
@@ -27,6 +27,7 @@ namespace ftxui {
 /// ▼ Show details
 /// <details component>
 ///  ```
+// NOLINTNEXTLINE
 Component Collapsible(ConstStringRef label, Component child, Ref<bool> show) {
   class Impl : public ComponentBase {
    public:
@@ -44,7 +45,7 @@ Component Collapsible(ConstStringRef label, Component child, Ref<bool> show) {
         return hbox({prefix, t});
       };
       Add(Container::Vertical({
-          Checkbox(std::move(label), show_.operator->(), opt),
+          Checkbox(label, show_.operator->(), opt),
           Maybe(std::move(child), show_.operator->()),
       }));
     }

--- a/src/ftxui/component/component_options.cpp
+++ b/src/ftxui/component/component_options.cpp
@@ -124,9 +124,9 @@ MenuOption MenuOption::Toggle() {
 ButtonOption ButtonOption::Ascii() {
   ButtonOption option;
   option.transform = [](const EntryState& s) {
-    const std::string label = s.focused ? "[" + s.label + "]"  //
-                                        : " " + s.label + " ";
-    return text(label);
+    const std::string t = s.focused ? "[" + s.label + "]"  //
+                                    : " " + s.label + " ";
+    return text(t);
   };
   return option;
 }

--- a/src/ftxui/component/component_options.cpp
+++ b/src/ftxui/component/component_options.cpp
@@ -48,7 +48,7 @@ void UnderlineOption::SetAnimationFunction(
 MenuOption MenuOption::Horizontal() {
   MenuOption option;
   option.direction = Direction::Right;
-  option.entries.transform = [](const EntryState& state) {
+  option.entries_option.transform = [](const EntryState& state) {
     Element e = text(state.label);
     if (state.focused) {
       e |= inverted;
@@ -76,7 +76,7 @@ MenuOption MenuOption::HorizontalAnimated() {
 // static
 MenuOption MenuOption::Vertical() {
   MenuOption option;
-  option.entries.transform = [](const EntryState& state) {
+  option.entries_option.transform = [](const EntryState& state) {
     Element e = text((state.active ? "> " : "  ") + state.label);  // NOLINT
     if (state.focused) {
       e |= inverted;
@@ -95,7 +95,7 @@ MenuOption MenuOption::Vertical() {
 // static
 MenuOption MenuOption::VerticalAnimated() {
   auto option = MenuOption::Vertical();
-  option.entries.transform = [](const EntryState& state) {
+  option.entries_option.transform = [](const EntryState& state) {
     Element e = text(state.label);
     if (state.focused) {
       e |= inverted;

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -175,7 +175,7 @@ class InputBase : public ComponentBase, public InputOption {
     }
 
     auto element = vbox(std::move(elements)) | frame;
-    return transform({
+    return transform_func({
                std::move(element), hovered_, is_focused,
                false  // placeholder
            }) |

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -517,7 +517,6 @@ class InputBase : public ComponentBase, public InputOption {
 }  // namespace
 
 /// @brief An input box for editing text.
-/// @param content The editable content.
 /// @param option Additional optional parameters.
 /// @ingroup component
 /// @see InputBase

--- a/src/ftxui/component/input_test.cpp
+++ b/src/ftxui/component/input_test.cpp
@@ -16,32 +16,36 @@ namespace ftxui {
 
 TEST(InputTest, Init) {
   std::string content;
+  int cursor_position = 0;
   auto option = InputOption();
-  Component input = Input(&content, &option);
-  EXPECT_EQ(option.cursor_position(), 0);
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
+  EXPECT_EQ(cursor_position, 0);
 }
 
 TEST(InputTest, Type) {
   std::string content;
-  std::string placeholder;
-  auto option = InputOption();
-  Component input = Input(&content, &option);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
 
   input->OnEvent(Event::Character("a"));
   EXPECT_EQ(content, "a");
-  EXPECT_EQ(option.cursor_position(), 1);
+  EXPECT_EQ(cursor_position, 1);
 
   input->OnEvent(Event::Character('b'));
   EXPECT_EQ(content, "ab");
-  EXPECT_EQ(option.cursor_position(), 2);
+  EXPECT_EQ(cursor_position, 2);
 
   input->OnEvent(Event::Return);
   EXPECT_EQ(content, "ab\n");
-  EXPECT_EQ(option.cursor_position(), 3);
+  EXPECT_EQ(cursor_position, 3);
 
   input->OnEvent(Event::Character('c'));
   EXPECT_EQ(content, "ab\nc");
-  EXPECT_EQ(option.cursor_position(), 4);
+  EXPECT_EQ(cursor_position, 4);
 
   auto document = input->Render();
 
@@ -55,57 +59,59 @@ TEST(InputTest, Type) {
 
 TEST(InputTest, ArrowLeftRight) {
   std::string content = "abc测测a测\na测\n";
-  auto option = InputOption();
-  auto input = Input(&content, &option);
-  EXPECT_EQ(option.cursor_position(), 0);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowLeft));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 1);
+  EXPECT_EQ(cursor_position, 1);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 1);
+  EXPECT_EQ(cursor_position, 1);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 2);
+  EXPECT_EQ(cursor_position, 2);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 3);
+  EXPECT_EQ(cursor_position, 3);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 6);
+  EXPECT_EQ(cursor_position, 6);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 9);
+  EXPECT_EQ(cursor_position, 9);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 10);
+  EXPECT_EQ(cursor_position, 10);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 13);
+  EXPECT_EQ(cursor_position, 13);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 14);
+  EXPECT_EQ(cursor_position, 14);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 15);
+  EXPECT_EQ(cursor_position, 15);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 18);
+  EXPECT_EQ(cursor_position, 18);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 19);
+  EXPECT_EQ(cursor_position, 19);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 19);
+  EXPECT_EQ(cursor_position, 19);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
-  EXPECT_EQ(option.cursor_position(), 18);
+  EXPECT_EQ(cursor_position, 18);
 }
 
 TEST(InputTest, ArrowUpDown) {
@@ -117,70 +123,75 @@ TEST(InputTest, ArrowUpDown) {
       "００\n"
       "０\n"
       "";
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 4);
+  EXPECT_EQ(cursor_position, 4);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 11);
+  EXPECT_EQ(cursor_position, 11);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 21);
+  EXPECT_EQ(cursor_position, 21);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 29);
+  EXPECT_EQ(cursor_position, 29);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 36);
+  EXPECT_EQ(cursor_position, 36);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 40);
+  EXPECT_EQ(cursor_position, 40);
   EXPECT_FALSE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 40);
+  EXPECT_EQ(cursor_position, 40);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 36);
+  EXPECT_EQ(cursor_position, 36);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 29);
+  EXPECT_EQ(cursor_position, 29);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 21);
+  EXPECT_EQ(cursor_position, 21);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 11);
+  EXPECT_EQ(cursor_position, 11);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 4);
+  EXPECT_EQ(cursor_position, 4);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
   EXPECT_FALSE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
-  EXPECT_EQ(option.cursor_position(), 3);
+  EXPECT_EQ(cursor_position, 3);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 7);
+  EXPECT_EQ(cursor_position, 7);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 14);
+  EXPECT_EQ(cursor_position, 14);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 24);
+  EXPECT_EQ(cursor_position, 24);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 32);
+  EXPECT_EQ(cursor_position, 32);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 39);
+  EXPECT_EQ(cursor_position, 39);
   EXPECT_TRUE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 40);
+  EXPECT_EQ(cursor_position, 40);
   EXPECT_FALSE(input->OnEvent(Event::ArrowDown));
-  EXPECT_EQ(option.cursor_position(), 40);
+  EXPECT_EQ(cursor_position, 40);
 
-  option.cursor_position() = 39;
+  cursor_position = 39;
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 32);
+  EXPECT_EQ(cursor_position, 32);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 24);
+  EXPECT_EQ(cursor_position, 24);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 14);
+  EXPECT_EQ(cursor_position, 14);
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
-  EXPECT_EQ(option.cursor_position(), 7);
+  EXPECT_EQ(cursor_position, 7);
 }
 
 TEST(InputTest, Insert) {
   std::string content;
-  Component input = Input(&content);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
 
   EXPECT_TRUE(input->OnEvent(Event::Character('a')));
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
@@ -213,8 +224,10 @@ TEST(InputTest, Insert) {
 
 TEST(InputTest, Home) {
   std::string content;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
 
   EXPECT_TRUE(input->OnEvent(Event::Character('a')));
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
@@ -224,21 +237,22 @@ TEST(InputTest, Home) {
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
   EXPECT_TRUE(input->OnEvent(Event::Character('c')));
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 
   EXPECT_TRUE(input->OnEvent(Event::Home));
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 
   EXPECT_TRUE(input->OnEvent(Event::Character('-')));
-  EXPECT_EQ(option.cursor_position(), 1u);
+  EXPECT_EQ(cursor_position, 1u);
   EXPECT_EQ(content, "-abc\n测bc");
 }
 
 TEST(InputTest, End) {
   std::string content;
-  std::string placeholder;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  Component input = Input(&content, {
+                                        .cursor_position = &cursor_position,
+                                    });
 
   EXPECT_TRUE(input->OnEvent(Event::Character('a')));
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
@@ -250,17 +264,18 @@ TEST(InputTest, End) {
   EXPECT_TRUE(input->OnEvent(Event::ArrowUp));
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 2u);
+  EXPECT_EQ(cursor_position, 2u);
 
   input->OnEvent(Event::End);
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 }
 
 TEST(InputTest, Delete) {
   std::string content;
-  std::string placeholder;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  auto input = Input(&content, {
+                                   .cursor_position = &cursor_position,
+                               });
 
   EXPECT_TRUE(input->OnEvent(Event::Character('a')));
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
@@ -271,38 +286,38 @@ TEST(InputTest, Delete) {
   EXPECT_TRUE(input->OnEvent(Event::Character('c')));
 
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 
   EXPECT_FALSE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 8u);
+  EXPECT_EQ(cursor_position, 8u);
 
   EXPECT_TRUE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abc\n测b");
-  EXPECT_EQ(option.cursor_position(), 8u);
+  EXPECT_EQ(cursor_position, 8u);
 
   EXPECT_FALSE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abc\n测b");
-  EXPECT_EQ(option.cursor_position(), 8u);
+  EXPECT_EQ(cursor_position, 8u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_TRUE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abc\nb");
-  EXPECT_EQ(option.cursor_position(), 4u);
+  EXPECT_EQ(cursor_position, 4u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_TRUE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abcb");
-  EXPECT_EQ(option.cursor_position(), 3u);
+  EXPECT_EQ(cursor_position, 3u);
 
   EXPECT_TRUE(input->OnEvent(Event::Delete));
   EXPECT_EQ(content, "abc");
-  EXPECT_EQ(option.cursor_position(), 3u);
+  EXPECT_EQ(cursor_position, 3u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
@@ -318,9 +333,10 @@ TEST(InputTest, Delete) {
 
 TEST(InputTest, Backspace) {
   std::string content;
-  std::string placeholder;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  auto input = Input(&content, {
+                                   .cursor_position = &cursor_position,
+                               });
 
   EXPECT_TRUE(input->OnEvent(Event::Character('a')));
   EXPECT_TRUE(input->OnEvent(Event::Character('b')));
@@ -331,45 +347,45 @@ TEST(InputTest, Backspace) {
   EXPECT_TRUE(input->OnEvent(Event::Character('c')));
 
   EXPECT_EQ(content, "abc\n测bc");
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "abc\n测b");
-  EXPECT_EQ(option.cursor_position(), 8u);
+  EXPECT_EQ(cursor_position, 8u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeft));
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "abc\nb");
-  EXPECT_EQ(option.cursor_position(), 4u);
+  EXPECT_EQ(cursor_position, 4u);
 
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "abcb");
-  EXPECT_EQ(option.cursor_position(), 3u);
+  EXPECT_EQ(cursor_position, 3u);
 
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "abb");
-  EXPECT_EQ(option.cursor_position(), 2u);
+  EXPECT_EQ(cursor_position, 2u);
 
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "ab");
-  EXPECT_EQ(option.cursor_position(), 1u);
+  EXPECT_EQ(cursor_position, 1u);
 
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "b");
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 
   EXPECT_FALSE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "b");
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRight));
   EXPECT_TRUE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "");
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 
   EXPECT_FALSE(input->OnEvent(Event::Backspace));
   EXPECT_EQ(content, "");
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 }
 
 TEST(InputTest, CtrlArrow) {
@@ -377,192 +393,193 @@ TEST(InputTest, CtrlArrow) {
       "word word 测ord wo测d word\n"
       "coucou    coucou coucou\n"
       "coucou coucou coucou\n";
-  std::string placeholder;
-  auto option = InputOption();
-  option.cursor_position = 1000;
-  auto input = Input(&content, &option);
+  int cursor_position = 1000;
+  auto input = Input(&content, {
+                                   .cursor_position = &cursor_position,
+                               });
 
   // Use CTRL+Left several time
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 67);
+  EXPECT_EQ(cursor_position, 67);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 60);
+  EXPECT_EQ(cursor_position, 60);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 53);
+  EXPECT_EQ(cursor_position, 53);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 46);
+  EXPECT_EQ(cursor_position, 46);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 39);
+  EXPECT_EQ(cursor_position, 39);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 29);
+  EXPECT_EQ(cursor_position, 29);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 24);
+  EXPECT_EQ(cursor_position, 24);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 17);
+  EXPECT_EQ(cursor_position, 17);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 10);
+  EXPECT_EQ(cursor_position, 10);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 5);
+  EXPECT_EQ(cursor_position, 5);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 4);
+  EXPECT_EQ(cursor_position, 4);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 9);
+  EXPECT_EQ(cursor_position, 9);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 16);
+  EXPECT_EQ(cursor_position, 16);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 23);
+  EXPECT_EQ(cursor_position, 23);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 28);
+  EXPECT_EQ(cursor_position, 28);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 35);
+  EXPECT_EQ(cursor_position, 35);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 45);
+  EXPECT_EQ(cursor_position, 45);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 52);
+  EXPECT_EQ(cursor_position, 52);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 59);
+  EXPECT_EQ(cursor_position, 59);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 66);
+  EXPECT_EQ(cursor_position, 66);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 73);
+  EXPECT_EQ(cursor_position, 73);
 }
 
 TEST(InputTest, CtrlArrowLeft2) {
   std::string content = "   word  word  测ord  wo测d  word   ";
-  auto option = InputOption();
-  option.cursor_position = 33;
-  auto input = Input(&content, &option);
+  int cursor_position = 33;
+  auto input = Input(&content, {
+                                   .cursor_position = &cursor_position,
+                               });
 
   // Use CTRL+Left several time
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 31);
+  EXPECT_EQ(cursor_position, 31);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 23);
+  EXPECT_EQ(cursor_position, 23);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 15);
+  EXPECT_EQ(cursor_position, 15);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 9);
+  EXPECT_EQ(cursor_position, 9);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 3);
+  EXPECT_EQ(cursor_position, 3);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowLeftCtrl));
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 }
 
 TEST(InputTest, CtrlArrowRight) {
   std::string content =
       "word word 测ord wo测d word\n"
       "coucou dfqdsf jmlkjm";
-
-  auto option = InputOption();
-  option.cursor_position = 2;
-  auto input = Input(&content, &option);
+  int cursor_position = 2;
+  auto input = Input(&content, {.cursor_position = &cursor_position});
 
   // Use CTRL+Left several time
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 4);
+  EXPECT_EQ(cursor_position, 4);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 9);
+  EXPECT_EQ(cursor_position, 9);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 16);
+  EXPECT_EQ(cursor_position, 16);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 23);
+  EXPECT_EQ(cursor_position, 23);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 28);
+  EXPECT_EQ(cursor_position, 28);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 35);
+  EXPECT_EQ(cursor_position, 35);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 42);
+  EXPECT_EQ(cursor_position, 42);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 49);
+  EXPECT_EQ(cursor_position, 49);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 49);
+  EXPECT_EQ(cursor_position, 49);
 }
 
 TEST(InputTest, CtrlArrowRight2) {
   std::string content = "   word  word  测ord  wo测d  word   ";
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  auto input = Input(&content, {.cursor_position = &cursor_position});
 
   // Use CTRL+Left several time
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 7);
+  EXPECT_EQ(cursor_position, 7);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 13);
+  EXPECT_EQ(cursor_position, 13);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 21);
+  EXPECT_EQ(cursor_position, 21);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 29);
+  EXPECT_EQ(cursor_position, 29);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 35);
+  EXPECT_EQ(cursor_position, 35);
 
   EXPECT_TRUE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 38);
+  EXPECT_EQ(cursor_position, 38);
 
   EXPECT_FALSE(input->OnEvent(Event::ArrowRightCtrl));
-  EXPECT_EQ(option.cursor_position(), 38);
+  EXPECT_EQ(cursor_position, 38);
 }
 
 TEST(InputTest, TypePassword) {
   std::string content;
   std::string placeholder;
-  auto option = InputOption();
-  option.cursor_position = 0;
-  option.password = true;
-  Component input = Input(&content, &placeholder, &option);
+  int cursor_position = 0;
+  Component input = Input(&content, &placeholder,
+                          {
+                              .password = true,
+                              .cursor_position = &cursor_position,
+                          });
 
   input->OnEvent(Event::Character('a'));
   EXPECT_EQ(content, "a");
-  EXPECT_EQ(option.cursor_position(), 1u);
+  EXPECT_EQ(cursor_position, 1u);
 
   input->OnEvent(Event::Character('b'));
   EXPECT_EQ(content, "ab");
-  EXPECT_EQ(option.cursor_position(), 2u);
+  EXPECT_EQ(cursor_position, 2u);
 
   auto document = input->Render();
   auto screen = Screen::Create(Dimension::Fit(document));
@@ -573,8 +590,8 @@ TEST(InputTest, TypePassword) {
 
 TEST(InputTest, MouseClick) {
   std::string content;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  auto input = Input(&content, {.cursor_position = &cursor_position});
 
   input->OnEvent(Event::Character("a"));
   input->OnEvent(Event::Character("b"));
@@ -588,7 +605,7 @@ TEST(InputTest, MouseClick) {
   input->OnEvent(Event::Return);
 
   EXPECT_EQ(content, "abcd\nabcd\n");
-  EXPECT_EQ(option.cursor_position(), 10u);
+  EXPECT_EQ(cursor_position, 10u);
 
   auto render = [&] {
     auto document = input->Render();
@@ -596,7 +613,7 @@ TEST(InputTest, MouseClick) {
     Render(screen, document);
   };
   render();
-  EXPECT_EQ(option.cursor_position(), 10u);
+  EXPECT_EQ(cursor_position, 10u);
 
   Mouse mouse;
   mouse.button = Mouse::Button::Left;
@@ -609,67 +626,67 @@ TEST(InputTest, MouseClick) {
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 0u);
+  EXPECT_EQ(cursor_position, 0u);
 
   mouse.x = 2;
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 2u);
+  EXPECT_EQ(cursor_position, 2u);
 
   mouse.x = 2;
   mouse.y = 0;
   EXPECT_FALSE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 2u);
+  EXPECT_EQ(cursor_position, 2u);
 
   mouse.x = 1;
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 1u);
+  EXPECT_EQ(cursor_position, 1u);
 
   mouse.x = 3;
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 3u);
+  EXPECT_EQ(cursor_position, 3u);
 
   mouse.x = 4;
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 4u);
+  EXPECT_EQ(cursor_position, 4u);
 
   mouse.x = 5;
   mouse.y = 0;
   EXPECT_FALSE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 4u);
+  EXPECT_EQ(cursor_position, 4u);
 
   mouse.x = 5;
   mouse.y = 1;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 9u);
+  EXPECT_EQ(cursor_position, 9u);
 
   mouse.x = 1;
   mouse.y = 1;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 6u);
+  EXPECT_EQ(cursor_position, 6u);
 
   mouse.x = 4;
   mouse.y = 2;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 10u);
+  EXPECT_EQ(cursor_position, 10u);
 }
 
 TEST(InputTest, MouseClickComplex) {
   std::string content;
-  auto option = InputOption();
-  auto input = Input(&content, &option);
+  int cursor_position = 0;
+  auto input = Input(&content, {.cursor_position = &cursor_position});
 
   input->OnEvent(Event::Character("测"));
   input->OnEvent(Event::Character("试"));
@@ -681,7 +698,7 @@ TEST(InputTest, MouseClickComplex) {
   input->OnEvent(Event::Character("a⃒"));
   input->OnEvent(Event::Character("ā"));
 
-  EXPECT_EQ(option.cursor_position(), 27u);
+  EXPECT_EQ(cursor_position, 27u);
 
   auto render = [&] {
     auto document = input->Render();
@@ -701,25 +718,25 @@ TEST(InputTest, MouseClickComplex) {
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 0);
+  EXPECT_EQ(cursor_position, 0);
 
   mouse.x = 0;
   mouse.y = 1;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 14);
+  EXPECT_EQ(cursor_position, 14);
 
   mouse.x = 1;
   mouse.y = 0;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 3);
+  EXPECT_EQ(cursor_position, 3);
 
   mouse.x = 1;
   mouse.y = 1;
   EXPECT_TRUE(input->OnEvent(Event::Mouse("", mouse)));
   render();
-  EXPECT_EQ(option.cursor_position(), 17);
+  EXPECT_EQ(cursor_position, 17);
 }
 
 TEST(InputTest, OnEnter) {
@@ -727,7 +744,7 @@ TEST(InputTest, OnEnter) {
   auto option = InputOption();
   bool on_enter_called = false;
   option.on_enter = [&] { on_enter_called = true; };
-  Component input = Input(&content, &option);
+  Component input = Input(&content, option);
 
   EXPECT_FALSE(on_enter_called);
   EXPECT_TRUE(input->OnEvent(Event::Return));

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -67,7 +67,7 @@ bool IsHorizontal(Direction direction) {
 /// @ingroup component
 class MenuBase : public ComponentBase, public MenuOption {
  public:
-  MenuBase(MenuOption option) : MenuOption(std::move(option)) {}
+  explicit MenuBase(MenuOption option) : MenuOption(std::move(option)) {}
 
   bool IsHorizontal() { return ftxui::IsHorizontal(direction); }
   void OnChange() {
@@ -613,7 +613,8 @@ Component MenuEntry(ConstStringRef label, MenuEntryOption option) {
 Component MenuEntry(MenuEntryOption option) {
   class Impl : public ComponentBase, public MenuEntryOption {
    public:
-    Impl(MenuEntryOption option) : MenuEntryOption(std::move(option)) {}
+    explicit Impl(MenuEntryOption option)
+        : MenuEntryOption(std::move(option)) {}
 
    private:
     Element Render() override {

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -611,7 +611,7 @@ Component MenuEntry(ConstStringRef label, MenuEntryOption option) {
 ///   entry 3
 /// ```
 Component MenuEntry(MenuEntryOption option) {
-  class Impl : public ComponentBase, public MenuEntryOption  {
+  class Impl : public ComponentBase, public MenuEntryOption {
    public:
     Impl(MenuEntryOption option) : MenuEntryOption(std::move(option)) {}
 
@@ -641,30 +641,28 @@ Component MenuEntry(MenuEntryOption option) {
       if (target == animator_background_.to()) {
         return;
       }
-      animator_background_ =
-          animation::Animator(&animation_background_, target,
-                              animated_colors.background.duration,
-                              animated_colors.background.function);
-      animator_foreground_ =
-          animation::Animator(&animation_foreground_, target,
-                              animated_colors.foreground.duration,
-                              animated_colors.foreground.function);
+      animator_background_ = animation::Animator(
+          &animation_background_, target, animated_colors.background.duration,
+          animated_colors.background.function);
+      animator_foreground_ = animation::Animator(
+          &animation_foreground_, target, animated_colors.foreground.duration,
+          animated_colors.foreground.function);
     }
 
     Decorator AnimatedColorStyle() {
       Decorator style = nothing;
       if (animated_colors.foreground.enabled) {
-        style = style | color(Color::Interpolate(
-                            animation_foreground_,
-                            animated_colors.foreground.inactive,
-                            animated_colors.foreground.active));
+        style = style |
+                color(Color::Interpolate(animation_foreground_,
+                                         animated_colors.foreground.inactive,
+                                         animated_colors.foreground.active));
       }
 
       if (animated_colors.background.enabled) {
-        style = style | bgcolor(Color::Interpolate(
-                            animation_background_,
-                            animated_colors.background.inactive,
-                            animated_colors.background.active));
+        style = style |
+                bgcolor(Color::Interpolate(animation_background_,
+                                           animated_colors.background.inactive,
+                                           animated_colors.background.active));
       }
       return style;
     }

--- a/src/ftxui/component/menu_test.cpp
+++ b/src/ftxui/component/menu_test.cpp
@@ -23,9 +23,11 @@ TEST(MenuTest, RemoveEntries) {
   int focused_entry = 0;
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  MenuOption option;
-  option.focused_entry = &focused_entry;
-  auto menu = Menu(&entries, &selected, option);
+  auto menu = Menu({
+      .entries = &entries,
+      .selected = &selected,
+      .focused_entry = &focused_entry,
+  });
 
   EXPECT_EQ(selected, 0);
   EXPECT_EQ(focused_entry, 0);
@@ -52,10 +54,8 @@ TEST(MenuTest, DirectionDown) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
   MenuOption option;
-  auto menu = Menu(&entries, &selected, &option);
+  auto menu = Menu(&entries, &selected, {.direction = Direction::Down});
 
-  selected = 0;
-  option.direction = Direction::Down;
   Screen screen(4, 3);
   Render(screen, menu->Render());
   EXPECT_EQ(screen.ToString(),
@@ -80,9 +80,7 @@ TEST(MenuTest, DirectionDown) {
 TEST(MenuTest, DirectionsUp) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  MenuOption option;
-  auto menu = Menu(&entries, &selected, &option);
-  option.direction = Direction::Up;
+  auto menu = Menu(&entries, &selected, {.direction = Direction::Up});
   Screen screen(4, 3);
   Render(screen, menu->Render());
   EXPECT_EQ(screen.ToString(),
@@ -106,9 +104,7 @@ TEST(MenuTest, DirectionsUp) {
 TEST(MenuTest, DirectionsRight) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  MenuOption option;
-  auto menu = Menu(&entries, &selected, &option);
-  option.direction = Direction::Right;
+  auto menu = Menu(&entries, &selected, {.direction = Direction::Right});
   Screen screen(10, 1);
   Render(screen, menu->Render());
   EXPECT_EQ(screen.ToString(),
@@ -132,9 +128,7 @@ TEST(MenuTest, DirectionsRight) {
 TEST(MenuTest, DirectionsLeft) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  MenuOption option;
-  auto menu = Menu(&entries, &selected, &option);
-  option.direction = Direction::Left;
+  auto menu = Menu(&entries, &selected, {.direction = Direction::Left});
   Screen screen(10, 1);
   Render(screen, menu->Render());
   EXPECT_EQ(screen.ToString(),
@@ -158,8 +152,7 @@ TEST(MenuTest, DirectionsLeft) {
 TEST(MenuTest, AnimationsHorizontal) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  auto option = MenuOption::HorizontalAnimated();
-  auto menu = Menu(&entries, &selected, &option);
+  auto menu = Menu(&entries, &selected, MenuOption::HorizontalAnimated());
   {
     Screen screen(4, 3);
     Render(screen, menu->Render());
@@ -195,8 +188,7 @@ TEST(MenuTest, AnimationsHorizontal) {
 TEST(MenuTest, AnimationsVertical) {
   int selected = 0;
   std::vector<std::string> entries = {"1", "2", "3"};
-  auto option = MenuOption::VerticalAnimated();
-  auto menu = Menu(&entries, &selected, &option);
+  auto menu = Menu(&entries, &selected, MenuOption::VerticalAnimated());
   {
     Screen screen(10, 3);
     Render(screen, menu->Render());

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -23,7 +23,7 @@ namespace {
 /// @ingroup component
 class RadioboxBase : public ComponentBase, public RadioboxOption {
  public:
-  RadioboxBase(RadioboxOption option) : RadioboxOption(option) {}
+  explicit RadioboxBase(RadioboxOption option) : RadioboxOption(option) {}
 
  private:
   Element Render() override {

--- a/src/ftxui/component/slider.cpp
+++ b/src/ftxui/component/slider.cpp
@@ -35,24 +35,24 @@ Decorator flexDirection(Direction direction) {
 template <class T>
 class SliderBase : public ComponentBase {
  public:
-  explicit SliderBase(Ref<SliderOption<T>> options)
-      : value_(options->value),
-        min_(options->min),
-        max_(options->max),
-        increment_(options->increment),
+  explicit SliderBase(SliderOption<T> options)
+      : value_(options.value),
+        min_(options.min),
+        max_(options.max),
+        increment_(options.increment),
         options_(options) {}
 
   Element Render() override {
-    auto gauge_color = Focused() ? color(options_->color_active)
-                                 : color(options_->color_inactive);
+    auto gauge_color = Focused() ? color(options_.color_active)
+                                 : color(options_.color_inactive);
     const float percent = float(value_() - min_()) / float(max_() - min_());
-    return gaugeDirection(percent, options_->direction) |
-           flexDirection(options_->direction) | reflect(gauge_box_) |
+    return gaugeDirection(percent, options_.direction) |
+           flexDirection(options_.direction) | reflect(gauge_box_) |
            gauge_color;
   }
 
   void OnLeft() {
-    switch (options_->direction) {
+    switch (options_.direction) {
       case Direction::Right:
         value_() -= increment_();
         break;
@@ -66,7 +66,7 @@ class SliderBase : public ComponentBase {
   }
 
   void OnRight() {
-    switch (options_->direction) {
+    switch (options_.direction) {
       case Direction::Right:
         value_() += increment_();
         break;
@@ -80,7 +80,7 @@ class SliderBase : public ComponentBase {
   }
 
   void OnUp() {
-    switch (options_->direction) {
+    switch (options_.direction) {
       case Direction::Up:
         value_() -= increment_();
         break;
@@ -94,7 +94,7 @@ class SliderBase : public ComponentBase {
   }
 
   void OnDown() {
-    switch (options_->direction) {
+    switch (options_.direction) {
       case Direction::Down:
         value_() -= increment_();
         break;
@@ -153,7 +153,7 @@ class SliderBase : public ComponentBase {
     }
 
     if (captured_mouse_) {
-      switch (options_->direction) {
+      switch (options_.direction) {
         case Direction::Right: {
           value_() = min_() + (event.mouse().x - gauge_box_.x_min) *
                                   (max_() - min_()) /
@@ -192,7 +192,7 @@ class SliderBase : public ComponentBase {
   ConstRef<T> min_;
   ConstRef<T> max_;
   ConstRef<T> increment_;
-  Ref<SliderOption<T>> options_;
+  SliderOption<T> options_;
   Box gauge_box_;
   CapturedMouse captured_mouse_;
 };

--- a/src/ftxui/component/slider.cpp
+++ b/src/ftxui/component/slider.cpp
@@ -199,8 +199,7 @@ class SliderBase : public ComponentBase {
 
 class SliderWithLabel : public ComponentBase {
  public:
-  SliderWithLabel(ConstStringRef label, Component inner)
-      : label_(std::move(label)) {
+  SliderWithLabel(ConstStringRef label, Component inner) : label_(label) {
     Add(std::move(inner));
     SetActiveChild(ChildAt(0));
   }

--- a/src/ftxui/component/toggle_test.cpp
+++ b/src/ftxui/component/toggle_test.cpp
@@ -91,7 +91,7 @@ TEST(ToggleTest, OnChange) {
   auto option = MenuOption::Toggle();
   option.on_change = [&] { counter++; };
 
-  auto toggle = Menu(&entries, &selected, &option);
+  auto toggle = Menu(&entries, &selected, option);
 
   EXPECT_FALSE(toggle->OnEvent(Event::ArrowLeft));  // Reached far left.
   EXPECT_EQ(counter, 0);
@@ -120,7 +120,7 @@ TEST(ToggleTest, OnEnter) {
 
   auto option = MenuOption::Toggle();
   option.on_enter = [&] { counter++; };
-  auto toggle = Menu(&entries, &selected, &option);
+  auto toggle = Menu(&entries, &selected, option);
 
   EXPECT_FALSE(toggle->OnEvent(Event::ArrowLeft));  // Reached far left.
   EXPECT_TRUE(toggle->OnEvent(Event::Return));

--- a/src/ftxui/dom/canvas.cpp
+++ b/src/ftxui/dom/canvas.cpp
@@ -845,9 +845,11 @@ class CanvasNodeBase : public Node {
 }  // namespace
 
 /// @brief Produce an element from a Canvas, or a reference to a Canvas.
+// NOLINTNEXTLINE
 Element canvas(ConstRef<Canvas> canvas) {
   class Impl : public CanvasNodeBase {
    public:
+    // NOLINTNEXTLINE
     explicit Impl(ConstRef<Canvas> canvas) : canvas_(std::move(canvas)) {
       requirement_.min_x = (canvas_->width() + 1) / 2;
       requirement_.min_y = (canvas_->height() + 3) / 4;

--- a/src/ftxui/dom/hyperlink.cpp
+++ b/src/ftxui/dom/hyperlink.cpp
@@ -13,10 +13,10 @@ namespace ftxui {
 class Hyperlink : public NodeDecorator {
  public:
   Hyperlink(Element child, std::string link)
-      : NodeDecorator(std::move(child)), link_(link) {}
+      : NodeDecorator(std::move(child)), link_(std::move(link)) {}
 
   void Render(Screen& screen) override {
-    uint8_t hyperlink_id = screen.RegisterHyperlink(link_);
+    const uint8_t hyperlink_id = screen.RegisterHyperlink(link_);
     for (int y = box_.y_min; y <= box_.y_max; ++y) {
       for (int x = box_.x_min; x <= box_.x_max; ++x) {
         screen.PixelAt(x, y).hyperlink = hyperlink_id;
@@ -44,7 +44,7 @@ class Hyperlink : public NodeDecorator {
 ///   hyperlink("https://github.com/ArthurSonzogni/FTXUI", "link");
 /// ```
 Element hyperlink(std::string link, Element child) {
-  return std::make_shared<Hyperlink>(std::move(child), link);
+  return std::make_shared<Hyperlink>(std::move(child), std::move(link));
 }
 
 /// @brief Decorate using an hyperlink.
@@ -61,6 +61,7 @@ Element hyperlink(std::string link, Element child) {
 /// Element document =
 ///   text("red") | hyperlink("https://github.com/Arthursonzogni/FTXUI");
 /// ```
+// NOLINTNEXTLINE
 Decorator hyperlink(std::string link) {
   return [link](Element child) { return hyperlink(link, std::move(child)); };
 }

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>  // for size_t
 #include <iostream>  // for operator<<, stringstream, basic_ostream, flush, cout, ostream
+#include <limits>
 #include <map>      // for _Rb_tree_const_iterator, map, operator!=, operator==
 #include <memory>   // for allocator, allocator_traits<>::value_type
 #include <sstream>  // IWYU pragma: keep
@@ -553,13 +554,13 @@ void Screen::ApplyShader() {
 }
 // clang-format on
 
-uint8_t Screen::RegisterHyperlink(std::string link) {
+uint8_t Screen::RegisterHyperlink(const std::string& link) {
   for (size_t i = 0; i < hyperlinks_.size(); ++i) {
     if (hyperlinks_[i] == link) {
       return i;
     }
   }
-  if (hyperlinks_.size() == 255) {
+  if (hyperlinks_.size() == std::numeric_limits<uint8_t>::max()) {
     return 0;
   }
   hyperlinks_.push_back(link);

--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -7,21 +7,16 @@
 
 #include "ftxui/screen/string.hpp"
 
-#include <stddef.h>  // for size_t
-#include <array>     // for array
-#include <cstdint>   // for uint32_t, uint8_t, uint16_t, int32_t
-#include <string>    // for string, basic_string, wstring
-#include <tuple>     // for _Swallow_assign, ignore
+#include <array>    // for array
+#include <cstddef>  // for size_t
+#include <cstdint>  // for uint32_t, uint8_t, uint16_t, int32_t
+#include <string>   // for string, basic_string, wstring
+#include <tuple>    // for _Swallow_assign, ignore
 
 #include "ftxui/screen/deprecated.hpp"       // for wchar_width, wstring_width
 #include "ftxui/screen/string_internal.hpp"  // for WordBreakProperty, EatCodePoint, CodepointToWordBreakProperty, GlyphCount, GlyphIterate, GlyphNext, GlyphPrevious, IsCombining, IsControl, IsFullWidth, Utf8ToWordBreakProperty
 
 namespace {
-
-using ftxui::EatCodePoint;
-using ftxui::IsCombining;
-using ftxui::IsControl;
-using ftxui::IsFullWidth;
 
 struct Interval {
   uint32_t first;
@@ -1565,8 +1560,9 @@ bool IsControl(uint32_t ucs) {
   if (ucs == 0) {
     return true;
   }
-  if (ucs < 32) {      // NOLINT
-    return ucs != 10;  // 10 => Line feed.
+  if (ucs < 32) {  // NOLINT
+    const uint32_t LINE_FEED = 10;
+    return ucs != LINE_FEED;
   }
   if (ucs >= 0x7f && ucs < 0xa0) {  // NOLINT
     return true;


### PR DESCRIPTION
Improve the overall interfaces.

1. Stop taking Ref<XxxOption> in Component constructors. Instead, use
   the XxxOption directly. Passing by copy avoid problems developers had
   where one was shared in between multiple component, causing issues.

2. Add variants of most component constructors taking a struct only.

This replaces:
https://github.com/ArthurSonzogni/FTXUI/pull/670

This fixes:
https://github.com/ArthurSonzogni/FTXUI/issues/426