### PR TITLE
Update color.cpp

### DIFF
--- a/src/ftxui/screen/color.cpp
+++ b/src/ftxui/screen/color.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdio>  // for snprintf
 #include <string>
+#include <tuple>
 
 #include "ftxui/screen/color_info.hpp"  // for GetColorInfo, ColorInfo
 #include "ftxui/screen/terminal.hpp"  // for ColorSupport, Color, Palette256, TrueColor


### PR DESCRIPTION
Fixes missing include when compiling with c++.

```
/out/Linux/Debug/_deps/ftxui-src/src/ftxui/screen/color.cpp: In static member function ‘static ftxui::Color ftxui::Color::Interpolate(float, const ftxui::Color&, const ftxui::Color&)’:
/out/Linux/Debug/_deps/ftxui-src/src/ftxui/screen/color.cpp:233:38: error: return type ‘class std::tuple<unsigned char, unsigned char, unsigned char>’ is incomplete
  233 |       [](const Color& color) -> std::tuple<uint8_t, uint8_t, uint8_t> {
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/out/Linux/Debug/_deps/ftxui-src/src/ftxui/screen/color.cpp:253:14: error: ‘const void <structured bindings>’ has incomplete type
  253 |   const auto [a_r, a_g, a_b] = to_rgb(a);
      |              ^~~~~~~~~~~~~~~
/out/Linux/Debug/_deps/ftxui-src/src/ftxui/screen/color.cpp:254:14: error: ‘const void <structured bindings>’ has incomplete type
  254 |   const auto [b_r, b_g, b_b] = to_rgb(b);
```