### PR TITLE
Added the translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
   <a href="https://arthursonzogni.github.io/FTXUI/examples/">Examples</a> .
   <a href="https://github.com/ArthurSonzogni/FTXUI/issues">Request Feature</a> ·
   <a href="https://github.com/ArthurSonzogni/FTXUI/pulls">Send a Pull Request</a>
+  
+  <br/>
+  <a href="https://github.com/ArthurSonzogni/">English</a> |
+  <a href="https://github.com/ArthurSonzogni/ftxui-translations/tree/zh-CH">中文翻译</a> |
+  <a href="https://github.com/ArthurSonzogni/ftxui-translations/tree/zh-CH">繁體中文</a> |
+  <a href="https://github.com/ArthurSonzogni/ftxui-translations/tree/ja">日本語</a>
 
 </p>
 

--- a/doc/installation_conan.md
+++ b/doc/installation_conan.md
@@ -91,7 +91,7 @@ add_executable(demo demo.cpp)
 target_link_libraries(demo PRIVATE ftxui::component)
 ```
 
-@todo 考虑到中国多数地区使用Conan很有可能遇到各种网络问题，我想做一个定制的版本说明，但是我对conan的了解有限再加上没有找到合适的资料，因此这个计划短暂的被搁置了，如果您知道方法，欢迎在[中文版本](xiaoditx.girhub.io/public/docs/ftxui%E4%B8%AD%E6%96%87%E7%BF%BB%E8%AF%91/installation/conan/)的下方留下评论以提醒我
+@todo 中国大陆在这方面的下载可能会受限制，需要一个替代的方案
 
 ---
 


### PR DESCRIPTION
I simply added the link and also made some minor changes to the previous todo list I had written.

The translation provided by LLM is not very accurate. In some parts (at least in the simplified Chinese version), they were not translated. I wanted to correct it but I wasn't sure how to do it while ensuring that the subsequent translations wouldn't overwrite. So, I decided not to fix the issues for now.

By the way, it seems that [https://github.com/ArthurSonzogni/ftxui-translations/tree/fr] has not been translated. What's the reason for this?