### PR TITLE
fix: ScreenInteractive::FixedSize screen stomps on the history terminal output

### DIFF
--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -107,9 +107,12 @@ class ScreenInteractive : public Screen {
   };
   Dimension dimension_ = Dimension::Fixed;
   bool use_alternative_screen_ = false;
-  ScreenInteractive(int dimx,
+
+  ScreenInteractive(Dimension dimension,
+                    bool use_alternative_screen);
+  ScreenInteractive(Dimension dimension,
+                    int dimx,
                     int dimy,
-                    Dimension dimension,
                     bool use_alternative_screen);
 
   bool track_mouse_ = true;
@@ -126,6 +129,8 @@ class ScreenInteractive : public Screen {
   bool animation_requested_ = false;
   animation::TimePoint previous_animation_time_;
 
+  int fixed_dimx_ = 0;
+  int fixed_dimy_ = 0;
   int cursor_x_ = 1;
   int cursor_y_ = 1;
 

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -346,12 +346,21 @@ void AnimationListener(std::atomic<bool>* quit, Sender<Task> out) {
 
 }  // namespace
 
-ScreenInteractive::ScreenInteractive(int dimx,
-                                     int dimy,
-                                     Dimension dimension,
+ScreenInteractive::ScreenInteractive(Dimension dimension,
                                      bool use_alternative_screen)
-    : Screen(dimx, dimy),
+    : Screen(0, 0),
       dimension_(dimension),
+      use_alternative_screen_(use_alternative_screen) {
+  task_receiver_ = MakeReceiver<Task>();
+}
+
+ScreenInteractive::ScreenInteractive(Dimension dimension,
+                                     int dimx,
+                                     int dimy,
+                                     bool use_alternative_screen)
+    : Screen(0, 0),
+      dimension_(dimension),
+      fixed_dimx_(dimx), fixed_dimy_(dimy),
       use_alternative_screen_(use_alternative_screen) {
   task_receiver_ = MakeReceiver<Task>();
 }
@@ -359,9 +368,9 @@ ScreenInteractive::ScreenInteractive(int dimx,
 // static
 ScreenInteractive ScreenInteractive::FixedSize(int dimx, int dimy) {
   return {
+      Dimension::Fixed,
       dimx,
       dimy,
-      Dimension::Fixed,
       false,
   };
 }
@@ -380,8 +389,6 @@ ScreenInteractive ScreenInteractive::Fullscreen() {
 // static
 ScreenInteractive ScreenInteractive::FullscreenPrimaryScreen() {
   return {
-      0,
-      0,
       Dimension::Fullscreen,
       false,
   };
@@ -392,8 +399,6 @@ ScreenInteractive ScreenInteractive::FullscreenPrimaryScreen() {
 // static
 ScreenInteractive ScreenInteractive::FullscreenAlternateScreen() {
   return {
-      0,
-      0,
       Dimension::Fullscreen,
       true,
   };
@@ -402,8 +407,6 @@ ScreenInteractive ScreenInteractive::FullscreenAlternateScreen() {
 // static
 ScreenInteractive ScreenInteractive::TerminalOutput() {
   return {
-      0,
-      0,
       Dimension::TerminalOutput,
       false,
   };
@@ -412,8 +415,6 @@ ScreenInteractive ScreenInteractive::TerminalOutput() {
 // static
 ScreenInteractive ScreenInteractive::FitComponent() {
   return {
-      0,
-      0,
       Dimension::FitComponent,
       false,
   };
@@ -904,8 +905,8 @@ void ScreenInteractive::Draw(Component component) {
   document->ComputeRequirement();
   switch (dimension_) {
     case Dimension::Fixed:
-      dimx = dimx_;
-      dimy = dimy_;
+      dimx = fixed_dimx_;
+      dimy = fixed_dimy_;
       break;
     case Dimension::TerminalOutput:
       dimx = terminal.dimx;


### PR DESCRIPTION
## Bug: ScreenInteractive::FixedSize screen stomps on the preceding terminal output

![image](https://github.com/user-attachments/assets/96d80861-f81e-4c81-874c-3c966fce6e8f)

if I use the "ScreenInteractive::FixedSize()" screen and it's `Loop` function to draw the screen, the entire screen is showed above the latest cursor line, and covers all history terminal output. This bug doesn't exist in other Dimension type like `TerminalOuput`.

## Reproduce
Reproduced on the lates main, using the following sample code:
```cpp
#include <memory>  // for allocator, __shared_ptr_access, shared_ptr
#include <string>  // for to_string, operator+
#include "ftxui/component/component.hpp"       // for Button, Renderer, Vertical
#include "ftxui/component/component_base.hpp"  // for ComponentBase
#include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
#include "ftxui/dom/elements.hpp"  // for operator|, text, Element, hbox, separator, size, vbox, border, frame, vscroll_indicator, HEIGHT, LESS_THAN
 
using namespace ftxui;

Component MakeOne() {
  static int id = 0;
  class Impl : public ComponentBase {
    private:
      std::string text_;
    public:
    Impl(std::string&& t) : text_(t) {}
    Element OnRender() {
      auto element = text(text_);
      return element;
    }
    bool Focusable() const final { return true; }
  };
  auto comp = Container::Vertical({});
  for (int i = 0; i < 10; i++)
  {
    comp->Add(Make<Impl>("Child " + std::to_string(i)));
  }
  return comp;
}

int main() {
  auto screen = ScreenInteractive::FixedSize(10, 12);
  auto slogon = text("************************************");
  auto slogoncomp = Renderer([] {
      return vbox({
          text("0000000000"),
          text("1111111111"),
          text("2222222222"),
          text("3333333333"),
          text("4444444444"),
          text("5555555555"),
          text("6666666666"),
          text("7777777777"),
          text("8888888888"),  
          text("9999999999")
          }) | border;
      });
  screen.Loop(slogoncomp);

  return 0;
}
```

 ## Root Cause
 
The problem comes from [ScreenInteractive::FixedSize(int dimx, int dimy)](https://github.com/ArthurSonzogni/FTXUI/blob/main/src/ftxui/component/screen_interactive.cpp#L362) factory function, it initialized the parent `Screen` dimensions to the fixed size at the very beginning, before the first draw.

When [ScreenInteractive::Draw()](https://github.com/ArthurSonzogni/FTXUI/blob/main/src/ftxui/component/screen_interactive.cpp#L896) did the first render later, it did an redundant [ResetPosition](https://github.com/ArthurSonzogni/FTXUI/blob/main/src/ftxui/component/screen_interactive.cpp#L926), because the screen's dimy is set to the expected fixed size initially, the ResetPostiion would move up the cursor by dimy lines, although actually in the first render, the cursor should not rewind, because no print happened before it.

## Fix

- Always initialize the parent screen to (0,0).
- Store the fixedSize at the ScreenInteractive subclass.
- Use the locally stored fixedSize to initialize the screen dimension at the first render.
 
 
 

