### PR TITLE
Table: support initializer list constructor.

### DIFF
--- a/include/ftxui/dom/table.hpp
+++ b/include/ftxui/dom/table.hpp
@@ -38,6 +38,7 @@ class Table {
   Table();
   explicit Table(std::vector<std::vector<std::string>>);
   explicit Table(std::vector<std::vector<Element>>);
+  Table(std::initializer_list<std::vector<std::string>> init);
   TableSelection SelectAll();
   TableSelection SelectCell(int column, int row);
   TableSelection SelectRow(int row_index);

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -71,6 +71,22 @@ Table::Table(std::vector<std::vector<Element>> input) {
   Initialize(std::move(input));
 }
 
+// @brief Create a table from a list of list of string.
+// @param init The input data.
+// @ingroup dom
+Table::Table(std::initializer_list<std::vector<std::string>> init) {
+  std::vector<std::vector<Element>> input;
+  for (const auto& row : init) {
+    std::vector<Element> output_row;
+    output_row.reserve(row.size());
+    for (const auto& cell : row) {
+      output_row.push_back(text(cell));
+    }
+    input.push_back(std::move(output_row));
+  }
+  Initialize(std::move(input));
+}
+
 // private
 void Table::Initialize(std::vector<std::vector<Element>> input) {
   input_dim_y_ = static_cast<int>(input.size());

--- a/src/ftxui/dom/table_test.cpp
+++ b/src/ftxui/dom/table_test.cpp
@@ -733,5 +733,17 @@ TEST(TableTest, Merge) {
       screen.ToString());
 }
 
+TEST(TableTest, Issue912) {
+  Table({
+      {"a"},
+  });
+  Table({
+      {"a", "b"},
+  });
+  Table({
+      {"a", "b", "c"},
+  });
+}
+
 }  // namespace ftxui
 // NOLINTEND


### PR DESCRIPTION
To avoid burdening the user with explicit type construction when using the library, we can use a constructor that accepts an initializer list (std::initializer_list). This allows users to pass initializer lists directly without having to wrap them in
std::vector<std::vector<std::string>>. This resolves the ambiguous case when the inner list contains only two elements.

Bug:https://github.com/ArthurSonzogni/FTXUI/issues/912