### PR TITLE
Change WordBreakProperty underlying type to int8_t

### DIFF
--- a/src/ftxui/screen/string_internal.hpp
+++ b/src/ftxui/screen/string_internal.hpp
@@ -32,7 +32,7 @@ int GlyphCount(const std::string& input);
 
 // Properties from:
 // https://www.unicode.org/Public/UCD/latest/ucd/auxiliary/WordBreakProperty.txt
-enum class WordBreakProperty {
+enum class WordBreakProperty : int8_t {
   ALetter,
   CR,
   Double_Quote,


### PR DESCRIPTION
This yields a ~1% performance improvements, likely because the smaller types causes less load on memory when bisearching the WordBreakProperty interval table