### PR TITLE
docs: indentation and typo in Renderer doc string

### DIFF
--- a/src/ftxui/component/renderer.cpp
+++ b/src/ftxui/component/renderer.cpp
@@ -117,9 +117,9 @@ Component Renderer(std::function<Element(bool)> render) {
 /// ```cpp
 /// auto screen = App::TerminalOutput();
 /// auto renderer =
-//     Renderer([] { return text("Hello");)
-///  | Renderer(bold)
-///  | Renderer(inverted);
+///   Renderer([] { return text("Hello"); })
+///   | Renderer(bold)
+///   | Renderer(inverted);
 /// screen.Loop(renderer);
 /// ```
 ComponentDecorator Renderer(ElementDecorator decorator) {  // NOLINT


### PR DESCRIPTION
The example in the doc string for `ComponentDecorator Renderer(ElementDecorator decorator)` was missing one slash and a closing brace.

I believe the missing slash lead to [strange formatting](https://arthursonzogni.github.io/FTXUI/group__component.html#ga41d63b7af41dee1570b54915821abd30) of the example in the online documentation:
```cpp
    auto screen = App::TerminalOutput();
    auto renderer = */
//     Renderer([] { return text("Hello");)
/**  | Renderer(bold)
     | Renderer(inverted);
    screen.Loop(renderer);
```

I also adjusted the indentation to what made sense to me. My formatter was not helpful, it prefers a single line :/