### PR TITLE
fix(component): normalize Home/End escape variants

### DIFF
--- a/src/ftxui/component/terminal_input_parser.cpp
+++ b/src/ftxui/component/terminal_input_parser.cpp
@@ -47,6 +47,10 @@ const std::map<std::string, std::string> g_uniformize = {
     {"\x1BOH", "\x1B[H"},  // HOME
     {"\x1BOF", "\x1B[F"},  // END
 
+    // Common Home/End sequences from terminals and multiplexers.
+    {"\x1B[1~", "\x1B[H"},  // HOME
+    {"\x1B[4~", "\x1B[F"},  // END
+
     // Variations around the FN keys.
     // Internally, we are using:
     // vt220, xterm-vt200, xterm-xf86-v44, xterm-new, mgt, screen

--- a/src/ftxui/component/terminal_input_parser_test.cpp
+++ b/src/ftxui/component/terminal_input_parser_test.cpp
@@ -372,6 +372,10 @@ TEST(Event, Special) {
       {str("\x1BOH"), Event::Home},
       {str("\x1BOF"), Event::End},
 
+      // Home/End variants.
+      {str("\x1B[1~"), Event::Home},
+      {str("\x1B[4~"), Event::End},
+
       // Backspace & Quirk for:
       // https://github.com/ArthurSonzogni/FTXUI/issues/508
       {{127}, Event::Backspace},


### PR DESCRIPTION
## Summary
- Normalize ESC[1~ to Event::Home and ESC[4~ to Event::End.
- This lets FTXUI recognize Home/End keypresses when environments such as tmux expose them through these terminfo sequences.
- Add focused terminal input parser regression coverage.
- Preserve existing Home/End handling for ESC[H, ESC[F, ESCOH, and ESCOF.

## Reference
- xterm/ncurses terminfo documents khome=\E[1~ and kend=\E[4~ in xterm+pc+edit:
  - https://invisible-island.net/xterm/terminfo-contents.html

## Tests
- cmake --build build --target ftxui-tests
- ./build/ftxui-tests --gtest_filter=Event.Special
- ctest --test-dir build --output-on-failure