### PR TITLE
fix: no trailing cursor on unfocused input

### DIFF
--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -148,10 +148,11 @@ class InputBase : public ComponentBase, public InputOption {
       }
 
       // The cursor is at the end of the line.
+      const std::string cursor_cell = is_focused ? " " : "";
       if (cursor_char_index >= (int)line.size()) {
         elements.push_back(hbox({
                                Text(line),
-                               text(" ") | focused | reflect(cursor_box_),
+                               text(cursor_cell) | focused | reflect(cursor_box_),
                            }) |
                            xflex);
         continue;


### PR DESCRIPTION
When an input element has the cursor at the end, a character is appended to signify the cursor (e.g. a cursor block shape). This vanishes again when the user moves the cursor left once into existing text. But when the cursor is at the end and the user switches to another element, this reserved cell for the cursor stays.

This can lead to unintended visualizations when an input element is right aligned or has a unit appended after the input field.

### Example

```cpp
#include <ftxui/component/component.hpp>
#include <ftxui/component/screen_interactive.hpp>

int main(int argc, char** argv) {
  std::string first_name = "Alice";
  std::string last_name;
  std::string address_name;

  // first remove properties set by default with ftxui::xflex so that the sell can be properly aligned to the right
  auto first_name_input = ftxui::Input(&first_name, "first name") | ftxui::notflex | ftxui::align_right;
  auto last_name_input  = ftxui::Input(&last_name, "last name") | ftxui::notflex | ftxui::align_right;
  auto address_input    = ftxui::Input(&address_name, "address") | ftxui::notflex | ftxui::align_right;
  auto box              = ftxui::Container::Vertical({first_name_input, last_name_input, address_input}) | ftxui::border;
  auto screen           = ftxui::ScreenInteractive::Fullscreen();
  screen.Loop(box);

  return EXIT_SUCCESS;
}
```

Initial state, cursor on "A" of "Alice":
<img width="326" height="152" alt="image" src="https://github.com/user-attachments/assets/ec36996b-96f7-4800-bf26-53f4dfe8fa17" />

After moving the cursor to the end of the first row:
<img width="326" height="152" alt="image" src="https://github.com/user-attachments/assets/46171ed2-564e-496a-9a11-3b08e6791e95" />

After moving the cursor down, now the first row is not aligned properly to the right:
<img width="326" height="152" alt="image" src="https://github.com/user-attachments/assets/c72ddae5-2ef3-4a45-931a-f6babdbe3a5e" />


### Changes
- only add a `" "`-cell when the Input element is focused