### PR TITLE
Add gridbox children to children_ 

### DIFF
--- a/src/ftxui/dom/box_helper.cpp
+++ b/src/ftxui/dom/box_helper.cpp
@@ -58,11 +58,39 @@ void ComputeShrinkHard(std::vector<Element>* elements,
 
     element.size = element.min_size + added_space;
   }
+
+}
+
+
+// Called when the size allowed is lower than the requested size, and the
+// shrinkable element can not absorbe the (negative) extra_space. This assign
+// zero to shrinkable elements and distribute the remaining (negative)
+// extra_space toward the other non shrinkable elements.
+void ComputeShrinkHardHack(std::vector<Element>* elements,
+                       int extra_space,
+                       int size)
+{
+  for (Element& element : *elements)
+  {
+    if (element.flex_shrink != 0)
+    {
+      element.size = 0;
+    }
+  }
+
+  for (auto it = elements->rbegin(); it != elements->rend(); ++it)
+  {
+    Element& element = *it;
+
+    auto remove = std::min(element.min_size, -extra_space);
+    element.size = element.min_size - remove;
+    extra_space += remove;
+  }
 }
 
 }  // namespace
 
-void Compute(std::vector<Element>* elements, int target_size) {
+void Compute(std::vector<Element>* elements, int target_size, bool hack) {
   int size = 0;
   int flex_grow_sum = 0;
   int flex_shrink_sum = 0;
@@ -84,8 +112,14 @@ void Compute(std::vector<Element>* elements, int target_size) {
     ComputeShrinkEasy(elements, extra_space, flex_shrink_sum);
 
   } else {
-    ComputeShrinkHard(elements, extra_space + flex_shrink_size,
-                      size - flex_shrink_size);
+    if (hack)
+    {
+      ComputeShrinkHardHack(elements, extra_space + flex_shrink_size, size - flex_shrink_size);
+    }
+    else
+    {
+      ComputeShrinkHard(elements, extra_space + flex_shrink_size, size - flex_shrink_size);
+    }
   }
 }
 

--- a/src/ftxui/dom/box_helper.hpp
+++ b/src/ftxui/dom/box_helper.hpp
@@ -19,7 +19,7 @@ struct Element {
   int size = 0;
 };
 
-void Compute(std::vector<Element>* elements, int target_size);
+void Compute(std::vector<Element>* elements, int target_size, bool hack=false);
 }  // namespace ftxui::box_helper
 
 #endif /* end of include guard: FTXUI_DOM_BOX_HELPER_HPP */

--- a/src/ftxui/dom/gridbox.cpp
+++ b/src/ftxui/dom/gridbox.cpp
@@ -46,6 +46,12 @@ class GridBox : public Node {
         line.push_back(filler());
       }
     }
+
+    for (const auto& line : lines_) {
+      for (const auto &element : line) {
+        children_.push_back( element );
+      }
+    }
   }
 
   void ComputeRequirement() override {

--- a/src/ftxui/dom/gridbox.cpp
+++ b/src/ftxui/dom/gridbox.cpp
@@ -115,7 +115,7 @@ class GridBox : public Node {
 
     const int target_size_x = box.x_max - box.x_min + 1;
     const int target_size_y = box.y_max - box.y_min + 1;
-    box_helper::Compute(&elements_x, target_size_x);
+    box_helper::Compute(&elements_x, target_size_x, true);
     box_helper::Compute(&elements_y, target_size_y);
 
     Box box_y = box;

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -216,13 +216,13 @@ Element Table::Render() {
 
       // Line
       if ((x + y) % 2 == 1) {
-        it = std::move(it) | flex;
+        it = std::move(it)| flex;  //it = std::move(it); // | flex;
         continue;
       }
 
       // Cells
       if ((x % 2) == 1 && (y % 2) == 1) {
-        it = std::move(it) | flex_shrink;
+        // it = std::move(it) | flex_shrink;   //it = std::move(it) | flex_shrink;
         continue;
       }
 


### PR DESCRIPTION
Fix so layout will iterate when there's a flex element inside of a gridbox that grows it's box size on the y axis.   (Allows need_iteration_ to work from Flexbox::SetBox() that's within the grid so that layout will re-run as the box grows)