### PR TITLE
Clear terminal output of interactive screen if alternate screen not in use

### DIFF
--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -121,6 +121,7 @@ class ScreenInteractive : public Screen {
   bool mouse_captured = false;
   bool previous_frame_resized_ = false;
 
+  bool validated_ = false;
   bool frame_valid_ = false;
 
   bool force_handle_ctrl_c_ = true;

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -858,6 +858,14 @@ void ScreenInteractive::Draw(Component component) {
   ResetCursorPosition();
   std::cout << ResetPosition(/*clear=*/resized);
 
+  // clear terminal output if non-fullscreen interactive screen dimx decreases
+#if !defined(_WIN32)
+  if ((dimx < dimx_) && validated_ && !use_alternative_screen_) {
+    std::cout << "\033[J";
+    std::cout << "\033[H";
+  }
+#endif
+
   // Resize the screen if needed.
   if (resized) {
     dimx_ = dimx;


### PR DESCRIPTION
This PR is submitted to close https://github.com/ArthurSonzogni/FTXUI/issues/951.

Few moments about changes:
1) Interactive screen is always created with dimx = 0 and dimy = 0, so on first iteration of loop screen will be resized.
I add new variable validated_ that is true since second iteration.
I think we can avoid this by passing component_ to the PreMain function to set init dimx and dimy, but than we should add component to the Install function, and than to the PostMain function...
2) Some part of scrollback (no more than one terminal screen) will be cleared because of how I chose to implement this, but i do not think it is big problem