### PR TITLE
Fix ResizableSplit handling keyboard navigation incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ current (development)
   Fixed by @chrysante in chrysante in PR #776.
 - Bugfix: Propertly restore cursor shape on exit. See #792.
 - Bugfix: Fix cursor position in when in the last column. See #831.
+- Bugfix: Fix `ResizeableSplit` keyboard navigation. Fixed by #842.
 
 ### Dom
 - Feature: Add `hscroll_indicator`. It display an horizontal indicator

--- a/src/ftxui/component/resizable_split.cpp
+++ b/src/ftxui/component/resizable_split.cpp
@@ -23,10 +23,32 @@ class ResizableSplitBase : public ComponentBase {
  public:
   explicit ResizableSplitBase(ResizableSplitOption options)
       : options_(std::move(options)) {
-    Add(Container::Horizontal({
-        options_->main,
-        options_->back,
-    }));
+    switch (options_->direction()) {
+      case Direction::Left:
+        Add(Container::Horizontal({
+            options_->main,
+            options_->back,
+        }));
+        break;
+      case Direction::Right:
+        Add(Container::Horizontal({
+            options_->back,
+            options_->main,
+        }));
+        break;
+      case Direction::Up:
+        Add(Container::Vertical({
+            options_->main,
+            options_->back,
+        }));
+        break;
+      case Direction::Down:
+        Add(Container::Vertical({
+            options_->back,
+            options_->main,
+        }));
+        break;
+    }
   }
 
   bool OnEvent(Event event) final {

--- a/src/ftxui/component/resizable_split_test.cpp
+++ b/src/ftxui/component/resizable_split_test.cpp
@@ -19,7 +19,7 @@ namespace ftxui {
 
 namespace {
 Component BasicComponent() {
-  return Renderer([] { return text(""); });
+  return Renderer([](bool focused) { return text(""); });
 }
 
 Event MousePressed(int x, int y) {
@@ -205,6 +205,33 @@ TEST(ResizableSplit, BasicBottomWithCustomSeparator) {
   EXPECT_EQ(position, 2);
   EXPECT_TRUE(component->OnEvent(MouseReleased(1, 1)));
   EXPECT_EQ(position, 2);
+}
+
+TEST(ResizableSplit, NavigationVertical) {
+  int position = 0;
+  auto component_top = BasicComponent();
+  auto component_bottom = BasicComponent();
+  auto component =
+      ResizableSplitTop(component_top, component_bottom, &position);
+
+  EXPECT_TRUE(component_top->Active());
+  EXPECT_FALSE(component_bottom->Active());
+
+  EXPECT_FALSE(component->OnEvent(Event::ArrowRight));
+  EXPECT_TRUE(component_top->Active());
+  EXPECT_FALSE(component_bottom->Active());
+
+  EXPECT_TRUE(component->OnEvent(Event::ArrowDown));
+  EXPECT_FALSE(component_top->Active());
+  EXPECT_TRUE(component_bottom->Active());
+
+  EXPECT_FALSE(component->OnEvent(Event::ArrowDown));
+  EXPECT_FALSE(component_top->Active());
+  EXPECT_TRUE(component_bottom->Active());
+
+  EXPECT_TRUE(component->OnEvent(Event::ArrowUp));
+  EXPECT_TRUE(component_top->Active());
+  EXPECT_FALSE(component_bottom->Active());
 }
 
 }  // namespace ftxui


### PR DESCRIPTION
example:
```cpp
auto focusableText = [] {
  return Renderer([](bool focused) {
    if (focused) {
      return text("focused!") | focus;
    } else {
      return text("not focused");
    }
  });
};
int top_size = 1;
screen.Loop(ResizableSplitTop(focusableText(), focusableText(), &top_size));
```

output:
```
focused!
--------------
not focused
```

Expected behavior: The text changes when I press up/down keys.
Actual behavior: The text changes when I press left/right keys.

I think this is because ResizableSplit internally uses Container::Horizontal regardless of its direction option, so I fixed it to use correct container.
