### PR TITLE
Fix CMake 3.12 compatibility by adding required install destinations

### DIFF
--- a/cmake/ftxui_install.cmake
+++ b/cmake/ftxui_install.cmake
@@ -11,6 +11,9 @@ include(CMakePackageConfigHelpers)
 install(
   TARGETS screen dom component
   EXPORT ftxui-targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
   )
 
 install(


### PR DESCRIPTION
The `install(TARGETS ...)` command in `cmake/ftxui_install.cmake` was missing required destination specifications that became mandatory in CMake 3.12+. This caused build failures when users tried to install FTXUI with the minimum supported CMake version.

The issue occurred because the install command:

```cmake
install(
  TARGETS screen dom component
  EXPORT ftxui-targets
  )
```

Was missing explicit destination specifications for different artifact types. CMake 3.12+ requires these destinations to be explicitly declared.

This PR adds the required destination specifications:

```cmake
install(
  TARGETS screen dom component
  EXPORT ftxui-targets
  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
  )
```

The fix ensures that:
- Static libraries (`.a` files) are installed to the archive destination
- Shared libraries are installed to the library destination
- Executables are installed to the runtime destination

All destinations use CMake's standard directory variables for proper cross-platform compatibility. The change is backward compatible and maintains the same installation behavior while satisfying CMake 3.12+ requirements.

Fixes #1118.