### PR TITLE
Add `terminal-rain` and `keywords` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ Feel free to add your projects here:
 - [TUISIC](https://github.com/Dark-Kernel/tuisic)
 - [inLimbo](https://github.com/nots1dd/inLimbo)
 - [BestEdrOfTheMarket](https://github.com/Xacone/BestEdrOfTheMarket)
+- [terminal-rain](https://github.com/Oakamoore/terminal-rain)
+- [keywords](https://github.com/Oakamoore/keywords)
 
 ### [cpp-best-practices/game_jam](https://github.com/cpp-best-practices/game_jam)
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Feel free to add your projects here:
 - [inLimbo](https://github.com/nots1dd/inLimbo)
 - [BestEdrOfTheMarket](https://github.com/Xacone/BestEdrOfTheMarket)
 - [terminal-rain](https://github.com/Oakamoore/terminal-rain)
-- [keywords](https://github.com/Oakamoore/keywords)
+- [keywords](https://github.com/Oakamoore/keywords) ([Play web version :heart:](https://oakamoore.itch.io/keywords))
 
 ### [cpp-best-practices/game_jam](https://github.com/cpp-best-practices/game_jam)
 


### PR DESCRIPTION
I made these two projects a while ago, but recently ported `keywords` to WebAssembly and realised that I hadn't added them to FTXUI's `README.md`.

The WebAssembly version of `keywords` is available [here](https://oakamoore.itch.io/keywords).