### PR TITLE
Added -fPIC compile option on UNIX

### DIFF
--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -49,6 +49,10 @@ function(ftxui_set_options library)
     target_compile_options(${library} PUBLIC "/utf-8")
   endif()
 
+  if(UNIX)
+    target_compile_options(${library} PRIVATE "-fPIC")
+  endif()
+
   # Add as many warning as possible:
   if (WIN32)
     if (MSVC)

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -49,9 +49,11 @@ function(ftxui_set_options library)
     target_compile_options(${library} PUBLIC "/utf-8")
   endif()
 
-  if(UNIX)
-    target_compile_options(${library} PRIVATE "-fPIC")
-  endif()
+  # CMake does automatically add -fPIC when linking a shared library, but it
+  # does not add it when linking a static library. This is a problem when the 
+  # static library is later linked into a shared library. 
+  # Doing it helps some users.
+  set_property(TARGET ${library} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
   # Add as many warning as possible:
   if (WIN32)


### PR DESCRIPTION
Without this, a shared object containing FTXUI code won't work. This is only needed on Unix.