### PR TITLE
Feature: adding exit button in the homescreen example

### DIFF
--- a/examples/component/homescreen.cpp
+++ b/examples/component/homescreen.cpp
@@ -490,15 +490,24 @@ int main() {
       },
       &tab_index);
 
+  auto exit_button = Button(
+      "Exit", [&] { screen.Exit(); }, ButtonOption::Animated());
+
   auto main_container = Container::Vertical({
-      tab_selection,
-      tab_content,
+    Container::Horizontal({
+        tab_selection,
+        exit_button,
+    }),
+    tab_content,
   });
 
   auto main_renderer = Renderer(main_container, [&] {
     return vbox({
         text("FTXUI Demo") | bold | hcenter,
-        tab_selection->Render(),
+        hbox({
+            tab_selection->Render() | flex,
+            exit_button->Render(),
+        }),
         tab_content->Render() | flex,
     });
   });


### PR DESCRIPTION
- Currently there is no clean way to exit an example (we need to press ctrl + c to do so)

- Added a exit button in the homescreen example to propose a cleaner way to exit the execution.

<img width="1369" alt="image" src="https://github.com/ArthurSonzogni/FTXUI/assets/31391202/420cc5ea-6970-4b50-88c6-f69dd4c60874">

