### PR TITLE
Fix CMAKE_UNITY_BUILD usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ current (development)
 - Feature: Add support for `Input`'s insert mode. Add `InputOption::insert`
   option. Added by @mingsheng13.
 
+### Build
+- Support for cmake's "unity/jumbo" builds. Fixed by @ClausKlein.
+
 5.0.0
 -----
 

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -58,6 +58,10 @@ target_include_directories(ftxui-tests
   PRIVATE src
 )
 target_compile_features(ftxui-tests PRIVATE cxx_std_20)
+
+# Disable unity build for tests. There are several files defining the same
+# function in different anonymous namespaces. This is not allowed in unity
+# builds, as it would result in multiple definitions of the same function.
 set_target_properties(ftxui-tests PROPERTIES UNITY_BUILD OFF)
 
 if (FTXUI_MICROSOFT_TERMINAL_FALLBACK)

--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -58,6 +58,7 @@ target_include_directories(ftxui-tests
   PRIVATE src
 )
 target_compile_features(ftxui-tests PRIVATE cxx_std_20)
+set_target_properties(ftxui-tests PROPERTIES UNITY_BUILD OFF)
 
 if (FTXUI_MICROSOFT_TERMINAL_FALLBACK)
   target_compile_definitions(ftxui-tests

--- a/src/ftxui/screen/util.hpp
+++ b/src/ftxui/screen/util.hpp
@@ -1,6 +1,9 @@
 // Copyright 2022 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.
+#ifndef FTXUI_SCREEN_UTIL_HPP
+#define FTXUI_SCREEN_UTIL_HPP
+
 namespace ftxui {
 namespace util {
 
@@ -12,3 +15,5 @@ constexpr const T& clamp(const T& v, const T& lo, const T& hi) {
 
 }  // namespace util
 }  // namespace ftxui
+
+#endif /* end of include guard: FTXUI_SCREEN_UTIL_HPP */


### PR DESCRIPTION
Add missing include guard.

This fix https://github.com/cpp-best-practices/cmake_template/issues/64