### PR TITLE
Upgrade the version of google benchmark

### DIFF
--- a/cmake/ftxui_find_google_benchmark.cmake
+++ b/cmake/ftxui_find_google_benchmark.cmake
@@ -13,7 +13,7 @@ include(FetchContent)
 
 FetchContent_Declare(googlebenchmark
   GIT_REPOSITORY "https://github.com/google/benchmark"
-  GIT_TAG        62937f91b5c763a8e119d0c20c67b87bde8eff1c 
+  GIT_TAG        "v1.8.2"
   GIT_PROGRESS   TRUE
 )
 

--- a/cmake/ftxui_find_google_benchmark.cmake
+++ b/cmake/ftxui_find_google_benchmark.cmake
@@ -13,7 +13,7 @@ include(FetchContent)
 
 FetchContent_Declare(googlebenchmark
   GIT_REPOSITORY "https://github.com/google/benchmark"
-  GIT_TAG        "v1.8.2"
+  GIT_TAG        "015d1a091af6937488242b70121858bce8fd40e9"  # v1.8.2
   GIT_PROGRESS   TRUE
 )
 


### PR DESCRIPTION
This upgrades the version of google benchmark used. The main reason for this upgrade is that the old version doesn't display the `OVERALL_GEOMEAN` when comparing two benchmarks.