### PR TITLE
Fix Wshadow warning in Color::Interpolate

### DIFF
--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -224,17 +224,17 @@ Color Color::Interpolate(float t, const Color& a, const Color& b) {
 
   // Gamma correction:
   // https://en.wikipedia.org/wiki/Gamma_correction
-  auto interp = [](uint8_t _a, uint8_t _b, float _t) {
+  auto interp = [t](uint8_t a_u, uint8_t b_u) {
     constexpr float gamma = 2.2F;
-    const float a_f = powf(_a, gamma);
-    const float b_f = powf(_b, gamma);
-    const float c_f = a_f * (1.0F - _t) +  //
-                      b_f * _t;
+    const float a_f = powf(a_u, gamma);
+    const float b_f = powf(b_u, gamma);
+    const float c_f = a_f * (1.0F - t) +  //
+                      b_f * t;
     return static_cast<uint8_t>(powf(c_f, 1.F / gamma));
   };
-  return Color::RGB(interp(a_r, b_r, t),   //
-                    interp(a_g, b_g, t),   //
-                    interp(a_b, b_b, t));  //
+  return Color::RGB(interp(a_r, b_r),   //
+                    interp(a_g, b_g),   //
+                    interp(a_b, b_b));  //
 }
 
 inline namespace literals {

--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -224,12 +224,12 @@ Color Color::Interpolate(float t, const Color& a, const Color& b) {
 
   // Gamma correction:
   // https://en.wikipedia.org/wiki/Gamma_correction
-  auto interp = [](uint8_t a, uint8_t b, float t) {
+  auto interp = [](uint8_t _a, uint8_t _b, float _t) {
     constexpr float gamma = 2.2F;
-    const float a_f = powf(a, gamma);
-    const float b_f = powf(b, gamma);
-    const float c_f = a_f * (1.0F - t) +  //
-                      b_f * t;
+    const float a_f = powf(_a, gamma);
+    const float b_f = powf(_b, gamma);
+    const float c_f = a_f * (1.0F - _t) +  //
+                      b_f * _t;
     return static_cast<uint8_t>(powf(c_f, 1.F / gamma));
   };
   return Color::RGB(interp(a_r, b_r, t),   //


### PR DESCRIPTION
-Wshadow would warn on shadowed local variables
in the Color::Interpolate function