### PR TITLE
Update nix lock and make nix package follow the current version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "lastModified": 1765644376,
+        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,15 +12,9 @@
     let llvm = pkgs.llvmPackages_latest; in
     {
       packages = rec {
-        default = pkgs.stdenv.mkDerivation rec {
-          pname = "ftxui";
-          version = "v4.0.0";
-          src = pkgs.fetchFromGitHub {
-            owner = "ArthurSonzogni";
-            repo = "FTXUI";
-            rev = version;
-            sha256 = "sha256-3kAhHDUwzwdvHc8JZAcA14tGqa6w69qrN1JXhSxNBQY=";
-          };
+        default = pkgs.stdenv.mkDerivation {
+          name = "ftxui";
+          src = ./.;
 
           nativeBuildInputs = [
             pkgs.cmake


### PR DESCRIPTION
With nix, usually you want to define the version of the code to be the one of the git-branch you are taking it, in this case, it was hardcoded to be version v4.0.0 (which is already quite old). 

For example, the usual is to do something like:

nix shell github:ArthurSonzogni/FTXUI

to get the latest version.

You can also get an specific commit via:

nix shell github:ArthurSonzogni/FTXUI/183a426efa93e7a1b25730e85e194246523ef1c8

(Which also works with branches or tags)

this fixes it for new releases, at the same time that updating the lockfile makes it use the newer versions of the libraries and tooling.

Check that nix builds are still working:  
<img width="432" height="90" alt="image" src="https://github.com/user-attachments/assets/ab621483-dd7a-4e0c-a539-df62875d8cdb" />

