### PR TITLE
Fix comment bug

### DIFF
--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -1561,7 +1561,7 @@ std::vector<WordBreakProperty> Utf8ToWordBreakProperty(
   return out;
 }
 
-/// Convert a UTF8 std::string into a std::wstring.
+/// Convert a std::wstring into a UTF8 std::string.
 std::string to_string(const std::wstring& s) {
   std::string out;
 
@@ -1633,7 +1633,7 @@ std::string to_string(const std::wstring& s) {
   return out;
 }
 
-/// Convert a std::wstring into a UTF8 std::string.
+/// Convert a UTF8 std::string into a std::wstring.
 std::wstring to_wstring(const std::string& s) {
   std::wstring out;
 


### PR DESCRIPTION
## Summary
- fix incorrect comments for UTF conversion helpers

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DFTXUI_BUILD_TESTS=ON -DFTXUI_BUILD_TESTS_FUZZER=OFF`
- `cmake --build build`
- `ctest -C Debug --rerun-failed --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684026042cdc8320aeee3361dc36304d