### PR TITLE
Fix: Use of max() min() collides with predefined macros in Windows build

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,6 @@
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
 Standard: Cpp11
+
+InsertBraces: true
+InsertNewlineAtEOF: true

--- a/examples/component/canvas_animated.cpp
+++ b/examples/component/canvas_animated.cpp
@@ -133,8 +133,9 @@ int main() {
       float dy = 50.f;
       ys[x] = int(dy + 20 * cos(dx * 0.14) + 10 * sin(dx * 0.42));
     }
-    for (int x = 1; x < 99; x++)
+    for (int x = 1; x < 99; x++) {
       c.DrawPointLine(x, ys[x], x + 1, ys[x + 1]);
+    }
 
     return canvas(std::move(c));
   });

--- a/examples/component/flexbox_gallery.cpp
+++ b/examples/component/flexbox_gallery.cpp
@@ -82,10 +82,12 @@ int main() {
                    size(WIDTH, EQUAL, dimx) | size(HEIGHT, EQUAL, dimy) |
                    bgcolor(Color::HSV(index * 25, 255, 255)) |
                    color(Color::Black);
-    if (element_xflex_grow)
+    if (element_xflex_grow) {
       element = element | xflex_grow;
-    if (element_yflex_grow)
+    }
+    if (element_yflex_grow) {
       element = element | yflex_grow;
+    }
     return element;
   };
 
@@ -119,10 +121,12 @@ int main() {
 
     group = group | notflex;
 
-    if (!group_xflex_grow)
+    if (!group_xflex_grow) {
       group = hbox(group, filler());
-    if (!group_yflex_grow)
+    }
+    if (!group_yflex_grow) {
       group = vbox(group, filler());
+    }
 
     group = group | flex;
     return group;

--- a/examples/component/homescreen.cpp
+++ b/examples/component/homescreen.cpp
@@ -1,11 +1,11 @@
 // Copyright 2020 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.
-#include <stddef.h>    // for size_t
-#include <array>       // for array
-#include <atomic>      // for atomic
-#include <chrono>      // for operator""s, chrono_literals
-#include <cmath>       // for sin
+#include <stddef.h>  // for size_t
+#include <array>     // for array
+#include <atomic>    // for atomic
+#include <chrono>    // for operator""s, chrono_literals
+#include <cmath>     // for sin
 #include <ftxui/component/loop.hpp>
 #include <functional>  // for ref, reference_wrapper, function
 #include <memory>      // for allocator, shared_ptr, __shared_ptr_access
@@ -514,7 +514,7 @@ int main() {
   });
 
   Loop loop(&screen, main_renderer);
-  while(!loop.HasQuitted()) {
+  while (!loop.HasQuitted()) {
     // Update the state of the application.
     shift++;
 
@@ -525,7 +525,7 @@ int main() {
     loop.RunOnce();
 
     // Sleep for a short duration to control the frame rate (60 FPS).
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000/60));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000 / 60));
   }
 
   return 0;

--- a/examples/component/menu_entries.cpp
+++ b/examples/component/menu_entries.cpp
@@ -22,10 +22,12 @@ MenuEntryOption Colored(ftxui::Color c) {
   option.transform = [c](EntryState state) {
     state.label = (state.active ? "> " : "  ") + state.label;
     Element e = text(state.label) | color(c);
-    if (state.focused)
+    if (state.focused) {
       e = e | inverted;
-    if (state.active)
+    }
+    if (state.active) {
       e = e | bold;
+    }
     return e;
   };
   return option;

--- a/examples/component/menu_in_frame.cpp
+++ b/examples/component/menu_in_frame.cpp
@@ -17,8 +17,9 @@ int main() {
   std::vector<std::string> entries;
   int selected = 0;
 
-  for (int i = 0; i < 30; ++i)
+  for (int i = 0; i < 30; ++i) {
     entries.push_back("Entry " + std::to_string(i));
+  }
   auto radiobox = Menu(&entries, &selected);
   auto renderer = Renderer(radiobox, [&] {
     return radiobox->Render() | vscroll_indicator | frame |

--- a/examples/component/menu_in_frame_horizontal.cpp
+++ b/examples/component/menu_in_frame_horizontal.cpp
@@ -17,8 +17,9 @@ int main() {
   std::vector<std::string> entries;
   int selected = 0;
 
-  for (int i = 0; i < 100; ++i)
+  for (int i = 0; i < 100; ++i) {
     entries.push_back(std::to_string(i));
+  }
   auto radiobox = Menu(&entries, &selected, MenuOption::Horizontal());
   auto renderer = Renderer(
       radiobox, [&] { return radiobox->Render() | hscroll_indicator | frame; });

--- a/examples/component/menu_style.cpp
+++ b/examples/component/menu_style.cpp
@@ -116,10 +116,12 @@ Component VMenu1(std::vector<std::string>* entries, int* selected) {
   option.entries_option.transform = [](EntryState state) {
     state.label = (state.active ? "> " : "  ") + state.label;
     Element e = text(state.label);
-    if (state.focused)
+    if (state.focused) {
       e = e | bgcolor(Color::Blue);
-    if (state.active)
+    }
+    if (state.active) {
       e = e | bold;
+    }
     return e;
   };
   return Menu(entries, selected, option);
@@ -130,10 +132,12 @@ Component VMenu2(std::vector<std::string>* entries, int* selected) {
   option.entries_option.transform = [](EntryState state) {
     state.label += (state.active ? " <" : "  ");
     Element e = hbox(filler(), text(state.label));
-    if (state.focused)
+    if (state.focused) {
       e = e | bgcolor(Color::Red);
-    if (state.active)
+    }
+    if (state.active) {
       e = e | bold;
+    }
     return e;
   };
   return Menu(entries, selected, option);
@@ -144,13 +148,16 @@ Component VMenu3(std::vector<std::string>* entries, int* selected) {
   option.entries_option.transform = [](EntryState state) {
     Element e = state.active ? text("[" + state.label + "]")
                              : text(" " + state.label + " ");
-    if (state.focused)
+    if (state.focused) {
       e = e | bold;
+    }
 
-    if (state.focused)
+    if (state.focused) {
       e = e | color(Color::Blue);
-    if (state.active)
+    }
+    if (state.active) {
       e = e | bold;
+    }
     return e;
   };
   return Menu(entries, selected, option);
@@ -245,10 +252,12 @@ Component HMenu5(std::vector<std::string>* entries, int* selected) {
                                 animation::easing::ElasticOut);
   option.entries_option.transform = [](EntryState state) {
     Element e = text(state.label) | hcenter | flex;
-    if (state.active && state.focused)
+    if (state.active && state.focused) {
       e = e | bold;
-    if (!state.focused && !state.active)
+    }
+    if (!state.focused && !state.active) {
       e = e | dim;
+    }
     return e;
   };
   option.underline.color_inactive = Color::Default;

--- a/examples/component/menu_underline_animated_gallery.cpp
+++ b/examples/component/menu_underline_animated_gallery.cpp
@@ -20,8 +20,9 @@ using namespace ftxui;
 Component DummyComponent(int id) {
   return Renderer([id](bool focused) {
     auto t = text("component " + std::to_string(id));
-    if (focused)
+    if (focused) {
       t = t | inverted;
+    }
     return t;
   });
 }

--- a/examples/component/radiobox_in_frame.cpp
+++ b/examples/component/radiobox_in_frame.cpp
@@ -17,8 +17,9 @@ int main() {
   std::vector<std::string> entries;
   int selected = 0;
 
-  for (int i = 0; i < 30; ++i)
+  for (int i = 0; i < 30; ++i) {
     entries.push_back("RadioBox " + std::to_string(i));
+  }
   auto radiobox = Radiobox(&entries, &selected);
   auto renderer = Renderer(radiobox, [&] {
     return radiobox->Render() | vscroll_indicator | frame |

--- a/examples/component/renderer.cpp
+++ b/examples/component/renderer.cpp
@@ -19,10 +19,11 @@ int main() {
 
   // 1. Example of focusable renderer:
   auto renderer_focusable = Renderer([](bool focused) {
-    if (focused)
+    if (focused) {
       return text("FOCUSABLE RENDERER()") | center | bold | border;
-    else
+    } else {
       return text(" Focusable renderer() ") | center | border;
+    }
   });
 
   // 2. Examples of a non focusable renderer.
@@ -33,10 +34,11 @@ int main() {
   // 3. Renderer can wrap other components to redefine their Render() function.
   auto button = Button("Wrapped quit button", screen.ExitLoopClosure());
   auto renderer_wrap = Renderer(button, [&] {
-    if (button->Focused())
+    if (button->Focused()) {
       return button->Render() | bold | color(Color::Red);
-    else
+    } else {
       return button->Render();
+    }
   });
 
   // Let's renderer everyone:

--- a/examples/dom/canvas.cpp
+++ b/examples/dom/canvas.cpp
@@ -32,10 +32,12 @@ int main() {
 
   // Plot a function:
   std::vector<int> ys(100);
-  for (int x = 0; x < 100; x++)
+  for (int x = 0; x < 100; x++) {
     ys[x] = int(80 + 20 * cos(x * 0.2));
-  for (int x = 0; x < 99; x++)
+  }
+  for (int x = 0; x < 99; x++) {
     c.DrawPointLine(x, ys[x], x + 1, ys[x + 1], Color::Red);
+  }
 
   auto document = canvas(&c) | border;
 

--- a/examples/dom/package_manager.cpp
+++ b/examples/dom/package_manager.cpp
@@ -86,8 +86,9 @@ int main() {
 
   auto render = [&]() {
     std::vector<Element> entries;
-    for (auto& task : displayed_task)
+    for (auto& task : displayed_task) {
       entries.push_back(renderTask(task));
+    }
 
     return vbox({
         // List of tasks.
@@ -138,8 +139,9 @@ int main() {
     std::this_thread::sleep_for(0.01s);
 
     // Exit
-    if (nb_active + nb_queued == 0)
+    if (nb_active + nb_queued == 0) {
       break;
+    }
 
     // Update the model for the next frame.
     updateModel();

--- a/examples/dom/spinner.cpp
+++ b/examples/dom/spinner.cpp
@@ -21,8 +21,9 @@ int main() {
   for (int index = 0; index < 200; ++index) {
     std::vector<Element> entries;
     for (int i = 0; i < 23; ++i) {
-      if (i != 0)
+      if (i != 0) {
         entries.push_back(separator());
+      }
       entries.push_back(  //
           hbox({
               text(std::to_string(i)) | size(WIDTH, EQUAL, 2),

--- a/include/ftxui/component/component.hpp
+++ b/include/ftxui/component/component.hpp
@@ -8,6 +8,7 @@
 #include <memory>      // for make_shared, shared_ptr
 #include <utility>     // for forward
 
+#include <ftxui/util/warn_windows_macro.hpp>
 #include "ftxui/component/component_base.hpp"  // for Component, Components
 #include "ftxui/component/component_options.hpp"  // for ButtonOption, CheckboxOption, MenuOption
 #include "ftxui/dom/elements.hpp"  // for Element

--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -9,8 +9,9 @@
 #include <ftxui/dom/direction.hpp>  // for Direction, Direction::Left, Direction::Right, Direction::Down
 #include <ftxui/dom/elements.hpp>  // for Element, separator
 #include <ftxui/util/ref.hpp>      // for Ref, ConstRef, StringRef
-#include <functional>              // for function
-#include <string>                  // for string
+#include <ftxui/util/warn_windows_macro.hpp>
+#include <functional>  // for function
+#include <string>      // for string
 
 #include "ftxui/component/component_base.hpp"  // for Component
 #include "ftxui/screen/color.hpp"  // for Color, Color::GrayDark, Color::White

--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -15,6 +15,14 @@
 #include "ftxui/component/component_base.hpp"  // for Component
 #include "ftxui/screen/color.hpp"  // for Color, Color::GrayDark, Color::White
 
+#if defined(max)
+#undef max
+#endif
+
+#if defined(min)
+#undef min
+#endif
+
 namespace ftxui {
 
 /// @brief arguments for transform from |ButtonOption|, |CheckboxOption|,

--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -15,14 +15,6 @@
 #include "ftxui/component/component_base.hpp"  // for Component
 #include "ftxui/screen/color.hpp"  // for Color, Color::GrayDark, Color::White
 
-#if defined(max)
-#undef max
-#endif
-
-#if defined(min)
-#undef min
-#endif
-
 namespace ftxui {
 
 /// @brief arguments for transform from |ButtonOption|, |CheckboxOption|,

--- a/include/ftxui/component/receiver.hpp
+++ b/include/ftxui/component/receiver.hpp
@@ -4,6 +4,7 @@
 #ifndef FTXUI_COMPONENT_RECEIVER_HPP_
 #define FTXUI_COMPONENT_RECEIVER_HPP_
 
+#include <ftxui/util/warn_windows_macro.h>
 #include <algorithm>           // for copy, max
 #include <atomic>              // for atomic, __atomic_base
 #include <condition_variable>  // for condition_variable

--- a/include/ftxui/component/screen_interactive.hpp
+++ b/include/ftxui/component/screen_interactive.hpp
@@ -4,10 +4,10 @@
 #ifndef FTXUI_COMPONENT_SCREEN_INTERACTIVE_HPP
 #define FTXUI_COMPONENT_SCREEN_INTERACTIVE_HPP
 
-#include <atomic>                        // for atomic
-#include <functional>                    // for function
-#include <memory>                        // for shared_ptr
-#include <string>                        // for string
+#include <atomic>      // for atomic
+#include <functional>  // for function
+#include <memory>      // for shared_ptr
+#include <string>      // for string
 
 #include "ftxui/component/animation.hpp"       // for TimePoint
 #include "ftxui/component/captured_mouse.hpp"  // for CapturedMouse
@@ -25,7 +25,7 @@ using Component = std::shared_ptr<ComponentBase>;
 class ScreenInteractivePrivate;
 
 namespace task {
-  class TaskRunner;
+class TaskRunner;
 }
 
 /// @brief ScreenInteractive is a `Screen` that can handle events, run a main
@@ -167,7 +167,6 @@ class ScreenInteractive : public Screen {
   friend class Loop;
 
   Component component_;
-
 
  public:
   class Private {

--- a/include/ftxui/util/warn_windows_macro.hpp
+++ b/include/ftxui/util/warn_windows_macro.hpp
@@ -1,0 +1,12 @@
+#ifndef FTXUI_UTIL_WARN_WINDOWS_MACRO_H_
+#define FTXUI_UTIL_WARN_WINDOWS_MACRO_H_
+
+#ifdef min
+#error "The macro 'min' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
+#endif
+
+#ifdef max
+#error "The macro 'max' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
+#endif
+
+#endif  // FTXUI_UTIL_WARN_WINDOWS_MACRO_H_

--- a/include/ftxui/util/warn_windows_macro.hpp
+++ b/include/ftxui/util/warn_windows_macro.hpp
@@ -1,12 +1,18 @@
+// Copyright 2025 Arthur Sonzogni. All rights reserved.
+// Use of this source code is governed by the MIT license that can be found in
+// the LICENSE file.
+
 #ifndef FTXUI_UTIL_WARN_WINDOWS_MACRO_H_
 #define FTXUI_UTIL_WARN_WINDOWS_MACRO_H_
 
 #ifdef min
-#error "The macro 'min' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
+#error \
+    "The macro 'min' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
 #endif
 
 #ifdef max
-#error "The macro 'max' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
+#error \
+    "The macro 'max' is defined, which conflicts with the standard C++ library and FTXUI. This is often caused by including <windows.h>. To fix this, add '#define NOMINMAX' before including <windows.h>, or pass '/DNOMINMAX' as a compiler flag."
 #endif
 
 #endif  // FTXUI_UTIL_WARN_WINDOWS_MACRO_H_

--- a/src/ftxui/component/component_fuzzer.cpp
+++ b/src/ftxui/component/component_fuzzer.cpp
@@ -23,8 +23,9 @@ bool GeneratorBool(const char*& data, size_t& size) {
 
 std::string GeneratorString(const char*& data, size_t& size) {
   int index = 0;
-  while (index < size && data[index])
+  while (index < size && data[index]) {
     ++index;
+  }
 
   auto out = std::string(data, data + index);
   data += index;
@@ -40,8 +41,9 @@ std::string GeneratorString(const char*& data, size_t& size) {
 }
 
 int GeneratorInt(const char* data, size_t size) {
-  if (size == 0)
+  if (size == 0) {
     return 0;
+  }
   auto out = int(data[0]);
   data++;
   size--;
@@ -113,8 +115,9 @@ Components GeneratorComponents(const char*& data, size_t& size, int depth);
 Component GeneratorComponent(const char*& data, size_t& size, int depth) {
   depth--;
   int value = GeneratorInt(data, size);
-  if (depth <= 0)
+  if (depth <= 0) {
     return Button(GeneratorString(data, size), [] {});
+  }
 
   constexpr int value_max = 19;
   value = (value % value_max + value_max) % value_max;

--- a/src/ftxui/component/screen_interactive.cpp
+++ b/src/ftxui/component/screen_interactive.cpp
@@ -1057,8 +1057,9 @@ void ScreenInteractive::FetchTerminalEvents() {
       case KEY_EVENT: {
         auto key_event = r.Event.KeyEvent;
         // ignore UP key events
-        if (key_event.bKeyDown == FALSE)
+        if (key_event.bKeyDown == FALSE) {
           continue;
+        }
         std::wstring wstring;
         wstring += key_event.uChar.UnicodeChar;
         for (auto it : to_string(wstring)) {

--- a/src/ftxui/component/screen_interactive_test.cpp
+++ b/src/ftxui/component/screen_interactive_test.cpp
@@ -28,8 +28,9 @@ namespace {
 class StdCapture {
  public:
   explicit StdCapture(std::string* captured) : captured_(captured) {
-    if (pipe(pipefd_) != 0)
+    if (pipe(pipefd_) != 0) {
       return;
+    }
     old_stdout_ = dup(fileno(stdout));
     fflush(stdout);
     dup2(pipefd_[1], fileno(stdout));

--- a/src/ftxui/component/task.cpp
+++ b/src/ftxui/component/task.cpp
@@ -16,5 +16,4 @@ bool PendingTask::operator<(const PendingTask& other) const {
   }
   return time.value() > other.time.value();
 }
-} // namespace ftxui::task
-
+}  // namespace ftxui::task

--- a/src/ftxui/component/task_internal.hpp
+++ b/src/ftxui/component/task_internal.hpp
@@ -21,8 +21,7 @@ struct PendingTask {
 
   // Delayed task with a duration
   PendingTask(Task t, std::chrono::steady_clock::duration duration)
-      : task(std::move(t)),
-        time(std::chrono::steady_clock::now() + duration) {}
+      : task(std::move(t)), time(std::chrono::steady_clock::now() + duration) {}
 
   /// The task to be executed.
   Task task;
@@ -36,7 +35,6 @@ struct PendingTask {
   bool operator<(const PendingTask& other) const;
 };
 
-} // namespace ftxui::task
-
+}  // namespace ftxui::task
 
 #endif  // TASK_HPP_

--- a/src/ftxui/component/task_queue.cpp
+++ b/src/ftxui/component/task_queue.cpp
@@ -50,5 +50,4 @@ auto TaskQueue::Get() -> MaybeTask {
   return std::monostate{};
 }
 
-} // namespace ftxui::task
-
+}  // namespace ftxui::task

--- a/src/ftxui/component/task_queue.hpp
+++ b/src/ftxui/component/task_queue.hpp
@@ -25,16 +25,13 @@ struct TaskQueue {
       std::variant<Task, std::chrono::steady_clock::duration, std::monostate>;
   auto Get() -> MaybeTask;
 
-  bool HasImmediateTasks() const {
-    return !immediate_tasks_.empty();
-  }
+  bool HasImmediateTasks() const { return !immediate_tasks_.empty(); }
 
  private:
   std::queue<PendingTask> immediate_tasks_;
   std::priority_queue<PendingTask> delayed_tasks_;
 };
 
-} // namespace ftxui::task
-
+}  // namespace ftxui::task
 
 #endif

--- a/src/ftxui/component/task_runner.cpp
+++ b/src/ftxui/component/task_runner.cpp
@@ -20,7 +20,6 @@ TaskRunner::~TaskRunner() {
   current_task_runner = previous_task_runner_;
 }
 
-
 // static
 auto TaskRunner::Current() -> TaskRunner* {
   assert(current_task_runner);
@@ -73,5 +72,4 @@ auto TaskRunner::Run() -> void {
   }
 }
 
-} // namespace ftxui::task
-
+}  // namespace ftxui::task

--- a/src/ftxui/component/task_runner.hpp
+++ b/src/ftxui/component/task_runner.hpp
@@ -21,8 +21,8 @@ class TaskRunner {
   auto PostTask(Task task) -> void;
 
   /// Schedules a task to be executed after a certain duration.
-  auto PostDelayedTask(Task task,
-                       std::chrono::steady_clock::duration duration) -> void;
+  auto PostDelayedTask(Task task, std::chrono::steady_clock::duration duration)
+      -> void;
 
   /// Runs the tasks in the queue, return the delay until the next delayed task
   /// can be executed.
@@ -31,9 +31,7 @@ class TaskRunner {
   // Runs the tasks in the queue, blocking until all tasks are executed.
   auto Run() -> void;
 
-  bool HasImmediateTasks() const {
-    return queue_.HasImmediateTasks();
-  }
+  bool HasImmediateTasks() const { return queue_.HasImmediateTasks(); }
 
   size_t ExecutedTasks() const { return executed_tasks_; }
 
@@ -43,7 +41,6 @@ class TaskRunner {
   size_t executed_tasks_ = 0;
 };
 
-} // namespace ftxui::task
-
+}  // namespace ftxui::task
 
 #endif  // TASK_RUNNER_HPP

--- a/src/ftxui/component/task_test.cpp
+++ b/src/ftxui/component/task_test.cpp
@@ -91,4 +91,4 @@ TEST(TaskTest, RunDelayedTask) {
   EXPECT_EQ(values, (std::vector<int>{1, 2, 3}));
 }
 
-} // namespace ftxui::task
+}  // namespace ftxui::task

--- a/src/ftxui/component/terminal_input_parser.cpp
+++ b/src/ftxui/component/terminal_input_parser.cpp
@@ -152,8 +152,8 @@ void TerminalInputParser::Send(TerminalInputParser::Output output) {
 
     case CURSOR_POSITION:
       out_(Event::CursorPosition(std::move(pending_),  // NOLINT
-                                      output.cursor.x,      // NOLINT
-                                      output.cursor.y));    // NOLINT
+                                 output.cursor.x,      // NOLINT
+                                 output.cursor.y));    // NOLINT
       pending_.clear();
       return;
 

--- a/src/ftxui/component/terminal_input_parser_test.cpp
+++ b/src/ftxui/component/terminal_input_parser_test.cpp
@@ -17,16 +17,19 @@ namespace ftxui {
 // Test char |c| to are trivially converted into |Event::Character(c)|.
 TEST(Event, Character) {
   std::vector<char> basic_char;
-  for (char c = 'a'; c <= 'z'; ++c)
+  for (char c = 'a'; c <= 'z'; ++c) {
     basic_char.push_back(c);
-  for (char c = 'A'; c <= 'Z'; ++c)
+  }
+  for (char c = 'A'; c <= 'Z'; ++c) {
     basic_char.push_back(c);
+  }
 
   std::vector<Event> received_events;
   auto parser = TerminalInputParser(
       [&](Event event) { received_events.push_back(std::move(event)); });
-  for (char c : basic_char)
+  for (char c : basic_char) {
     parser.Add(c);
+  }
 
   for (size_t i = 0; i < basic_char.size(); ++i) {
     EXPECT_TRUE(received_events[i].is_character());
@@ -285,8 +288,9 @@ TEST(Event, UTF8) {
     std::vector<Event> received_events;
     auto parser = TerminalInputParser(
         [&](Event event) { received_events.push_back(std::move(event)); });
-    for (auto input : test.input)
+    for (auto input : test.input) {
       parser.Add(input);
+    }
 
     if (test.valid) {
       EXPECT_EQ(1, received_events.size());
@@ -315,8 +319,9 @@ TEST(Event, Control) {
   };
   std::vector<TestCase> cases;
   for (int i = 0; i < 32; ++i) {
-    if (i == 8 || i == 13 || i == 24 || i == 26 || i == 27)
+    if (i == 8 || i == 13 || i == 24 || i == 26 || i == 27) {
       continue;
+    }
     cases.push_back({char(i), false});
   }
   cases.push_back({char(24), false});
@@ -341,8 +346,9 @@ TEST(Event, Control) {
 TEST(Event, Special) {
   auto str = [](std::string input) {
     std::vector<unsigned char> output;
-    for (auto it : input)
+    for (auto it : input) {
       output.push_back(it);
+    }
     return output;
   };
 
@@ -351,9 +357,12 @@ TEST(Event, Special) {
     Event expected;
   } kTestCase[] = {
       // Arrow (default cursor mode)
-      {str("[A"), Event::ArrowUp},    {str("[B"), Event::ArrowDown},
-      {str("[C"), Event::ArrowRight}, {str("[D"), Event::ArrowLeft},
-      {str("[H"), Event::Home},       {str("[F"), Event::End},
+      {str("[A"), Event::ArrowUp},
+      {str("[B"), Event::ArrowDown},
+      {str("[C"), Event::ArrowRight},
+      {str("[D"), Event::ArrowLeft},
+      {str("[H"), Event::Home},
+      {str("[F"), Event::End},
 
       // Arrow (application cursor mode)
       {str("\x1BOA"), Event::ArrowUp},

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -47,8 +47,9 @@ namespace {
 #if defined(_WIN32)
 void WindowsEmulateVT100Terminal() {
   static bool done = false;
-  if (done)
+  if (done) {
     return;
+  }
   done = true;
 
   // Enable VT processing on stdout and stdin

--- a/src/ftxui/screen/string.cpp
+++ b/src/ftxui/screen/string.cpp
@@ -1284,8 +1284,9 @@ bool IsCombining(uint32_t ucs) {
 }
 
 bool IsFullWidth(uint32_t ucs) {
-  if (ucs < 0x0300)  // Quick path: // NOLINT
+  if (ucs < 0x0300) {  // Quick path: // NOLINT
     return false;
+  }
 
   return Bisearch(ucs, g_full_width_characters);
 }

--- a/tools/license_headers.cpp
+++ b/tools/license_headers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Arthur Sonzogni. All rights reserved.
+// Copyright 2025 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.
 


### PR DESCRIPTION
When compiling include/ftxui/component/component_options.hpp on windows the vc compiler gives an error:

`Error C2760	syntax error: ')' was unexpected here; expected 'expression' ... component_options.hpp	230`		

The reason for this is that max() and min() are predefined macros under Windows. The proposed solution is to remove the definition of these macros.
