### PR TITLE
Fix cmake command in manual installation

### DIFF
--- a/doc/installation_manual.md
+++ b/doc/installation_manual.md
@@ -8,7 +8,7 @@ Clone and build the project using CMake:
 ```bash
 git clone https://github.com/ArthurSonzogni/FTXUI.git
 cd FTXUI
-cmake -S . -B build -DFTXUI_ENABLE_INSTALL=ON -D
+cmake -S . -B build -D FTXUI_ENABLE_INSTALL=ON
 cmake --build build -j
 sudo cmake --install build
 ```


### PR DESCRIPTION
CMake Error: -D must be followed with VAR=VALUE