### PR TITLE
Add option to change cursor shape on exit of ScreenInteractive loop

### DIFF
--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -39,6 +39,8 @@ class ScreenInteractive : public Screen {
   // Options. Must be called before Loop().
   void TrackMouse(bool enable = true);
 
+  void SetCursorReset(Screen::Cursor::Shape shape);
+
   // Return the currently active screen, nullptr if none.
   static ScreenInteractive* Active();
 

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -441,6 +441,11 @@ void ScreenInteractive::TrackMouse(bool enable) {
   track_mouse_ = enable;
 }
 
+/// @brief Set cursor shape on exit of main loop
+void ScreenInteractive::SetCursorReset(Screen::Cursor::Shape shape) {
+  cursor_reset_shape_ = shape;
+}
+
 /// @brief Add a task to the main loop.
 /// It will be executed later, after every other scheduled tasks.
 /// @ingroup component


### PR DESCRIPTION
Currently there is no option to set cursor_reset_shape_ on ScreenInteractive class. Because of that, cursor is always block and blinks (cursor shape is always 1). 

This PR adds SetCursorReset method as option.

Will close https://github.com/ArthurSonzogni/FTXUI/issues/904