### PR TITLE
Fix typo borderLight and borderDashed

### DIFF
--- a/src/ftxui/dom/border.cpp
+++ b/src/ftxui/dom/border.cpp
@@ -267,7 +267,7 @@ Decorator borderStyled(BorderStyle style, Color foreground_color) {
   };
 }
 
-/// @brief Draw a light border around the element.
+/// @brief Draw a dashed border around the element.
 /// @ingroup dom
 /// @see border
 /// @see borderLight
@@ -302,7 +302,7 @@ Element borderDashed(Element child) {
   return std::make_shared<Border>(unpack(std::move(child)), DASHED);
 }
 
-/// @brief Draw a dashed border around the element.
+/// @brief Draw a light border around the element.
 /// @ingroup dom
 /// @see border
 /// @see borderLight


### PR DESCRIPTION
Seems like the documentation [site](https://arthursonzogni.github.io/FTXUI/namespaceftxui.html#aa074cdab57eeb47b99f1699bcc8addd8) has this as a minor typo.

<img width="954" alt="Screenshot 2024-11-20 at 1 38 25 PM" src="https://github.com/user-attachments/assets/7307576f-afd6-4726-8a6c-432b2097ccdd">
<img width="943" alt="Screenshot 2024-11-20 at 1 39 14 PM" src="https://github.com/user-attachments/assets/9d3dc79b-96b0-4c99-acb1-5eea5c9ad991">
