### PR TITLE
Make Checkbox take focus when clicked

### DIFF
--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -73,6 +73,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
         event.mouse().motion == Mouse::Pressed) {
       *checked = !*checked;
       on_change();
+      TakeFocus();
       return true;
     }
 


### PR DESCRIPTION
Interacting with a component is a strong indicator of focus, so clicking a checkbox should cause it to take focus. This also allows keyboard input to toggle a checkbox after clicking it. (#798)