### PR TITLE
Improve unicode codepoint Bisearch performance

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -5,7 +5,6 @@
     <script src="https://cdn.jsdelivr.net/npm/xterm@4.18.0/lib/xterm.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.11.4/lib/xterm-addon-webgl.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.5.0/lib/xterm-addon-fit.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.8.0/lib/xterm-addon-web-links.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.11.0/css/xterm.css"></link>
     <!--Add COOP/COEP via a ServiceWorker to use SharedArrayBuffer-->
     <script>
@@ -84,8 +83,8 @@
     const term_element = document.querySelector('#terminal');
     term.open(term_element);
 
-    term.loadAddon(new (WebglAddon.WebglAddon)());
-    term.loadAddon(new (WebLinksAddon.WebLinksAddon)());
+    const webgl_addon = new (WebglAddon.WebglAddon)();
+    term.loadAddon(webgl_addon);
 
     const onBinary = e => {
       for(c of e)

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,6 +5,7 @@
     <script src="https://cdn.jsdelivr.net/npm/xterm@4.18.0/lib/xterm.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.11.4/lib/xterm-addon-webgl.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.5.0/lib/xterm-addon-fit.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.8.0/lib/xterm-addon-web-links.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.11.0/css/xterm.css"></link>
     <!--Add COOP/COEP via a ServiceWorker to use SharedArrayBuffer-->
     <script>
@@ -83,8 +84,8 @@
     const term_element = document.querySelector('#terminal');
     term.open(term_element);
 
-    const webgl_addon = new (WebglAddon.WebglAddon)();
-    term.loadAddon(webgl_addon);
+    term.loadAddon(new (WebglAddon.WebglAddon)());
+    term.loadAddon(new (WebLinksAddon.WebLinksAddon)());
 
     const onBinary = e => {
       for(c of e)

--- a/src/ftxui/dom/benchmark_test.cpp
+++ b/src/ftxui/dom/benchmark_test.cpp
@@ -30,6 +30,19 @@ static void BencharkBasic(benchmark::State& state) {
 }
 BENCHMARK(BencharkBasic)->DenseRange(0, 256, 16);
 
+static void BencharkText(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    std::string content = "ＨＥＬＬＯ world ";
+    for(int i=0; i<state.range(0); ++i) {
+      content += content;
+    }
+    auto document = paragraph(content);
+    Screen screen(200,200);
+    Render(screen, document);
+  }
+}
+BENCHMARK(BencharkText)->DenseRange(0, 10, 1);
+
 }  // namespace ftxui
 // NOLINTEND
 

--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -1368,7 +1368,7 @@ const std::array<WordBreakPropertyInterval, 1288> g_word_break_intervals = {{
 
 // Find a codepoint inside a sorted list of Interval.
 template <size_t N>
-bool Bisearch(uint32_t ucs, const std::array<Interval, N> table) {
+bool Bisearch(uint32_t ucs, const std::array<Interval, N>& table) {
   if (ucs < table.front().first || ucs > table.back().last) {  // NOLINT
     return false;
   }
@@ -1391,7 +1391,7 @@ bool Bisearch(uint32_t ucs, const std::array<Interval, N> table) {
 
 // Find a value inside a sorted list of Interval + property.
 template <class C, size_t N>
-bool Bisearch(uint32_t ucs, const std::array<C, N> table, C* out) {
+bool Bisearch(uint32_t ucs, const std::array<C, N>& table, C* out) {
   if (ucs < table.front().first || ucs > table.back().last) {  // NOLINT
     return false;
   }


### PR DESCRIPTION
Improve the performance of the functions for searching for codepoints in a table by passing the table array in as a reference instead of copying it.

This doesn't really improve the results of the benchmarks for some reason, but in my application with GCC8 i686, Intel Atom E3950 and a 180x60 terminal, this reduces the time for rendering a frame from ~31 ms to ~5.5 ms.