### PR TITLE
ftxui_set_options: properly check the current compiler.

### DIFF
--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -45,7 +45,7 @@ function(ftxui_set_options library)
 
   # Force Microsoft Visual Studio to decode sources files in UTF-8. This applies
   # to the library and the library users.
-  if (MSVC)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL MSVC)
     target_compile_options(${library} PUBLIC "/utf-8")
   endif()
 

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -45,7 +45,6 @@ function(ftxui_set_options library)
 
   # Force Microsoft Visual Studio to decode sources files in UTF-8. This applies
   # to the library and the library users.
-
   if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(${library} PUBLIC "/utf-8")
   endif()

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -45,7 +45,8 @@ function(ftxui_set_options library)
 
   # Force Microsoft Visual Studio to decode sources files in UTF-8. This applies
   # to the library and the library users.
-  if (CMAKE_CXX_COMPILER_ID STREQUAL MSVC)
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(${library} PUBLIC "/utf-8")
   endif()
 


### PR DESCRIPTION
This pr aims to fix the problem discussed in [this issue](https://github.com/ArthurSonzogni/FTXUI/issues/801).