### PR TITLE
add clion paths to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ out/
 # tools directory:
 !tools/**/*.sh
 !tools/**/*.cpp
+
+# clion config dir
+.idea/
+# clion build dirs
+cmake-build-*


### PR DESCRIPTION
Clion creates some folders that would be nice to add to gitignore

`.idea` - local config dir
`cmake-build-*` - default build dirs for cmake (cmake-build-Debug/cmake-build-Release/etc)