### PR TITLE
docs: add/remove missing variable in container examples

### DIFF
--- a/src/ftxui/component/container.cpp
+++ b/src/ftxui/component/container.cpp
@@ -329,6 +329,7 @@ Component Vertical(Components children) {
 /// ### Example
 ///
 /// ```cpp
+/// int selected_children = 2;
 /// auto container = Container::Vertical({
 ///   children_1,
 ///   children_2,
@@ -349,7 +350,6 @@ Component Vertical(Components children, int* selector) {
 /// ### Example
 ///
 /// ```cpp
-/// int selected_children = 2;
 /// auto container = Container::Horizontal({
 ///   children_1,
 ///   children_2,


### PR DESCRIPTION
The doc string example code in `container.cpp` for `Component Vertical(Components children, int* selector) {...}` is missing the variable `int selected_children`. Similarly, the doc string for `Component Horizontal(Components children) {...}` has said variable, but it is unused.

### Changes
- add the missing variable in doc string of `Component Vertical(Components children, int* selector) {...}`
- remove the unused variable in doc string of `Component Horizontal(Components children) {...}`

This was not corrected after adjusting the doc string in b0e087ec.