### PR TITLE
perf: reset Pixel fields in-place in Image::Clear() instead of recons…

### DIFF
--- a/src/ftxui/screen/image.cpp
+++ b/src/ftxui/screen/image.cpp
@@ -55,7 +55,21 @@ const Pixel& Image::PixelAt(int x, int y) const {
 void Image::Clear() {
   for (auto& line : pixels_) {
     for (auto& cell : line) {
-      cell = Pixel();
+      // Reset style bits in-place instead of constructing a new Pixel.
+      // This avoids destroying and re-allocating the character string.
+      cell.blink = false;
+      cell.bold = false;
+      cell.dim = false;
+      cell.italic = false;
+      cell.inverted = false;
+      cell.underlined = false;
+      cell.underlined_double = false;
+      cell.strikethrough = false;
+      cell.automerge = false;
+      cell.hyperlink = 0;
+      cell.character.clear();  // Reuse existing allocation.
+      cell.background_color = Color::Default;
+      cell.foreground_color = Color::Default;
     }
   }
 }


### PR DESCRIPTION
…tructing

Replace 'cell = Pixel()' with in-place field resets in Image::Clear(). The previous approach constructed a new Pixel per cell per frame, destroying and re-allocating the std::string character member each time. The new approach resets each field individually and calls character.clear() to reuse the existing string allocation.

For 80x24 (1,920 pixels), this eliminates ~1,920 string destructions + constructions per frame.

Benchmark results (80x24, 10s, Release build):
- Stable Avg: 1258 -> 1298 FPS (+3.2%)
- P50: 1429 -> 1494 FPS (+4.6%)
- P99: 1582 -> 1615 FPS (+2.1%)
- Total frames: 7984 -> 8422 (+438)