### PR TITLE
Set focused entry in MenuBase constructor

### DIFF
--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -68,7 +68,9 @@ bool IsHorizontal(Direction direction) {
 /// @ingroup component
 class MenuBase : public ComponentBase, public MenuOption {
  public:
-  explicit MenuBase(const MenuOption& option) : MenuOption(option) {}
+  explicit MenuBase(const MenuOption& option) : MenuOption(option) {
+    focused_entry() = selected();
+  }
 
   bool IsHorizontal() { return ftxui::IsHorizontal(direction); }
   void OnChange() {


### PR DESCRIPTION
Initialize focused entry to selected entry in MenuBase. Fixes https://github.com/ArthurSonzogni/FTXUI/issues/1179