### PR TITLE
Use module partitions instead of full modules

### DIFF
--- a/doc/cpp20-modules.md
+++ b/doc/cpp20-modules.md
@@ -73,38 +73,6 @@ are available:
 
 - `ftxui`
     - `ftxui.component`
-      - `ftxui.component:Animation`
-      - `ftxui.component:CapturedMouse`
-      - `ftxui.component:Component`
-      - `ftxui.component:ComponentBase`
-      - `ftxui.component:ComponentOptions`
-      - `ftxui.component:Event`
-      - `ftxui.component:Loop`
-      - `ftxui.component:Mouse`
-      - `ftxui.component:Receiver`
-      - `ftxui.component:ScreenInteractive`
-      - `ftxui.component:Task`
-- `ftxui.dom`
-    - `ftxui.dom:Canvas`
-    - `ftxui.dom:Deprecated`
-    - `ftxui.dom:Direction`
-    - `ftxui.dom:Elements`
-    - `ftxui.dom:FlexboxConfig`
-    - `ftxui.dom:LinearGradient`
-    - `ftxui.dom:Node`
-    - `ftxui.dom:Requirement`
-    - `ftxui.dom:Selection`
-    - `ftxui.dom:Table`
-- `ftxui.screen`
-    - `ftxui.screen:Box`
-    - `ftxui.screen:Color`
-    - `ftxui.screen:ColorInfo`
-    - `ftxui.screen:Deprecated`
-    - `ftxui.screen:Image`
-    - `ftxui.screen:Pixel`
-    - `ftxui.screen:Screen`
-    - `ftxui.screen:String`
-    - `ftxui.screen:Terminal`
-- `ftxui.util`
-    - `ftxui.util:AutoReset`
-    - `ftxui.util:Ref`
+    - `ftxui.dom`
+    - `ftxui.screen`
+    - `ftxui.util`

--- a/doc/cpp20-modules.md
+++ b/doc/cpp20-modules.md
@@ -4,15 +4,15 @@
 > [!WARNING]
 > This feature is still in development, and the API may change in future releases.
 > Your contribution is needed to help us improve the compatibility and usability
-> of C++20 modules in FTXUI. If you encounter any issues or have suggestions,
+> of C++ modules in FTXUI. If you encounter any issues or have suggestions,
 > please open an issue.
 
 FTXUI experimentally supports
 [C++20 modules](https://en.cppreference.com/w/cpp/language/modules) to reduce
-compilation times and improve code organization. Each header has a
-corresponding module.
+compilation times and improve code organization. Each part of the library has a
+corresponding module, split into partitions per each header.
 
-Use the FTXUI_BUILD_MODULES option to build the FTXUI project itself to provide C++ 20 modules,
+Use the FTXUI_BUILD_MODULES option to build the FTXUI project itself to provide C++20 modules,
 for example with CMake and Ninja:
 
 ```sh
@@ -25,7 +25,7 @@ ninja
 ```
 
 > [!NOTE]
-> To use modules, you need a C++20 compatible compiler, CMake version 3.20 or
+> To use modules, you need a C++≥20 compatible compiler, CMake version 3.20 or
 > higher, and use a compatible generator like Ninja. Note that Makefile
 > generators **do not support modules**.
 
@@ -34,9 +34,12 @@ Then, in your own code you can consume the modules and code as normal:
 ```cpp
 import ftxui;
 
+using ftxui::Button;
+using ftxui::ScreenInteractive;
+
 int main() {
-  auto screen = ftxui::ScreenInteractive::TerminalOutput();
-  auto button = ftxui::Button("Click me", screen.QuitClosure());
+  auto screen = ScreenInteractive::TerminalOutput();
+  auto button = Button("Click me", screen.QuitClosure());
   screen.Loop(button);
   return 0;
 }
@@ -70,38 +73,38 @@ are available:
 
 - `ftxui`
     - `ftxui.component`
-      - `ftxui.component.Animation`
-      - `ftxui.component.CapturedMouse`
-      - `ftxui.component.Component`
-      - `ftxui.component.ComponentBase`
-      - `ftxui.component.ComponentOptions`
-      - `ftxui.component.Event`
-      - `ftxui.component.Loop`
-      - `ftxui.component.Mouse`
-      - `ftxui.component.Receiver`
-      - `ftxui.component.ScreenInteractive`
-      - `ftxui.component.Task`
+      - `ftxui.component:Animation`
+      - `ftxui.component:CapturedMouse`
+      - `ftxui.component:Component`
+      - `ftxui.component:ComponentBase`
+      - `ftxui.component:ComponentOptions`
+      - `ftxui.component:Event`
+      - `ftxui.component:Loop`
+      - `ftxui.component:Mouse`
+      - `ftxui.component:Receiver`
+      - `ftxui.component:ScreenInteractive`
+      - `ftxui.component:Task`
 - `ftxui.dom`
-    - `ftxui.dom.Canvas`
-    - `ftxui.dom.Deprecated`
-    - `ftxui.dom.Direction`
-    - `ftxui.dom.Elements`
-    - `ftxui.dom.FlexboxConfig`
-    - `ftxui.dom.LinearGradient`
-    - `ftxui.dom.Node`
-    - `ftxui.dom.Requirement`
-    - `ftxui.dom.Selection`
-    - `ftxui.dom.Table`
+    - `ftxui.dom:Canvas`
+    - `ftxui.dom:Deprecated`
+    - `ftxui.dom:Direction`
+    - `ftxui.dom:Elements`
+    - `ftxui.dom:FlexboxConfig`
+    - `ftxui.dom:LinearGradient`
+    - `ftxui.dom:Node`
+    - `ftxui.dom:Requirement`
+    - `ftxui.dom:Selection`
+    - `ftxui.dom:Table`
 - `ftxui.screen`
-    - `ftxui.screen.Box`
-    - `ftxui.screen.Color`
-    - `ftxui.screen.ColorInfo`
-    - `ftxui.screen.Deprecated`
-    - `ftxui.screen.Image`
-    - `ftxui.screen.Pixel`
-    - `ftxui.screen.Screen`
-    - `ftxui.screen.String`
-    - `ftxui.screen.Terminal`
+    - `ftxui.screen:Box`
+    - `ftxui.screen:Color`
+    - `ftxui.screen:ColorInfo`
+    - `ftxui.screen:Deprecated`
+    - `ftxui.screen:Image`
+    - `ftxui.screen:Pixel`
+    - `ftxui.screen:Screen`
+    - `ftxui.screen:String`
+    - `ftxui.screen:Terminal`
 - `ftxui.util`
-    - `ftxui.util.AutoReset`
-    - `ftxui.util.Ref`
+    - `ftxui.util:AutoReset`
+    - `ftxui.util:Ref`

--- a/src/ftxui/component.cppm
+++ b/src/ftxui/component.cppm
@@ -3,14 +3,14 @@
 
 export module ftxui.component;
 
-export import ftxui.component.animation;
-export import ftxui.component.captured_mouse;
-export import ftxui.component.component;
-export import ftxui.component.component_base;
-export import ftxui.component.component_options;
-export import ftxui.component.event;
-export import ftxui.component.loop;
-export import ftxui.component.mouse;
-export import ftxui.component.receiver;
-export import ftxui.component.screen_interactive;
-export import ftxui.component.task;
+export import :Animation;
+export import :CapturedMouse;
+export import :Component;
+export import :ComponentBase;
+export import :ComponentOptions;
+export import :Event;
+export import :Loop;
+export import :Mouse;
+export import :Receiver;
+export import :ScreenInteractive;
+export import :Task;

--- a/src/ftxui/component/animation.cppm
+++ b/src/ftxui/component/animation.cppm
@@ -1,4 +1,4 @@
-/// @module ftxui.component.animation
+/// @module ftxui.component:Animation
 /// @brief C++20 module interface for the Animation namespace of the Component module.
 ///
 
@@ -6,7 +6,7 @@ module;
 
 #include <ftxui/component/animation.hpp>
 
-export module ftxui.component.animation;
+export module ftxui.component:Animation;
 
 /**
  * @namespace ftxui::animation
@@ -23,7 +23,7 @@ export namespace ftxui::animation {
 
     /**
      * @namespace easing
-     * @brief The FTXUI sf::animation::easing:: namespace
+     * @brief The FTXUI ftxui::animation::easing:: namespace
      */
     namespace easing {
         using ftxui::animation::easing::Function;

--- a/src/ftxui/component/captured_mouse.cppm
+++ b/src/ftxui/component/captured_mouse.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.captured_mouse
+/// @module ftxui.component.CapturedMouse
 /// @brief Module file for the CapturedMouseInterface class of the Component module
 
 module;
 
 #include <ftxui/component/captured_mouse.hpp>
 
-export module ftxui.component.captured_mouse;
+export module ftxui.component:CapturedMouse;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/component.cppm
+++ b/src/ftxui/component/component.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.component
+/// @module ftxui.component:Component
 /// @brief Module file for the Component classes of the Component module
 
 module;
 
 #include <ftxui/component/component.hpp>
 
-export module ftxui.component.component;
+export module ftxui.component:Component;
 
 /**
  * @namespace ftxui
@@ -28,6 +28,10 @@ export namespace ftxui {
     using ftxui::operator|;
     using ftxui::operator|=;
 
+    /**
+     * @namespace Container
+     * @brief The FTXUI ftxui::Container:: namespace
+     */
     namespace Container {
         using ftxui::Container::Vertical;
         using ftxui::Container::Horizontal;

--- a/src/ftxui/component/component_base.cppm
+++ b/src/ftxui/component/component_base.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.component_base
+/// @module ftxui.component:ComponentBase
 /// @brief Module file for the ComponentBase class of the Component module
 
 module;
 
 #include <ftxui/component/component_base.hpp>
 
-export module ftxui.component.component_base;
+export module ftxui.component:ComponentBase;
 
 /**
  * @namespace ftxui
@@ -16,6 +16,10 @@ export namespace ftxui {
     using ftxui::Focus;
     using ftxui::Event;
 
+    /**
+     * @namespace animation
+     * @brief The FTXUI ftxui::animation:: namespace
+     */
     namespace animation {
         using ftxui::animation::Params;
     }

--- a/src/ftxui/component/component_options.cppm
+++ b/src/ftxui/component/component_options.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.component_options
+/// @module ftxui.component:ComponentOptions
 /// @brief Module file for options for the Component class of the Component module
 
 module;
 
 #include <ftxui/component/component_options.hpp>
 
-export module ftxui.component.component_options;
+export module ftxui.component:ComponentOptions;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/event.cppm
+++ b/src/ftxui/component/event.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.event
+/// @module ftxui.component:Event
 /// @brief Module file for the Event struct of the Component module
 
 module;
 
 #include <ftxui/component/event.hpp>
 
-export module ftxui.component.event;
+export module ftxui.component:Event;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/loop.cppm
+++ b/src/ftxui/component/loop.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.loop
+/// @module ftxui.component:Loop
 /// @brief Module file for the Loop class of the Component module
 
 module;
 
 #include <ftxui/component/loop.hpp>
 
-export module ftxui.component.loop;
+export module ftxui.component:Loop;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/mouse.cppm
+++ b/src/ftxui/component/mouse.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.mouse
+/// @module ftxui.component:Mouse
 /// @brief Module file for the Mouse struct of the Component module
 
 module;
 
 #include <ftxui/component/mouse.hpp>
 
-export module ftxui.component.mouse;
+export module ftxui.component:Mouse;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/receiver.cppm
+++ b/src/ftxui/component/receiver.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.receiver
+/// @module ftxui.component:Receiver
 /// @brief Module file for the Receiver class of the Component module
 
 module;
 
 #include <ftxui/component/receiver.hpp>
 
-export module ftxui.component.receiver;
+export module ftxui.component:Receiver;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/screen_interactive.cppm
+++ b/src/ftxui/component/screen_interactive.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.screen_interactive
+/// @module ftxui.component:ScreenInteractive
 /// @brief Module file for the ScreenInteractive class of the Component module
 
 module;
 
 #include <ftxui/component/screen_interactive.hpp>
 
-export module ftxui.component.screen_interactive;
+export module ftxui.component:ScreenInteractive;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/component/task.cppm
+++ b/src/ftxui/component/task.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.component.task
+/// @module ftxui.component:Task
 /// @brief Module file for the Task class of the Component module
 
 module;
 
 #include <ftxui/component/task.hpp>
 
-export module ftxui.component.task;
+export module ftxui.component:Task;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom.cppm
+++ b/src/ftxui/dom.cppm
@@ -1,15 +1,15 @@
 /// @module ftxui.dom
-/// @brief Module file for FTXUI main operations.
+/// @brief Module file for FTXUI DOM operations.
 
 export module ftxui.dom;
 
-export import ftxui.dom.canvas;
-export import ftxui.dom.deprecated;
-export import ftxui.dom.direction;
-export import ftxui.dom.elements;
-export import ftxui.dom.flexbox_config;
-export import ftxui.dom.linear_gradient;
-export import ftxui.dom.node;
-export import ftxui.dom.requirement;
-export import ftxui.dom.selection;
-export import ftxui.dom.table;
+export import :Canvas;
+export import :Deprecated;
+export import :Direction;
+export import :Elements;
+export import :FlexboxConfig;
+export import :LinearGradient;
+export import :Node;
+export import :Requirement;
+export import :Selection;
+export import :Table;

--- a/src/ftxui/dom/canvas.cppm
+++ b/src/ftxui/dom/canvas.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.canvas
-/// @brief Module file for the Canvas struct of the Dom module
+/// @module ftxui.dom:Canvas
+/// @brief Module file for the Canvas struct of the DOM module
 
 module;
 
 #include <ftxui/dom/canvas.hpp>
 
-export module ftxui.dom.canvas;
+export module ftxui.dom:Canvas;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/deprecated.cppm
+++ b/src/ftxui/dom/deprecated.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.deprecated
-/// @brief Module file for deprecated parts of the Dom module
+/// @module ftxui.dom:Deprecated
+/// @brief Module file for deprecated parts of the DOM module
 
 module;
 
 #include <ftxui/dom/deprecated.hpp>
 
-export module ftxui.dom.deprecated;
+export module ftxui.dom:Deprecated;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/direction.cppm
+++ b/src/ftxui/dom/direction.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.direction
+/// @module ftxui.dom:Direction
 /// @brief Module file for the Direction enum of the Dom module
 
 module;
 
 #include <ftxui/dom/direction.hpp>
 
-export module ftxui.dom.direction;
+export module ftxui.dom:Direction;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/elements.cppm
+++ b/src/ftxui/dom/elements.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.elements
-/// @brief Module file for the Element classes and functions of the Dom module
+/// @module ftxui.dom:Elements
+/// @brief Module file for the Element classes and functions of the DOM module
 
 module;
 
 #include <ftxui/dom/elements.hpp>
 
-export module ftxui.dom.elements;
+export module ftxui.dom:Elements;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/flexbox_config.cppm
+++ b/src/ftxui/dom/flexbox_config.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.flexbox_config
-/// @brief Module file for the FlexboxConfig struct of the Dom module
+/// @module ftxui.dom:FlexboxConfig
+/// @brief Module file for the FlexboxConfig struct of the DOM module
 
 module;
 
 #include <ftxui/dom/flexbox_config.hpp>
 
-export module ftxui.dom.flexbox_config;
+export module ftxui.dom:FlexboxConfig;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/linear_gradient.cppm
+++ b/src/ftxui/dom/linear_gradient.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.linear_gradient
-/// @brief Module file for the LinearGradient struct of the Dom module
+/// @module ftxui.dom:LinearGradient
+/// @brief Module file for the LinearGradient struct of the DOM module
 
 module;
 
 #include <ftxui/dom/linear_gradient.hpp>
 
-export module ftxui.dom.linear_gradient;
+export module ftxui.dom:LinearGradient;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/node.cppm
+++ b/src/ftxui/dom/node.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.node
-/// @brief Module file for the Node class of the Dom module
+/// @module ftxui.dom:Node
+/// @brief Module file for the Node class of the DOM module
 
 module;
 
 #include <ftxui/dom/node.hpp>
 
-export module ftxui.dom.node;
+export module ftxui.dom:Node;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/requirement.cppm
+++ b/src/ftxui/dom/requirement.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.requirement
-/// @brief Module file for the Requirement struct of the Dom module
+/// @module ftxui.dom:Requirement
+/// @brief Module file for the Requirement struct of the DOM module
 
 module;
 
 #include <ftxui/dom/requirement.hpp>
 
-export module ftxui.dom.requirement;
+export module ftxui.dom:Requirement;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/selection.cppm
+++ b/src/ftxui/dom/selection.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.selection
-/// @brief Module file for the Selection class of the Dom module
+/// @module ftxui.dom:Selection
+/// @brief Module file for the Selection class of the DOM module
 
 module;
 
 #include <ftxui/dom/selection.hpp>
 
-export module ftxui.dom.selection;
+export module ftxui.dom:Selection;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/dom/table.cppm
+++ b/src/ftxui/dom/table.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.dom.table
-/// @brief Module file for the Table class of the Dom module
+/// @module ftxui.dom:Table
+/// @brief Module file for the Table class of the DOM module
 
 module;
 
 #include <ftxui/dom/table.hpp>
 
-export module ftxui.dom.table;
+export module ftxui.dom:Table;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen.cppm
+++ b/src/ftxui/screen.cppm
@@ -3,12 +3,12 @@
 
 export module ftxui.screen;
 
-export import ftxui.screen.box;
-export import ftxui.screen.color;
-export import ftxui.screen.color_info;
-export import ftxui.screen.deprecated;
-export import ftxui.screen.image;
-export import ftxui.screen.pixel;
-export import ftxui.screen.screen;
-export import ftxui.screen.string;
-export import ftxui.screen.terminal;
+export import :Box;
+export import :Color;
+export import :ColorInfo;
+export import :Deprecated;
+export import :Image;
+export import :Pixel;
+export import :Screen;
+export import :String;
+export import :Terminal;

--- a/src/ftxui/screen/box.cppm
+++ b/src/ftxui/screen/box.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.box
+/// @module ftxui.screen:Box
 /// @brief Module file for the Box struct of the Screen module
 
 module;
 
 #include <ftxui/screen/box.hpp>
 
-export module ftxui.screen.box;
+export module ftxui.screen:Box;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/color.cppm
+++ b/src/ftxui/screen/color.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.color
+/// @module ftxui.screen:Color
 /// @brief Module file for the Color class of the Screen module
 
 module;
 
 #include <ftxui/screen/color.hpp>
 
-export module ftxui.screen.color;
+export module ftxui.screen:Color;
 
 /**
  * @namespace ftxui
@@ -14,6 +14,10 @@ export module ftxui.screen.color;
 export namespace ftxui {
     using ftxui::Color;
 
+    /**
+     * @namespace literals
+     * @brief The FTXUI ftxui::literals:: namespace
+     */
     inline namespace literals {
         using ftxui::literals::operator""_rgb;
     }

--- a/src/ftxui/screen/color_info.cppm
+++ b/src/ftxui/screen/color_info.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.color_info
+/// @module ftxui.screen:ColorInfo
 /// @brief Module file for the ColorInfo struct of the Screen module
 
 module;
 
 #include <ftxui/screen/color_info.hpp>
 
-export module ftxui.screen.color_info;
+export module ftxui.screen:ColorInfo;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/deprecated.cppm
+++ b/src/ftxui/screen/deprecated.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.deprecated
+/// @module ftxui.screen:Deprecated
 /// @brief Module file for the deprecated parts of the Screen module
 
 module;
 
 #include <ftxui/screen/deprecated.hpp>
 
-export module ftxui.screen.deprecated;
+export module ftxui.screen:Deprecated;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/image.cppm
+++ b/src/ftxui/screen/image.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.image
+/// @module ftxui.screen:Image
 /// @brief Module file for the Image class of the Screen module
 
 module;
 
 #include <ftxui/screen/image.hpp>
 
-export module ftxui.screen.image;
+export module ftxui.screen:Image;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/pixel.cppm
+++ b/src/ftxui/screen/pixel.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.pixel
+/// @module ftxui.screen:Pixel
 /// @brief Module file for the Pixel struct of the Screen module
 
 module;
 
 #include <ftxui/screen/pixel.hpp>
 
-export module ftxui.screen.pixel;
+export module ftxui.screen:Pixel;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/screen.cppm
+++ b/src/ftxui/screen/screen.cppm
@@ -1,17 +1,21 @@
-/// @module ftxui.screen.screen
+/// @module ftxui.screen:Screen
 /// @brief Module file for the Screen class of the Screen module
 
 module;
 
 #include <ftxui/screen/screen.hpp>
 
-export module ftxui.screen.screen;
+export module ftxui.screen:Screen;
 
 /**
  * @namespace ftxui
  * @brief The FTXUI ftxui:: namespace
  */
 export namespace ftxui {
+    /**
+     * @namespace Dimension
+     * @brief The FTXUI ftxui::Dimension:: namespace
+     */
     namespace Dimension {
         using ftxui::Dimension::Fixed;
         using ftxui::Dimension::Full;

--- a/src/ftxui/screen/string.cppm
+++ b/src/ftxui/screen/string.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.string
+/// @module ftxui.screen:String
 /// @brief Module file for string functions of the Screen module
 
 module;
 
 #include <ftxui/screen/string.hpp>
 
-export module ftxui.screen.string;
+export module ftxui.screen:String;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/screen/terminal.cppm
+++ b/src/ftxui/screen/terminal.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.screen.terminal
+/// @module ftxui.screen:Terminal
 /// @brief Module file for the Terminal namespace of the Screen module
 
 module;
 
 #include <ftxui/screen/terminal.hpp>
 
-export module ftxui.screen.terminal;
+export module ftxui.screen:Terminal;
 
 /**
  * @namespace ftxui
@@ -14,6 +14,10 @@ export module ftxui.screen.terminal;
 export namespace ftxui {
     using ftxui::Dimensions;
 
+    /**
+     * @namespace Terminal
+     * @brief The FTXUI ftxui::Terminal:: namespace
+     */
     namespace Terminal {
         using ftxui::Terminal::Size;
         using ftxui::Terminal::SetFallbackSize;

--- a/src/ftxui/util.cppm
+++ b/src/ftxui/util.cppm
@@ -3,5 +3,5 @@
 
 export module ftxui.util;
 
-export import ftxui.util.autoreset;
-export import ftxui.util.ref;
+export import :AutoReset;
+export import :Ref;

--- a/src/ftxui/util/autoreset.cppm
+++ b/src/ftxui/util/autoreset.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.util.autoreset
+/// @module ftxui.util:AutoReset
 /// @brief Module file for the AutoReset class of the Util module
 
 module;
 
 #include <ftxui/util/autoreset.hpp>
 
-export module ftxui.util.autoreset;
+export module ftxui.util:AutoReset;
 
 /**
  * @namespace ftxui

--- a/src/ftxui/util/ref.cppm
+++ b/src/ftxui/util/ref.cppm
@@ -1,11 +1,11 @@
-/// @module ftxui.util.ref
+/// @module ftxui.util:Ref
 /// @brief Module file for the Ref classes of the Util module
 
 module;
 
 #include <ftxui/util/ref.hpp>
 
-export module ftxui.util.ref;
+export module ftxui.util:Ref;
 
 /**
  * @namespace ftxui


### PR DESCRIPTION
Follow-up to #1015. This pull request replaces the full modules that represent headers, with partitions, to emphasise the belonging of the header to the module. This should hopefully provide a speedup to compilation, and confuse users less by aggregating the usable modules into a smaller set.