### PR TITLE
Add ostree-tui to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Prebuilt components are declared in [<ftxui/component/component.hpp>](https://ar
 Feel free to add your projects here:
 - [json-tui](https://github.com/ArthurSonzogni/json-tui)
 - [git-tui](https://github.com/ArthurSonzogni/git-tui)
+- [ostree-tui](https://github.com/AP-Sensing/ostree-tui)
 - [rgb-tui](https://github.com/ArthurSonzogni/rgb-tui)
 - [chrome-log-beautifier](https://github.com/ArthurSonzogni/chrome-log-beautifier)
 - [x86-64 CPU Architecture Simulation](https://github.com/AnisBdz/CPU)


### PR DESCRIPTION
## ostree-tui using FTXUI
I am currently working on [ostree-tui](https://github.com/AP-Sensing/ostree-tui), a **TUI** for **OSTree** (a Version Control System for operating system binaries). It makes use of this awesome TUI library and I would love to add it to the **FTXUI project list**.

## Addition to Project-List
I couldn't determine any order of the listed projects, which is why I suggest putting the [ostree-tui](https://github.com/AP-Sensing/ostree-tui) right under the [git-tui](https://github.com/ArthurSonzogni/git-tui), as they are very similar projects (in the sense that both are built for supporting the user in handling a VCS).