### PR TITLE
Fix typos and grammar in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Element can be arranged together:
   - inside a grid with `gridbox`
   - wrap along one direction using the `flexbox`.
   
-Element can become flexible using the the `flex` decorator.
+Element can become flexible using the `flex` decorator.
   
 [Example](https://arthursonzogni.github.io/FTXUI/examples_2dom_2vbox_hbox_8cpp-example.html) using `hbox`, `vbox` and `filler`.
 

--- a/doc/cpp20-modules.md
+++ b/doc/cpp20-modules.md
@@ -1,6 +1,5 @@
 @page cpp20-modules C++20 Modules
 
-coucou
 
 > [!WARNING]
 > This feature is still in development, and the API may change in future releases.
@@ -8,10 +7,10 @@ coucou
 > of C++20 modules in FTXUI. If you encounter any issues or have suggestions,
 > please open an issue.
 
-FTXUI provides an experimental support for [C++20
-modules](https://en.cppreference.com/w/cpp/language/modules) to improve 
-compilation times and code organization. The existing API has a module 
-corresponding to each header.
+FTXUI experimentally supports
+[C++20 modules](https://en.cppreference.com/w/cpp/language/modules) to reduce
+compilation times and improve code organization. Each header has a
+corresponding module.
 
 **Example with CMake and Ninja**
 

--- a/doc/installation_cmake.md
+++ b/doc/installation_cmake.md
@@ -10,7 +10,7 @@ This page explains how to depend on FTXUI using [CMake](https://cmake.org).
 
 This approach downloads FTXUI at configure time and doesn't require a system-wide install.
 
-```fortran 
+```cmake 
 include(FetchContent)
 
 FetchContent_Declare(ftxui
@@ -34,8 +34,8 @@ This ensures reproducible builds and easy dependency management.
 
 If FTXUI is installed system-wide or via a package manager (e.g. vcpkg or Conan), you can use:
 
-```fortran 
-fortranind_package(ftxui REQUIRED)
+```cmake 
+find_package(ftxui REQUIRED)
 
 add_executable(main main.cpp)
 target_link_libraries(main
@@ -51,7 +51,7 @@ Make sure the package is visible in your `CMAKE_PREFIX_PATH`.
 
 You can also add FTXUI as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), keeping it as part of your repository:
 
-```fortran
+```cmake
 git submodule add https://github.com/ArthurSonzogni/FTXUI external/ftxui
 git submodule update --init --recursive
 ```
@@ -66,7 +66,7 @@ git submodule update --init --recursive
 
 Then in your `CMakeLists.txt`:
 
-```fortran
+```cmake
 add_subdirectory(external/ftxui)
 
 add_executable(main main.cpp)

--- a/doc/module-component.md
+++ b/doc/module-component.md
@@ -14,7 +14,7 @@ A `ftxui::Component` is a shared pointer to a `ftxui::ComponentBase`. The latter
   - `ftxui::ComponentBase::Render()`: How to render the interface.
   - `ftxui::ComponentBase::OnEvent()`: How to react to events.
   - `ftxui::ComponentBase::Add()`: Construct a parent/child relationship
-    between two components. The tree of component is used to define how to
+    between two components. The tree of components is used to define how to
     navigate using the keyboard.
 
 `ftxui::Element` are used to render a single frame.
@@ -45,7 +45,7 @@ Produced by: `ftxui::Input()` from "ftxui/component/component.hpp"
 
 ## Filtered input
 
-On can filter out the characters received by the input component, using
+One can filter out the characters received by the input component, using
 `ftxui::CatchEvent`.
 
 ```cpp
@@ -123,8 +123,8 @@ Produced by: `ftxui::Radiobox()` from "ftxui/component/component.hpp"
 
 # Dropdown {#component-dropdown}
 
-A drop down menu is a component that when checked display a list of element for
-the user to select one.
+A drop-down menu is a component that, when opened, displays a list of elements
+for the user to select from.
 
 [Example](https://arthursonzogni.github.io/FTXUI/examples_2component_2dropdown_8cpp-example.html):
 
@@ -204,12 +204,12 @@ component = component
 
 # Collapsible {#component-collapsible}
 
-Useful for visual elements whose visibility can be toggle on/off by the user.
-Essentially, this the combination of the `ftxui::Checkbox()` and
+Useful for visual elements whose visibility can be toggled on or off by the
+user. Essentially, this is the combination of the `ftxui::Checkbox()` and
 `ftxui::Maybe()` components.
 
 ```cpp
-auto collabsible = Collapsible("Show more", inner_element);
+auto collapsible = Collapsible("Show more", inner_element);
 ```
 
 # Maybe {#component-maybe}
@@ -245,7 +245,7 @@ component = component
 
 Produced by: `ftxui::Container::Horizontal()` from
 "ftxui/component/component.hpp". It displays a list of components horizontally
-and handle keyboard/mouse navigation.
+and handles keyboard/mouse navigation.
 
 ## Vertical {#component-vertical}
 
@@ -256,8 +256,8 @@ and handles keyboard/mouse navigation.
 ## Tab {#component-tab}
 
 Produced by: `ftxui::Container::Tab()` from
-"ftxui/component/component.hpp". It take a list of component and display only
-one of them. This is useful for implementing a tab bar.
+"ftxui/component/component.hpp". It takes a list of components and displays
+only one of them. This is useful for implementing a tab bar.
 
 [Vertical](https://arthursonzogni.github.io/FTXUI/examples_2component_2tab_vertical_8cpp-example.html):
   

--- a/doc/module-dom.md
+++ b/doc/module-dom.md
@@ -207,7 +207,7 @@ Code:
 border(gauge(0.5))
 ```
 
-Teminal output:
+Terminal output:
 ```bash
 ┌────────────────────────────────────────────────────────────────────────────┐
 │██████████████████████████████████████                                      │
@@ -407,7 +407,7 @@ Checkout this
 and the associated
 [demo](https://arthursonzogni.github.io/FTXUI/examples/?file=component/flexbox).
 
-Element can also become flexible using the the `ftxui::flex` decorator.
+Element can also become flexible using the `ftxui::flex` decorator.
 
 Code:
 ```cpp

--- a/src/ftxui/component/collapsible.cpp
+++ b/src/ftxui/component/collapsible.cpp
@@ -12,11 +12,11 @@
 
 namespace ftxui {
 
-/// @brief A collapsible component. It display a checkbox with an arrow. Once
-/// activated, the children is displayed.
+/// @brief A collapsible component. It displays a checkbox with an arrow. Once
+/// activated, the child is displayed.
 /// @param label The label of the checkbox.
-/// @param child The children to display.
-/// @param show Hold the state about whether the children is displayed or not.
+/// @param child The child to display.
+/// @param show Hold the state about whether the child is displayed or not.
 ///
 /// ### Example
 /// ```cpp

--- a/src/ftxui/component/component_options.cpp
+++ b/src/ftxui/component/component_options.cpp
@@ -68,7 +68,7 @@ void UnderlineOption::SetAnimationFunction(
   follower_function = std::move(f_follower);
 }
 
-/// @brief Standard options for an horizontal menu.
+/// @brief Standard options for a horizontal menu.
 /// This can be useful to implement a tab bar.
 /// @ingroup component
 // static
@@ -148,7 +148,7 @@ MenuOption MenuOption::VerticalAnimated() {
   return option;
 }
 
-/// @brief Standard options for a horitontal menu with some separator.
+/// @brief Standard options for a horizontal menu with some separator.
 /// This can be useful to implement a tab bar.
 /// @ingroup component
 // static

--- a/src/ftxui/dom/clear_under.cpp
+++ b/src/ftxui/dom/clear_under.cpp
@@ -32,7 +32,7 @@ class ClearUnder : public NodeDecorator {
 }  // namespace
 
 /// @brief Before drawing |child|, clear the pixels below. This is useful in
-//         combinaison with dbox.
+///        combination with dbox.
 /// @see ftxui::dbox
 /// @ingroup dom
 Element clear_under(Element element) {

--- a/src/ftxui/dom/hyperlink.cpp
+++ b/src/ftxui/dom/hyperlink.cpp
@@ -34,8 +34,8 @@ class Hyperlink : public NodeDecorator {
 }  // namespace
 
 /// @brief Make the rendered area clickable using a web browser.
-///        The link will be opened when the user click on it.
-///        This is supported only on a limited set of terminal emulator.
+///        The link will be opened when the user clicks on it.
+///        This is supported only on a limited set of terminal emulators.
 ///        List: https://github.com/Alhadis/OSC8-Adoption/
 /// @param link The link
 /// @param child The input element.
@@ -52,9 +52,9 @@ Element hyperlink(std::string link, Element child) {
   return std::make_shared<Hyperlink>(std::move(child), std::move(link));
 }
 
-/// @brief Decorate using an hyperlink.
-///        The link will be opened when the user click on it.
-///        This is supported only on a limited set of terminal emulator.
+/// @brief Decorate using a hyperlink.
+///        The link will be opened when the user clicks on it.
+///        This is supported only on a limited set of terminal emulators.
 ///        List: https://github.com/Alhadis/OSC8-Adoption/
 /// @param link The link to redirect the users to.
 /// @return The Decorator applying the hyperlink.

--- a/src/ftxui/dom/node.cpp
+++ b/src/ftxui/dom/node.cpp
@@ -16,7 +16,7 @@ Node::Node() = default;
 Node::Node(Elements children) : children_(std::move(children)) {}
 Node::~Node() = default;
 
-/// @brief Compute how much space an elements needs.
+/// @brief Compute how much space an element needs.
 /// @ingroup dom
 void Node::ComputeRequirement() {
   if (children_.empty()) {

--- a/src/ftxui/dom/scroll_indicator.cpp
+++ b/src/ftxui/dom/scroll_indicator.cpp
@@ -15,8 +15,8 @@
 
 namespace ftxui {
 
-/// @brief Display a vertical scrollbar to the right.
-/// colors.
+/// @brief Display a vertical scrollbar on the right.
+/// Colors follow the content.
 /// @ingroup dom
 Element vscroll_indicator(Element child) {
   class Impl : public NodeDecorator {
@@ -70,8 +70,8 @@ Element vscroll_indicator(Element child) {
   return std::make_shared<Impl>(std::move(child));
 }
 
-/// @brief Display an horizontal scrollbar to the bottom.
-/// colors.
+/// @brief Display a horizontal scrollbar at the bottom.
+/// Colors follow the content.
 /// @ingroup dom
 Element hscroll_indicator(Element child) {
   class Impl : public NodeDecorator {

--- a/src/ftxui/dom/separator.cpp
+++ b/src/ftxui/dom/separator.cpp
@@ -427,7 +427,7 @@ Element separator(Pixel pixel) {
   return std::make_shared<SeparatorWithPixel>(std::move(pixel));
 }
 
-/// @brief Draw an horizontal bar, with the area in between left/right colored
+/// @brief Draw a horizontal bar, with the area in between left/right colored
 /// differently.
 /// @param left the left limit of the active area.
 /// @param right the right limit of the active area.

--- a/src/ftxui/dom/spinner.cpp
+++ b/src/ftxui/dom/spinner.cpp
@@ -273,8 +273,8 @@ const std::vector<std::vector<std::vector<std::string>>> elements = {
 
 }  // namespace
 
-/// @brief Useful to represent the effect of time and/or events. This display an
-/// ASCII art "video".
+/// @brief Useful to represent the effect of time and/or events. This displays
+/// an ASCII art "video".
 /// @param charset_index The type of "video".
 /// @param image_index The "frame" of the video. You need to increase this for
 /// every "step".

--- a/src/ftxui/dom/underlined.cpp
+++ b/src/ftxui/dom/underlined.cpp
@@ -28,7 +28,7 @@ class Underlined : public NodeDecorator {
 };
 }  // namespace
 
-/// @brief Make the underlined element to be underlined.
+/// @brief Underline the given element.
 /// @ingroup dom
 Element underlined(Element child) {
   return std::make_shared<Underlined>(std::move(child));


### PR DESCRIPTION
## Summary
- polish documentation across the repo
- clean up README layout section
- correct Doxygen comments in several DOM files

## Testing
- `./tools/format.sh`
- `./tools/test_bazel.sh` *(failed: could not download Bazel)*

------
https://chatgpt.com/codex/tasks/task_e_68407c5d815883208e06cab38986020e