### PR TITLE
Added some true colors in the benchmark

### DIFF
--- a/src/ftxui/dom/benchmark_test.cpp
+++ b/src/ftxui/dom/benchmark_test.cpp
@@ -59,6 +59,9 @@ static void BenchmarkStyle(benchmark::State& state) {
           text("Test") | strikethrough,
           text("Test") | color(Color::Red),
           text("Test") | bgcolor(Color::Red),
+          text("Test") | color(Color::RGB(42, 87, 124)),
+          text("Test") | bgcolor(Color::RGB(42, 87, 124)),
+          text("Test") | color(Color::RGB(42, 87, 124)) | bgcolor(Color::RGB(172, 94, 212)),
           text("Test") | blink,
           text("Test") | automerge,
       }));


### PR DESCRIPTION
Hi there,

I suggest the addition of some truecolor ... colors be included in the benchmarks. Those feel (to me) like the one being the most likely to be used today and they come with a performance cost that I feel should be taken into consideration when benchmarking.