### PR TITLE
Resolve unused varaible warning in _WIN32 builds of screen_interactiv…

### DIFF
--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -70,7 +70,7 @@ void Flush() {
 }
 
 constexpr int timeout_milliseconds = 20;
-constexpr int timeout_microseconds = timeout_milliseconds * 1000;
+[[maybe_unused]] constexpr int timeout_microseconds = timeout_milliseconds * 1000;
 #if defined(_WIN32)
 
 void EventListener(std::atomic<bool>* quit, Sender<Task> out) {


### PR DESCRIPTION
Bug:#692

Marks constexpr int timeout_microseconds on line 73 as [[maybe_unused]] to resolve unused variable warning on _WIN32 builds.