### PR TITLE
Added the print stage to the benchmarks

### DIFF
--- a/src/ftxui/dom/benchmark_test.cpp
+++ b/src/ftxui/dom/benchmark_test.cpp
@@ -27,6 +27,7 @@ static void BencharkBasic(benchmark::State& state) {
     auto root = gauge(1.0);
     Screen screen(80, state.range(0));
     Render(screen, root);
+    auto str = screen.ToString();
   }
 }
 BENCHMARK(BencharkBasic)->DenseRange(0, 256, 16);
@@ -40,6 +41,7 @@ static void BencharkText(benchmark::State& state) {
     auto document = paragraph(content);
     Screen screen(200, 200);
     Render(screen, document);
+    auto str = screen.ToString();
   }
 }
 BENCHMARK(BencharkText)->DenseRange(0, 10, 1);
@@ -65,6 +67,7 @@ static void BenchmarkStyle(benchmark::State& state) {
     auto document = hbox(std::move(elements));
     Screen screen(state.range(1), state.range(1));
     Render(screen, document);
+    auto str = screen.ToString();
   }
 }
 BENCHMARK(BenchmarkStyle)

--- a/src/ftxui/dom/benchmark_test.cpp
+++ b/src/ftxui/dom/benchmark_test.cpp
@@ -27,7 +27,7 @@ static void BencharkBasic(benchmark::State& state) {
     auto root = gauge(1.0);
     Screen screen(80, state.range(0));
     Render(screen, root);
-    auto str = screen.ToString();
+    screen.ToString();
   }
 }
 BENCHMARK(BencharkBasic)->DenseRange(0, 256, 16);
@@ -41,7 +41,7 @@ static void BencharkText(benchmark::State& state) {
     auto document = paragraph(content);
     Screen screen(200, 200);
     Render(screen, document);
-    auto str = screen.ToString();
+    screen.ToString();
   }
 }
 BENCHMARK(BencharkText)->DenseRange(0, 10, 1);
@@ -67,7 +67,7 @@ static void BenchmarkStyle(benchmark::State& state) {
     auto document = hbox(std::move(elements));
     Screen screen(state.range(1), state.range(1));
     Render(screen, document);
-    auto str = screen.ToString();
+    screen.ToString();
   }
 }
 BENCHMARK(BenchmarkStyle)


### PR DESCRIPTION
The benchmarks were only doing a render but not calling the ToString() method (as done in the Screen:Print method). I added this.

This allows us to see the performance improvement in https://github.com/ArthurSonzogni/FTXUI/pull/704.