### PR TITLE
Add explicit include for std::max

### DIFF
--- a/src/ftxui/component/resizable_split.cpp
+++ b/src/ftxui/component/resizable_split.cpp
@@ -4,6 +4,7 @@
 #include <ftxui/component/component_options.hpp>  // for ResizableSplitOption
 #include <ftxui/dom/direction.hpp>  // for Direction, Direction::Down, Direction::Left, Direction::Right, Direction::Up
 #include <ftxui/util/ref.hpp>       // for Ref
+#include <algorithm>                // for max
 #include <functional>               // for function
 #include <utility>                  // for move
 


### PR DESCRIPTION
Add an explicit include for `std::max`.
Visual Studio 2019 and 2022 seem a bit generous here, but this include is required in Visual Studio 2017.