### PR TITLE
Add `Merge()` specializations to support more `Element` containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Next
 ### Dom
 - Fix integer overflow in `ComputeShrinkHard`. Thanks @its-pablo in #1137 for
   reporting and fixing the issue.
+- Add specialization for `vbox/hbox/dbox` to allow a container of Element as
+  as input. Thanks @nbusser in #1117.
 
 6.1.9 (2025-05-07)
 ------------

--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -173,7 +173,7 @@ class InputBase : public ComponentBase, public InputOption {
       elements.push_back(element);
     }
 
-    auto element = vbox(std::move(elements), cursor_line) | frame;
+    auto element = vbox(std::move(elements)) | frame;
     return transform_func({
                std::move(element), hovered_, is_focused,
                false  // placeholder

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -145,8 +145,8 @@ class MenuBase : public ComponentBase, public MenuOption {
     }
 
     const Element bar = IsHorizontal()
-                            ? hbox(std::move(elements), selected_focus_)
-                            : vbox(std::move(elements), selected_focus_);
+                            ? hbox(std::move(elements))
+                            : vbox(std::move(elements));
 
     if (!underline.enabled) {
       return bar | reflect(box_);

--- a/src/ftxui/component/radiobox.cpp
+++ b/src/ftxui/component/radiobox.cpp
@@ -46,7 +46,7 @@ class RadioboxBase : public ComponentBase, public RadioboxOption {
       }
       elements.push_back(element | reflect(boxes_[i]));
     }
-    return vbox(std::move(elements), hovered_) | reflect(box_);
+    return vbox(std::move(elements)) | reflect(box_);
   }
 
   // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/src/ftxui/dom/hbox_test.cpp
+++ b/src/ftxui/dom/hbox_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>  // for Test, TestInfo (ptr only), EXPECT_EQ, Message, TEST, TestPartResult
 #include <array>          // for array
 #include <cstddef>        // for size_t
+#include <queue>
 #include <stack>          // for stack
 #include <string>         // for allocator, basic_string, string
 #include <unordered_set>  // for unordered_set


### PR DESCRIPTION
## Related issue

https://github.com/ArthurSonzogni/FTXUI/issues/1108

## Description

`Merge()` was previously only supporting `Elements` as a `Element` container.  
This PR adds specialization for:
- all the containers that matches the concept `std::ranges::range`
- `std::queue`
- `std::stack`

## Interrogation

I did not find a clear reference about the C++ standard that FTXUI claims to support.

@ArthurSonzogni Is it ok to use C++20 concepts here, or should FTXUI be compatible with older C++ standards? In that case I will change the PR content accordingly.