### PR TITLE
add ftxui-image-view for image display

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Prebuilt components are declared in [<ftxui/component/component.hpp>](https://ar
 - *Want to share a useful Component for FTXUI? Feel free to add yours here*
 - [ftxui-grid-container](https://github.com/mingsheng13/grid-container-ftxui)
 - [ftxui-ip-input](https://github.com/mingsheng13/ip-input-ftxui)
+- [ftxui-image-view](https://github.com/ljrrjl/ftxui-image-view.git): For Image Display.
 
 
 ## Project using FTXUI


### PR DESCRIPTION
issue: [Add an image display component](https://github.com/ArthurSonzogni/FTXUI/issues/782)
Hi, I've tried to add an [image display component](https://github.com/ljrrjl/ftxui-image-view) to FTXUI, at the moment the efficiency and functionality of this component is not perfect, I'll try to improve it later on.