### PR TITLE
fix(flexbox): correct child index skipping when line has no selection

### DIFF
--- a/src/ftxui/dom/flexbox.cpp
+++ b/src/ftxui/dom/flexbox.cpp
@@ -191,6 +191,7 @@ class Flexbox : public Node {
       // If the line box doesn't intersect with the selection, then no
       // selection.
       if (Box::Intersection(selection.GetBox(), box).IsEmpty()) {
+        i += line.blocks.size();
         continue;
       }
 


### PR DESCRIPTION
Fix a bug in Flexbox::Select() where child indices get misaligned when skipping lines without selection.

When iterating through lines, if a line's box has no intersection with the selection, the code `continue`s without incrementing the child index `i`. This causes subsequent lines to access wrong `children_` elements.
