### PR TITLE
Fixed SliderOption compilation error when compiling with MSVC

### DIFF
--- a/include/ftxui/component/component_options.hpp
+++ b/include/ftxui/component/component_options.hpp
@@ -226,7 +226,7 @@ struct SliderOption {
   Ref<T> value;
   ConstRef<T> min = T(0);
   ConstRef<T> max = T(100);
-  ConstRef<T> increment = (max() - min()) / 20;
+  ConstRef<T> increment = ((max)() - (min)()) / 20;
   Direction direction = Direction::Right;
   Color color_active = Color::White;
   Color color_inactive = Color::GrayDark;


### PR DESCRIPTION
## Problem
I've ran into a problem when trying to compile from source using MSVC from CMAKE's 'Visual Studio 17 2022' generator. I'm not sure if this happens in other circumstances, but this is where I encountered this issue. When trying to compile, I get the following error:
```
include\ftxui\component\component_options.hpp(227,28): error C2760: syntax error: ')' was unexpected here; expected 'expression'
```
The struct is as follows:
```cpp
template <typename T>
struct SliderOption {
  Ref<T> value;
  ConstRef<T> min = T(0);
  ConstRef<T> max = T(100);
  ConstRef<T> increment = ((max)() - (min)()) / 20;
  Direction direction = Direction::Right;
  Color color_active = Color::White;
  Color color_inactive = Color::GrayDark;
  std::function<void()> on_change;  ///> Called when `value` is updated.
};
```
The culprit is this line:
```cpp
ConstRef<T> increment = (max() - min()) / 20;
```
## Solution
My assumption is that MSVC sees `max()` and `min()` as function calls calling the standard library's max and min function instead of calling `operator()` on the `min` and `max` members. I solved this by simply adding parentheses:
```cpp
ConstRef<T> increment = ((max)() - (min)()) / 20;
```
This is my first pr on GitHub, so forgive me for any mistakes.