### PR TITLE
Improve const correctness in the Screen class

### DIFF
--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -66,13 +66,18 @@ class Screen {
   static Screen Create(Dimensions dimension);
   static Screen Create(Dimensions width, Dimensions height);
 
-  // Node write into the screen using Screen::at.
+  // Access a character in the grid at a given position.
   std::string& at(int x, int y);
-  Pixel& PixelAt(int x, int y);
+  const std::string& at(int x, int y) const;
 
-  // Convert the screen into a printable string in the terminal.
-  std::string ToString();
-  void Print();
+  // Access a cell (Pixel) in the grid at a given position.
+  Pixel& PixelAt(int x, int y);
+  const Pixel& PixelAt(int x, int y) const;
+
+  std::string ToString() const;
+
+  // Print the Screen on to the terminal.
+  void Print() const;
 
   // Get screen dimensions.
   int dimx() const { return dimx_; }
@@ -81,7 +86,7 @@ class Screen {
   // Move the terminal cursor n-lines up with n = dimy().
   std::string ResetPosition(bool clear = false) const;
 
-  // Fill with space.
+  // Fill the screen with space.
   void Clear();
 
   void ApplyShader();

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -428,9 +428,11 @@ Screen::Screen(int dimx, int dimy)
 #endif
 }
 
-/// Produce a std::string that can be used to print the Screen on the terminal.
-/// Don't forget to flush stdout. Alternatively, you can use Screen::Print();
-std::string Screen::ToString() {
+/// Produce a std::string that can be used to print the Screen on the
+/// terminal.
+/// @note Don't forget to flush stdout. Alternatively, you can use
+/// Screen::Print();
+std::string Screen::ToString() const {
   std::stringstream ss;
 
   Pixel previous_pixel;
@@ -456,21 +458,36 @@ std::string Screen::ToString() {
   return ss.str();
 }
 
-void Screen::Print() {
+// Print the Screen to the terminal.
+void Screen::Print() const {
   std::cout << ToString() << '\0' << std::flush;
 }
 
-/// @brief Access a character a given position.
-/// @param x The character position along the x-axis.
-/// @param y The character position along the y-axis.
+/// @brief Access a character in a cell at a given position.
+/// @param x The cell position along the x-axis.
+/// @param y The cell position along the y-axis.
 std::string& Screen::at(int x, int y) {
   return PixelAt(x, y).character;
 }
 
-/// @brief Access a Pixel at a given position.
-/// @param x The pixel position along the x-axis.
-/// @param y The pixel position along the y-axis.
+/// @brief Access a character in a cell at a given position.
+/// @param x The cell position along the x-axis.
+/// @param y The cell position along the y-axis.
+const std::string& Screen::at(int x, int y) const {
+  return PixelAt(x, y).character;
+}
+
+/// @brief Access a cell (Pixel) at a given position.
+/// @param x The cell position along the x-axis.
+/// @param y The cell position along the y-axis.
 Pixel& Screen::PixelAt(int x, int y) {
+  return stencil.Contain(x, y) ? pixels_[y][x] : dev_null_pixel();
+}
+
+/// @brief Access a cell (Pixel) at a given position.
+/// @param x The cell position along the x-axis.
+/// @param y The cell position along the y-axis.
+const Pixel& Screen::PixelAt(int x, int y) const {
   return stencil.Contain(x, y) ? pixels_[y][x] : dev_null_pixel();
 }
 


### PR DESCRIPTION
This PR addresses what we discussed in #700 by making the following changes:
- Add a const variant to the accessor functions
- Make Print and ToString functions const
- Move Doxygen comments to the header (I am happy to remove this change but I decided to kill two birds with one stone here)

This, when merged, should close #700 
