### PR TITLE
update nix and add dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "lastModified": 1697915759,
+        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679734080,
-        "narHash": "sha256-z846xfGLlon6t9lqUzlNtBOmsgQLQIZvR6Lt2dImk1M=",
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbf5322e93bcc6cfc52268367a8ad21c09d76fea",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,71 +8,69 @@
 
   outputs = {self, nixpkgs, flake-utils}:
     flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs { inherit system; };
-      llvm = pkgs.llvmPackages_latest;
-    in
-      {
-        packages = rec { 
-          default = pkgs.stdenv.mkDerivation rec {
-            pname = "ftxui";
-            version = "v4.0.0";
-            src = pkgs.fetchFromGitHub {
-              owner = "ArthurSonzogni";
-              repo = "FTXUI";
-              rev = version;
-              sha256 = "sha256-3kAhHDUwzwdvHc8JZAcA14tGqa6w69qrN1JXhSxNBQY=";
-            };
-
-            nativeBuildInputs = [
-              pkgs.cmake
-            ];
-
-            cmakeFlags = [
-              "-DFTXUI_ENABLE_INSTALL=ON"
-              "-DFTXUI_BUILD_EXAMPLES=OFF"
-              "-DFTXUI_BUILD_TESTS=OFF"
-              "-DFTXUI_BUILD_DOCS=OFF"
-              "-DCMAKE_BUILD_TYPE=Release"
-            ];
-
-            meta = {
-              homepage = "https://arthursonzogni.github.io/FTXUI/";
-              description = "C++ Functional Terminal User Interface.";
-              longDescription = ''
-                Functional Terminal (X) User interface
-                
-                A simple C++ library for terminal based user interfaces!
-                Feature
-                - Functional style. Inspired by [1] and React
-                - Simple and elegant syntax (in my opinion)
-                - Keyboard & mouse navigation.
-                - Support for UTF8 and fullwidth chars (→ 测试)
-                - Support for animations. Demo 1, Demo 2
-                - Support for drawing. Demo
-                - No dependencies
-                - Cross platform: Linux/MacOS (main target), WebAssembly, Windows (Thanks to contributors!).
-                - Learn by examples, and tutorials
-                - Multiple packages: CMake FetchContent (preferred), vcpkg, pkgbuild, conan, nix, etc...
-                - Good practises: documentation, tests, fuzzers, performance tests, automated CI, automated packaging, etc...
-              '';
-              license = pkgs.lib.licenses.mit;
-              platforms = pkgs.lib.platforms.all;
-            };
+    let pkgs = import nixpkgs { inherit system; }; in
+    let llvm = pkgs.llvmPackages_latest; in
+    {
+      packages = rec {
+        default = pkgs.stdenv.mkDerivation rec {
+          pname = "ftxui";
+          version = "v4.0.0";
+          src = pkgs.fetchFromGitHub {
+            owner = "ArthurSonzogni";
+            repo = "FTXUI";
+            rev = version;
+            sha256 = "sha256-3kAhHDUwzwdvHc8JZAcA14tGqa6w69qrN1JXhSxNBQY=";
           };
 
-          ftxui = default;
-        };
+          nativeBuildInputs = [
+            pkgs.cmake
+          ];
 
-        devShells = {
-          default = pkgs.mkShell {
-            nativeBuildInputs = [
-              pkgs.cmake
-              pkgs.clang-tools
-              llvm.clang
-            ];
+          cmakeFlags = [
+            "-DFTXUI_ENABLE_INSTALL=ON"
+            "-DFTXUI_BUILD_EXAMPLES=OFF"
+            "-DFTXUI_BUILD_TESTS=OFF"
+            "-DFTXUI_BUILD_DOCS=OFF"
+            "-DCMAKE_BUILD_TYPE=Release"
+          ];
+
+          meta = {
+            homepage = "https://arthursonzogni.github.io/FTXUI/";
+            description = "C++ Functional Terminal User Interface.";
+            longDescription = ''
+              Functional Terminal (X) User interface
+              
+              A simple C++ library for terminal based user interfaces!
+              Feature
+              - Functional style. Inspired by [1] and React
+              - Simple and elegant syntax (in my opinion)
+              - Keyboard & mouse navigation.
+              - Support for UTF8 and fullwidth chars (→ 测试)
+              - Support for animations. Demo 1, Demo 2
+              - Support for drawing. Demo
+              - No dependencies
+              - Cross platform: Linux/MacOS (main target), WebAssembly, Windows (Thanks to contributors!).
+              - Learn by examples, and tutorials
+              - Multiple packages: CMake FetchContent (preferred), vcpkg, pkgbuild, conan, nix, etc...
+              - Good practises: documentation, tests, fuzzers, performance tests, automated CI, automated packaging, etc...
+            '';
+            license = pkgs.lib.licenses.mit;
+            platforms = pkgs.lib.platforms.all;
           };
         };
-      }
-    );
+
+        ftxui = default;
+      };
+
+      devShells = {
+        default = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.cmake
+            pkgs.clang-tools
+            llvm.clang
+          ];
+        };
+      };
+    }
+  );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,52 +8,69 @@
 
   outputs = {self, nixpkgs, flake-utils}:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; }; in
+    let
+      pkgs = import nixpkgs { inherit system; };
+      llvm = pkgs.llvmPackages_latest;
+    in
       {
-        packages.ftxui = pkgs.stdenv.mkDerivation rec {
-          pname = "ftxui";
-          version = "v4.0.0";
-          src = pkgs.fetchFromGitHub {
-            owner = "ArthurSonzogni";
-            repo = "FTXUI";
-            rev = version;
-            sha256 = "sha256-3kAhHDUwzwdvHc8JZAcA14tGqa6w69qrN1JXhSxNBQY=";
+        packages = rec { 
+          default = pkgs.stdenv.mkDerivation rec {
+            pname = "ftxui";
+            version = "v4.0.0";
+            src = pkgs.fetchFromGitHub {
+              owner = "ArthurSonzogni";
+              repo = "FTXUI";
+              rev = version;
+              sha256 = "sha256-3kAhHDUwzwdvHc8JZAcA14tGqa6w69qrN1JXhSxNBQY=";
+            };
+
+            nativeBuildInputs = [
+              pkgs.cmake
+            ];
+
+            cmakeFlags = [
+              "-DFTXUI_ENABLE_INSTALL=ON"
+              "-DFTXUI_BUILD_EXAMPLES=OFF"
+              "-DFTXUI_BUILD_TESTS=OFF"
+              "-DFTXUI_BUILD_DOCS=OFF"
+              "-DCMAKE_BUILD_TYPE=Release"
+            ];
+
+            meta = {
+              homepage = "https://arthursonzogni.github.io/FTXUI/";
+              description = "C++ Functional Terminal User Interface.";
+              longDescription = ''
+                Functional Terminal (X) User interface
+                
+                A simple C++ library for terminal based user interfaces!
+                Feature
+                - Functional style. Inspired by [1] and React
+                - Simple and elegant syntax (in my opinion)
+                - Keyboard & mouse navigation.
+                - Support for UTF8 and fullwidth chars (→ 测试)
+                - Support for animations. Demo 1, Demo 2
+                - Support for drawing. Demo
+                - No dependencies
+                - Cross platform: Linux/MacOS (main target), WebAssembly, Windows (Thanks to contributors!).
+                - Learn by examples, and tutorials
+                - Multiple packages: CMake FetchContent (preferred), vcpkg, pkgbuild, conan, nix, etc...
+                - Good practises: documentation, tests, fuzzers, performance tests, automated CI, automated packaging, etc...
+              '';
+              license = pkgs.lib.licenses.mit;
+              platforms = pkgs.lib.platforms.all;
+            };
           };
 
-          nativeBuildInputs = [
-            pkgs.cmake
-          ];
+          ftxui = default;
+        };
 
-          cmakeFlags = [
-            "-DFTXUI_ENABLE_INSTALL=ON"
-            "-DFTXUI_BUILD_EXAMPLES=OFF"
-            "-DFTXUI_BUILD_TESTS=OFF"
-            "-DFTXUI_BUILD_DOCS=OFF"
-            "-DCMAKE_BUILD_TYPE=Release"
-          ];
-
-          meta = {
-            homepage = "https://arthursonzogni.github.io/FTXUI/";
-            description = "C++ Functional Terminal User Interface.";
-            longDescription = ''
-              Functional Terminal (X) User interface
-              
-              A simple C++ library for terminal based user interfaces!
-              Feature
-              - Functional style. Inspired by [1] and React
-              - Simple and elegant syntax (in my opinion)
-              - Keyboard & mouse navigation.
-              - Support for UTF8 and fullwidth chars (→ 测试)
-              - Support for animations. Demo 1, Demo 2
-              - Support for drawing. Demo
-              - No dependencies
-              - Cross platform: Linux/MacOS (main target), WebAssembly, Windows (Thanks to contributors!).
-              - Learn by examples, and tutorials
-              - Multiple packages: CMake FetchContent (preferred), vcpkg, pkgbuild, conan, nix, etc...
-              - Good practises: documentation, tests, fuzzers, performance tests, automated CI, automated packaging, etc...
-            '';
-            license = pkgs.lib.licenses.mit;
-            platforms = pkgs.lib.platforms.all;
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.cmake
+              pkgs.clang-tools
+              llvm.clang
+            ];
           };
         };
       }


### PR DESCRIPTION
We update the lock on the nix flake and also add a dev shell. This means you can do `nix build` to build the project and `nix develop` to drop into a development environment with cmake and clang.