### PR TITLE
Bugfix: Avoid crash with ResizeableSplit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Development
+-----------
+### Component
+- Bugfix: Fix a crash with ResizeableSplit. See #1023.
+  - Clamp screen size to terminal size.
+  - Disallow `ResizeableSplit` with negative size.
+
+### Dom
+- Bugfix: Disallow specifying a negative size constraint. See #1023.
+
+
 6.0.2 (2025-03-30)
 -----
 

--- a/src/ftxui/component/resizable_split.cpp
+++ b/src/ftxui/component/resizable_split.cpp
@@ -77,16 +77,16 @@ class ResizableSplitBase : public ComponentBase {
 
     switch (options_->direction()) {
       case Direction::Left:
-        options_->main_size() = event.mouse().x - box_.x_min;
+        options_->main_size() = std::max(0, event.mouse().x - box_.x_min);
         return true;
       case Direction::Right:
-        options_->main_size() = box_.x_max - event.mouse().x;
+        options_->main_size() = std::max(0, box_.x_max - event.mouse().x);
         return true;
       case Direction::Up:
-        options_->main_size() = event.mouse().y - box_.y_min;
+        options_->main_size() = std::max(0, event.mouse().y - box_.y_min);
         return true;
       case Direction::Down:
-        options_->main_size() = box_.y_max - event.mouse().y;
+        options_->main_size() = std::max(0, box_.y_max - event.mouse().y);
         return true;
     }
 

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -34,6 +34,7 @@
 #include "ftxui/dom/requirement.hpp"                  // for Requirement
 #include "ftxui/screen/pixel.hpp"                     // for Pixel
 #include "ftxui/screen/terminal.hpp"                  // for Dimensions, Size
+#include "ftxui/screen/util.hpp"                      // for util::clamp
 
 #if defined(_WIN32)
 #define DEFINE_CONSOLEV2_PROPERTIES
@@ -917,15 +918,15 @@ void ScreenInteractive::Draw(Component component) {
       break;
     case Dimension::TerminalOutput:
       dimx = terminal.dimx;
-      dimy = document->requirement().min_y;
+      dimy = util::clamp(document->requirement().min_y, 0, terminal.dimy);
       break;
     case Dimension::Fullscreen:
       dimx = terminal.dimx;
       dimy = terminal.dimy;
       break;
     case Dimension::FitComponent:
-      dimx = std::min(document->requirement().min_x, terminal.dimx);
-      dimy = std::min(document->requirement().min_y, terminal.dimy);
+      dimx = util::clamp(document->requirement().min_x, 0, terminal.dimx);
+      dimy = util::clamp(document->requirement().min_y, 0, terminal.dimy);
       break;
   }
 

--- a/src/ftxui/dom/size.cpp
+++ b/src/ftxui/dom/size.cpp
@@ -19,7 +19,7 @@ class Size : public Node {
       : Node(unpack(std::move(child))),
         direction_(direction),
         constraint_(constraint),
-        value_(value) {}
+        value_(std::max(0, value)) {}
 
   void ComputeRequirement() override {
     Node::ComputeRequirement();


### PR DESCRIPTION
Component
---------
- Bugfix: Fix a crash with ResizeableSplit. See #1023.
  - Clamp screen size to terminal size.
  - Disallow `ResizeableSplit` with negative size.

Dom
---
- Bugfix: Disallow specifying a negative size constraint. See #1023.

Bug: https://github.com/ArthurSonzogni/FTXUI/issues/1023