### PR TITLE
Fix use of uninitialized cursor variable

### DIFF
--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -60,7 +60,7 @@ class Screen : public Image {
       BarBlinking = 5,
       Bar = 6,
     };
-    Shape shape;
+    Shape shape = Hidden;
   };
 
   Cursor cursor() const { return cursor_; }


### PR DESCRIPTION
The cursor_ variable was being default initialized, which causes undefined behaviour when accessing properties in
ScreenInteractive::Draw. This caused a crash when running with UBSAN.

```
ftxui/src/ftxui/component/screen_interactive.cpp:852:17: runtime error:
load of value 4195502944, which is not a valid value for type 'Shape'
```

This change causes cursor_ to be value initialized so that its members will be initialized to 0.