### PR TITLE
Remove system install interface "include"

### DIFF
--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -30,11 +30,6 @@ function(ftxui_set_options library)
     )
   endif()
 
-  target_include_directories(${library} SYSTEM
-    INTERFACE
-      $<INSTALL_INTERFACE:include>
-  )
-
   target_include_directories(${library}
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>


### PR DESCRIPTION
I am currently packaging ftxui for debian. I am able to package it and also install it fine from Tag 5.0.0

When using installed ftxui with cmake's find_package, cmake is unable to configure ftxui::screen. 
It complains about a path "/include" in its INTERFACE_INCLUDE_DIRECTORIES. 

Removing the SYSTEM INSTALL_INTERFACE from ftxui_set_options seems to fix the issue without causing any other problems in building and using the library.

This is the error (running on debian sid):

```none
-- The CXX compiler identification is GNU 13.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Configuring done (0.4s)
CMake Error in CMakeLists.txt:
  Imported target "ftxui::screen" includes non-existent path

    "/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.



-- Generating done (0.0s)

```

Not sure if this is the correct way to solve this, but it doesn't seem to have any impact on the library's functioning itself.
Atleast from my preliminary analysis.