### PR TITLE
Fix comment typos in Maybe component

### DIFF
--- a/src/ftxui/component/maybe.cpp
+++ b/src/ftxui/component/maybe.cpp
@@ -15,7 +15,7 @@ namespace ftxui {
 
 /// @brief Decorate a component |child|. It is shown only when |show| returns
 /// true.
-/// @param child the compoenent to decorate.
+/// @param child the component to decorate.
 /// @param show a function returning whether |child| should shown.
 /// @ingroup component
 Component Maybe(Component child, std::function<bool()> show) {
@@ -61,7 +61,7 @@ ComponentDecorator Maybe(std::function<bool()> show) {
 }
 
 /// @brief Decorate a component |child|. It is shown only when |show| is true.
-/// @param child the compoennt to decorate.
+/// @param child the component to decorate.
 /// @param show a boolean. |child| is shown when |show| is true.
 /// @ingroup component
 ///


### PR DESCRIPTION
## Summary
- correct misspellings of "component" in maybe.cpp comments

## Testing
- `cmake -S . -B build -DFTXUI_BUILD_TESTS=ON -DFTXUI_BUILD_EXAMPLES=OFF` *(failed: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_684046425d308320b0a651a7496a3dab