### PR TITLE
Add missing include guard for screen/pixel.hpp

### DIFF
--- a/include/ftxui/screen/pixel.hpp
+++ b/include/ftxui/screen/pixel.hpp
@@ -1,6 +1,8 @@
 // Copyright 2024 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.
+#ifndef FTXUI_SCREEN_PIXEL_HPP
+#define FTXUI_SCREEN_PIXEL_HPP
 
 #include <cstdint>                 // for uint8_t
 #include <string>                  // for string, basic_string, allocator
@@ -46,3 +48,5 @@ struct Pixel {
 };
 
 }  // namespace ftxui
+
+#endif // FTXUI_SCREEN_PIXEL_HPP


### PR DESCRIPTION
I'm not sure whether it's intended or just oversighted, but the header `pixel.hpp` does not have include guard, for it's only included in `image.hpp` so there hadn't had any issue while using. I just added include guard:
```cpp
#ifndef FTXUI_SCREEN_PIXEL_HPP
#define FTXUI_SCREEN_PIXEL_HPP
...
#endif // FTXUI_SCREEN_PIXEL_HPP
```
