### PR TITLE
Add index to EntryState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ current (development)
 - Bugfix: Fix cursor position in when in the last column. See #831.
 - Bugfix: Fix `ResizeableSplit` keyboard navigation. Fixed by #842.
 - Bugfix: Fix `Menu` focus. See #841
+- Feature: Add `ComponentBase::Index()`. This allows to get the index of a
+  component in its parent. See #932
+- Feature: Add `EntryState::index`. This allows to get the index of a menu entry.
+  See #932
 
 ### Dom
 - Feature: Add `hscroll_indicator`. It display an horizontal indicator

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -44,6 +44,7 @@ class ComponentBase {
   ComponentBase* Parent() const;
   Component& ChildAt(size_t i);
   size_t ChildCount() const;
+  int IndexOf(ComponentBase* child) const;
   void Add(Component children);
   void Detach();
   void DetachAllChildren();

--- a/include/ftxui/component/component_base.hpp
+++ b/include/ftxui/component/component_base.hpp
@@ -44,7 +44,7 @@ class ComponentBase {
   ComponentBase* Parent() const;
   Component& ChildAt(size_t i);
   size_t ChildCount() const;
-  int IndexOf(ComponentBase* child) const;
+  int Index() const;
   void Add(Component children);
   void Detach();
   void DetachAllChildren();

--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -25,6 +25,7 @@ struct EntryState {
   bool state;         ///< The state of the button/checkbox/radiobox
   bool active;        ///< Whether the entry is the active one.
   bool focused;       ///< Whether the entry is one focused by the user.
+  int index;          ///< Index of the entry when applicable or -1.
 };
 
 struct UnderlineOption {

--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -53,6 +53,7 @@ class ButtonBase : public ComponentBase, public ButtonOption {
         false,
         active,
         focused_or_hover,
+        -1,
     };
 
     auto element = (transform ? transform : DefaultTransform)  //

--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -48,12 +48,8 @@ class ButtonBase : public ComponentBase, public ButtonOption {
     }
 
     auto focus_management = focused ? focus : active ? select : nothing;
-    const EntryState state = {
-        *label,
-        false,
-        active,
-        focused_or_hover,
-        -1,
+    const EntryState state{
+        *label, false, active, focused_or_hover, Index(),
     };
 
     auto element = (transform ? transform : DefaultTransform)  //

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -32,6 +32,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
         *checked,
         is_active,
         is_focused || hovered_,
+        -1,
     };
     auto element = (transform ? transform : CheckboxOption::Simple().transform)(
         entry_state);

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -28,11 +28,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
     const bool is_active = Active();
     auto focus_management = is_focused ? focus : is_active ? select : nothing;
     auto entry_state = EntryState{
-        *label,
-        *checked,
-        is_active,
-        is_focused || hovered_,
-        -1,
+        *label, *checked, is_active, is_focused || hovered_, -1,
     };
     auto element = (transform ? transform : CheckboxOption::Simple().transform)(
         entry_state);

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -51,7 +51,7 @@ size_t ComponentBase::ChildCount() const {
   return children_.size();
 }
 
-/// @brief Return index of child or -1 if not found.
+/// @brief Return index of the component in its parent. -1 if no parent.
 /// @ingroup component
 int ComponentBase::Index() const {
   if (parent_ == nullptr) {

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -51,6 +51,18 @@ size_t ComponentBase::ChildCount() const {
   return children_.size();
 }
 
+/// @brief Return index of child or -1 if not found.
+/// @ingroup component
+int ComponentBase::IndexOf(ComponentBase* child) const {
+  int index = 0;
+  for (Component c : children_) {
+    if (&(*c) == child)
+      return index;
+    index++;
+  }
+  return -1;
+}
+
 /// @brief Add a child.
 /// @@param child The child to be attached.
 /// @ingroup component

--- a/src/ftxui/component/component.cpp
+++ b/src/ftxui/component/component.cpp
@@ -53,14 +53,18 @@ size_t ComponentBase::ChildCount() const {
 
 /// @brief Return index of child or -1 if not found.
 /// @ingroup component
-int ComponentBase::IndexOf(ComponentBase* child) const {
+int ComponentBase::Index() const {
+  if (parent_ == nullptr) {
+    return -1;
+  }
   int index = 0;
-  for (Component c : children_) {
-    if (&(*c) == child)
+  for (const Component& child : parent_->children_) {
+    if (child.get() == this) {
       return index;
+    }
     index++;
   }
-  return -1;
+  return -1;  // Not reached.
 }
 
 /// @brief Add a child.

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -127,6 +127,7 @@ class MenuBase : public ComponentBase, public MenuOption {
           false,
           is_selected,
           is_focused,
+          i,
       };
 
       auto focus_management = (selected_focus_ != i) ? nothing
@@ -630,6 +631,7 @@ Component MenuEntry(MenuEntryOption option) {
           false,
           hovered_,
           focused,
+          Parent()->IndexOf(this),
       };
 
       const Element element =

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -123,11 +123,7 @@ class MenuBase : public ComponentBase, public MenuOption {
       const bool is_selected = (selected() == i);
 
       const EntryState state = {
-          entries[i],
-          false,
-          is_selected,
-          is_focused,
-          i,
+          entries[i], false, is_selected, is_focused, i,
       };
 
       auto focus_management = (selected_focus_ != i) ? nothing
@@ -626,12 +622,8 @@ Component MenuEntry(MenuEntryOption option) {
       const bool focused = Focused();
       UpdateAnimationTarget();
 
-      const EntryState state = {
-          label(),
-          false,
-          hovered_,
-          focused,
-          Parent()->IndexOf(this),
+      const EntryState state{
+          label(), false, hovered_, focused, Index(),
       };
 
       const Element element =

--- a/src/ftxui/component/menu_test.cpp
+++ b/src/ftxui/component/menu_test.cpp
@@ -266,10 +266,8 @@ TEST(MenuTest, MenuEntryIndex) {
   menu->OnEvent(Event::ArrowDown);
   menu->OnEvent(Event::ArrowDown);
   menu->OnEvent(Event::Return);
-  for(int idx = 0; idx < menu->ChildCount(); idx++)
-  {
-    auto child = menu->ChildAt(idx);
-    EXPECT_EQ(menu->IndexOf(&(*child)), idx);  
+  for (int index = 0; index < menu->ChildCount(); index++) {
+    EXPECT_EQ(menu->ChildAt(index)->Index(), index);
   }
 }
 

--- a/src/ftxui/component/menu_test.cpp
+++ b/src/ftxui/component/menu_test.cpp
@@ -226,5 +226,52 @@ TEST(MenuTest, AnimationsVertical) {
   }
 }
 
+TEST(MenuTest, EntryIndex) {
+  int selected = 0;
+  std::vector<std::string> entries = {"0", "1", "2"};
+
+  auto option = MenuOption::Vertical();
+  option.entries = &entries;
+  option.selected = &selected;
+  option.entries_option.transform = [&](const EntryState& state) {
+    int curidx = std::stoi(state.label);
+    EXPECT_EQ(state.index, curidx);
+    return text(state.label);
+  };
+  auto menu = Menu(option);
+  menu->OnEvent(Event::ArrowDown);
+  menu->OnEvent(Event::ArrowDown);
+  menu->OnEvent(Event::Return);
+  entries.resize(2);
+  (void)menu->Render();
+}
+
+TEST(MenuTest, MenuEntryIndex) {
+  int selected = 0;
+
+  MenuEntryOption option;
+  option.transform = [&](const EntryState& state) {
+    int curidx = std::stoi(state.label);
+    EXPECT_EQ(state.index, curidx);
+    return text(state.label);
+  };
+  auto menu = Container::Vertical(
+      {
+          MenuEntry("0", option),
+          MenuEntry("1", option),
+          MenuEntry("2", option),
+      },
+      &selected);
+
+  menu->OnEvent(Event::ArrowDown);
+  menu->OnEvent(Event::ArrowDown);
+  menu->OnEvent(Event::Return);
+  for(int idx = 0; idx < menu->ChildCount(); idx++)
+  {
+    auto child = menu->ChildAt(idx);
+    EXPECT_EQ(menu->IndexOf(&(*child)), idx);  
+  }
+}
+
 }  // namespace ftxui
 // NOLINTEND

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -44,6 +44,7 @@ class RadioboxBase : public ComponentBase, public RadioboxOption {
           selected() == i,
           is_selected,
           is_focused,
+          i,
       };
       auto element =
           (transform ? transform : RadioboxOption::Simple().transform)(state);

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -40,11 +40,7 @@ class RadioboxBase : public ComponentBase, public RadioboxOption {
                               : is_menu_focused ? focus
                                                 : select;
       auto state = EntryState{
-          entries[i],
-          selected() == i,
-          is_selected,
-          is_focused,
-          i,
+          entries[i], selected() == i, is_selected, is_focused, i,
       };
       auto element =
           (transform ? transform : RadioboxOption::Simple().transform)(state);


### PR DESCRIPTION
Change to enable checking item index via MenuEntryOption.transform, so custom code can fetch data instead of relying on label string.

Note the index lookup via parent in MenuEntry.