### PR TITLE
Add a DisableMouseEvents() on ScreenInteractive to disable mouse events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ current (development)
   Component Slider(SliderOption<T> options);
   Component ResizableSplit(ResizableSplitOption options);
   ```
+- Feature: Add `ScreenInteractive::TrackMouse(false)` disable mouse support.
 
 ### Dom
 - Feature: Add `hyperlink` decorator. For instance:

--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -31,6 +31,9 @@ class ScreenInteractive : public Screen {
   static ScreenInteractive FitComponent();
   static ScreenInteractive TerminalOutput();
 
+  // Options. Must be called before Loop().
+  void TrackMouse(bool enable = true);
+
   // Return the currently active screen, nullptr if none.
   static ScreenInteractive* Active();
 
@@ -83,6 +86,8 @@ class ScreenInteractive : public Screen {
                     int dimy,
                     Dimension dimension,
                     bool use_alternative_screen);
+
+  bool track_mouse_= true;
 
   Sender<Task> task_sender_;
   Receiver<Task> task_receiver_;

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -379,6 +379,26 @@ ScreenInteractive ScreenInteractive::FitComponent() {
   };
 }
 
+/// @ingroup component
+/// @brief Set whether mouse is tracked and events reported.
+/// called outside of the main loop. E.g `ScreenInteractive::Loop(...)`.
+/// @param enable Whether to enable mouse event tracking.
+/// @note This muse be called outside of the main loop. E.g. before calling
+/// `ScreenInteractive::Loop`.
+/// @note Mouse tracking is enabled by default.
+/// @note Mouse tracking is only supported on terminals that supports it.
+///
+/// ### Example
+///
+/// ```cpp
+/// auto screen = ScreenInteractive::TerminalOutput();
+/// screen.TrackMouse(false);
+/// screen.Loop(component);
+/// ```
+void ScreenInteractive::TrackMouse(bool enable) {
+  track_mouse_ = enable;
+}
+
 void ScreenInteractive::Post(Task task) {
   // Task/Events sent toward inactive screen or screen waiting to become
   // inactive are dropped.
@@ -580,10 +600,12 @@ void ScreenInteractive::Install() {
       DECMode::kLineWrap,
   });
 
-  enable({DECMode::kMouseVt200});
-  enable({DECMode::kMouseAnyEvent});
-  enable({DECMode::kMouseUrxvtMode});
-  enable({DECMode::kMouseSgrExtMode});
+  if (track_mouse_) {
+    enable({DECMode::kMouseVt200});
+    enable({DECMode::kMouseAnyEvent});
+    enable({DECMode::kMouseUrxvtMode});
+    enable({DECMode::kMouseSgrExtMode});
+  }
 
   // After installing the new configuration, flush it to the terminal to
   // ensure it is fully applied:


### PR DESCRIPTION
When mouse events are enabled, it is not possible to select text in the terminal and copy it somewhere else. This could be usefull for some applications if they don't need to handle mouse events.

Add a function on the ScreenInteractive class to disable grabbing of mouse events so that it is e.g. possible to select text in the user interface. The function needs to be called on the screen object before starting the application loop if such a behaviour is desired.