### PR TITLE
Fix minor typo in terminal comment

### DIFF
--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -72,7 +72,7 @@ Terminal::Color ComputeColorSupport() {
   }
 
 #if defined(FTXUI_MICROSOFT_TERMINAL_FALLBACK)
-  // Microsoft terminals do not properly declare themselve supporting true
+  // Microsoft terminals do not properly declare themselves supporting true
   // colors: https://github.com/microsoft/terminal/issues/1040
   // As a fallback, assume microsoft terminal are the ones not setting those
   // variables, and enable true colors.


### PR DESCRIPTION
## Summary
- fix a typo in the Microsoft terminal fallback comment

## Testing
- `cmake -B build ...` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68404754a0d48320bcf230059cacd204