### PR TITLE
Input onchange not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ current (development)
 ### Component
 - Feature: Add support for `Input`'s insert mode. Add `InputOption::insert`
   option. Added by @mingsheng13.
+- Bugfix: `Input` `onchange` was not called on backspace or delete key.
+  Fixed by @chrysante in chrysante in PR #776.
 
 ### Dom
 - Feature: Add `hscroll_indicator`. It display an horizontal indicator

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -210,7 +210,7 @@ class InputBase : public ComponentBase, public InputOption {
     on_change();
     return true;
   }
-    
+
   bool DeleteImpl() {
     if (cursor_position() == (int)content->size()) {
       return false;

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -207,10 +207,11 @@ class InputBase : public ComponentBase, public InputOption {
     const size_t end = cursor_position();
     content->erase(start, end - start);
     cursor_position() = start;
+    on_change();
     return true;
   }
-
-  bool HandleDelete() {
+    
+  bool DeleteImpl() {
     if (cursor_position() == (int)content->size()) {
       return false;
     }
@@ -218,6 +219,14 @@ class InputBase : public ComponentBase, public InputOption {
     const size_t end = GlyphNext(content(), cursor_position());
     content->erase(start, end - start);
     return true;
+  }
+
+  bool HandleDelete() {
+    if (DeleteImpl()) {
+      on_change();
+      return true;
+    }
+    return false;
   }
 
   bool HandleArrowLeft() {
@@ -345,7 +354,7 @@ class InputBase : public ComponentBase, public InputOption {
   bool HandleCharacter(const std::string& character) {
     if (!insert() && cursor_position() < (int)content->size() &&
         content()[cursor_position()] != '\n') {
-      HandleDelete();
+      DeleteImpl();
     }
     content->insert(cursor_position(), character);
     cursor_position() += character.size();


### PR DESCRIPTION
I noticed that the `on_change` callback for the `Input()` component is not called when backspace or delete keys are pressed. This PR fixes that.