### PR TITLE
Remove redundant member from ButtonBase

### DIFF
--- a/src/ftxui/component/button.cpp
+++ b/src/ftxui/component/button.cpp
@@ -139,7 +139,6 @@ class ButtonBase : public ComponentBase, public ButtonOption {
  private:
   bool mouse_hover_ = false;
   Box box_;
-  ButtonOption option_;
   float animation_background_ = 0;
   float animation_foreground_ = 0;
   animation::Animator animator_background_ =


### PR DESCRIPTION
The `ButtonBase` class inherits from `ButtonOption` but also had a private `option_` member of the same type. This member was redundant and unused.

This PR removes the unnecessary member to clean up the code and slightly reduce the object's memory footprint.