### PR TITLE
Updated bazel build example section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ cc_binary(
     name = "your_target",
     srcs = ["your_source.cc"],
     deps = [
-        "@ftxui//:ftxui_component",
-        "@ftxui//:ftxui_dom",
-        "@ftxui//:ftxui_screen",
+        "@ftxui//:component",
+        "@ftxui//:dom",
+        "@ftxui//:screen",
     ],
 )
 ```


### PR DESCRIPTION
I'm new to FTXUI and was trying to build using Bazel by following the instructions in the README.md file. I would get some errors and couldn't get it to compile successfully.

After some while, I found that the instructions on the  [website](https://arthursonzogni.github.io/FTXUI/installation_bazel.html) are different and worked for me.

This PR updates the Bazel usage section in the README.md to match the correct and working example from the website.