### PR TITLE
a grid container

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Prebuilt components are declared in [<ftxui/component/component.hpp>](https://ar
 
 ## Libraries for FTXUI
 - *Want to share a useful component using FTXUI? Feel free adding yours here*
-
+- [GridContainer](https://github.com/mingsheng13/grid-container-ftxui)
 
 ## Project using FTXUI
 


### PR DESCRIPTION
Hi, I've written a simple grid container using Horizontal and Vertical Containers. But I think this should be put into the container.cpp instead of a different library. Which one would you prefer? Thank you.