### PR TITLE
Tidy up some ConstRef<T> and Ref<T> constructor cases

### DIFF
--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -44,7 +44,7 @@ class Ref {
   Ref(T t) : variant_( std::move(t) ) {}
   Ref(T* t) : variant_(t) {}
 
-  // Make a "re-seatable" reference
+  // Make a "reseatable" reference.
   Ref<T>& operator=(const Ref<T>&) = default;
 
   // Accessors:

--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -13,8 +13,8 @@ class ConstRef {
  public:
   ConstRef() = default;
   ConstRef(const ConstRef<T>&) = default;
-  ConstRef(      ConstRef<T>&&) = default;
-  ConstRef(      T  t) : variant_( std::move(t) ) {}
+  ConstRef(ConstRef<T>&&) = default;
+  ConstRef(T t) : variant_(std::move(t)) {}
   ConstRef(const T* t) : variant_(t) {}
 
   // Make a "reseatable" reference
@@ -41,7 +41,7 @@ class Ref {
   Ref() = default;
   Ref(const Ref<T>&) = default;
   Ref(Ref<T>&&) = default;
-  Ref(T t) : variant_( std::move(t) ) {}
+  Ref(T t) : variant_(std::move(t)) {}
   Ref(T* t) : variant_(t) {}
 
   // Make a "reseatable" reference.

--- a/include/ftxui/util/ref.hpp
+++ b/include/ftxui/util/ref.hpp
@@ -13,10 +13,11 @@ class ConstRef {
  public:
   ConstRef() = default;
   ConstRef(const ConstRef<T>&) = default;
-  ConstRef(const T& t) : variant_(t) {}
+  ConstRef(      ConstRef<T>&&) = default;
+  ConstRef(      T  t) : variant_( std::move(t) ) {}
   ConstRef(const T* t) : variant_(t) {}
 
-  // Make a "resetable" reference
+  // Make a "reseatable" reference
   ConstRef<T>& operator=(const ConstRef<T>&) = default;
 
   // Accessors:
@@ -39,11 +40,11 @@ class Ref {
  public:
   Ref() = default;
   Ref(const Ref<T>&) = default;
-  Ref(const T& t) : variant_(t) {}
-  Ref(T&& t) : variant_(std::forward<T>(t)) {}
+  Ref(Ref<T>&&) = default;
+  Ref(T t) : variant_( std::move(t) ) {}
   Ref(T* t) : variant_(t) {}
 
-  // Make a "resetable" reference
+  // Make a "re-seatable" reference
   Ref<T>& operator=(const Ref<T>&) = default;
 
   // Accessors:

--- a/src/ftxui/dom/canvas.cpp
+++ b/src/ftxui/dom/canvas.cpp
@@ -849,7 +849,7 @@ class CanvasNodeBase : public Node {
 Element canvas(ConstRef<Canvas> canvas) {
   class Impl : public CanvasNodeBase {
    public:
-    explicit Impl(ConstRef<Canvas> canvas) : canvas_(canvas) {
+    explicit Impl(ConstRef<Canvas> canvas) : canvas_(std::move(canvas)) {
       requirement_.min_x = (canvas_->width() + 1) / 2;
       requirement_.min_y = (canvas_->height() + 3) / 4;
     }


### PR DESCRIPTION
Here is a slight improvement in the handling of the construction of those two classes.

It uses a pass-by-value-when-moving type of approach.  This will handle both L-values and R-values cleanly.  Of course, this assumes that moves are free (which they typically are) and are inlined.

What do you think?

P.S. Yes, I meant "reseatable" and not "resetable".  :)