### PR TITLE
Fix typos across the codebase

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -131,7 +131,7 @@ ftxui_cc_library(
     deps = [":screen"],
 )
 
-# @ftxui:component is a library to create "dynamic" component renderering and
+# @ftxui:component is a library to create "dynamic" component rendering and
 # updating a ftxui::dom document on the screen. It is a higher level API than
 # ftxui:dom.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ See #1017 and #1019.
   alternate screen.
 - Bugfix: `Input` `onchange` was not called on backspace or delete key.
   Fixed by @chrysante in chrysante in PR #776.
-- Bugfix: Propertly restore cursor shape on exit. See #792.
+- Bugfix: Properly restore cursor shape on exit. See #792.
 - Bugfix: Fix cursor position in when in the last column. See #831.
 - Bugfix: Fix `ResizeableSplit` keyboard navigation. Fixed by #842.
 - Bugfix: Fix `Menu` focus. See #841
@@ -260,7 +260,7 @@ See #1017 and #1019.
 - Breaking: `Ref<{Component}Option>` becomes `{Component}Option` in component constructors.
 - Feature: `ResizeableSplit` now support arbitrary element as a separator.
 - Feature: `input` is now supporting multiple lines.
-- Feature: `input` style is now customizeable.
+- Feature: `input` style is now customizable.
 - Bugfix: Support F1-F5 from OS terminal.
 - Feature: Add struct based constructor:
   ```cpp
@@ -317,9 +317,9 @@ See #1017 and #1019.
 - Expose the pkg-config file
 - Check version compatibility when using cmake find_package()
 
-4.1.0  (Abandonned)
+4.1.0  (Abandoned)
 -----
-This version is abandonned and must not be used. It introduced a breaking change in the API.
+This version is abandoned and must not be used. It introduced a breaking change in the API.
 
 4.0.0
 -----
@@ -342,7 +342,7 @@ This version is abandonned and must not be used. It introduced a breaking change
 - Bugfix: Forward the selected/focused area from the child in gridbox.
 - Bugfix: Fix incorrect Canvas computed dimensions.
 - Bugfix: Support `vscroll_indicator` with a zero inner size.
-- Bugfix: Fix `vscroll_indicator` hidding the last column.
+- Bugfix: Fix `vscroll_indicator` hiding the last column.
 
 ### Component:
 - Feature: Add the `Modal` component.
@@ -407,7 +407,7 @@ This version is abandonned and must not be used. It introduced a breaking change
   - Add the `Maybe` decorator.
   - Add the `CatchEvent` decorator.
   - Add the `Renderer` decorator.
-- **breaking** remove the "deprectated.hpp" header and Input support for wide
+- **breaking** remove the "deprecated.hpp" header and Input support for wide
     string.
 
 ### DOM:
@@ -461,7 +461,7 @@ Element gaugeDirection(float ratio, GaugeDirection);
 #### Component 
 - Add the `collapsible` component.
 - Add the `App::WithRestoredIO`. This decorates a callback. This
-  runs it with the terminal hooks temporarilly uninstalled. This is useful if
+  runs it with the terminal hooks temporarily uninstalled. This is useful if
   you want to execute command using directly stdin/stdout/sterr.
 
 ### Bug
@@ -515,7 +515,7 @@ Element gaugeDirection(float ratio, GaugeDirection);
 - `separatorFixed`. A separator drawing the provided character.
 
 ### Component
-- `Maybe`: Display an component conditionnally based on a boolean.
+- `Maybe`: Display an component conditionally based on a boolean.
 - `Dropdown`: A dropdown select list.
 
 0.9 (2021-09-26)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(ftxui
 
 
 set(FTXUI_MICROSOFT_TERMINAL_FALLBACK_HELP_TEXT "On windows, assume the \
-terminal used will be one of Microsoft and use a set of reasonnable fallback \
+terminal used will be one of Microsoft and use a set of reasonable fallback \
 to counteract its implementations problems.")
 if (WIN32)
   option(FTXUI_MICROSOFT_TERMINAL_FALLBACK

--- a/examples/component/maybe.cpp
+++ b/examples/component/maybe.cpp
@@ -32,7 +32,7 @@ int main() {
       Radiobox(&entries, &menu_2_selected) | border | Maybe(&menu_2_show),
 
       Renderer([] {
-        return text("You found the secret combinaison!") | color(Color::Red);
+        return text("You found the secret combination!") | color(Color::Red);
       }) | Maybe([&] { return menu_1_selected == 1 && menu_2_selected == 2; }),
   });
 

--- a/examples/component/modal_dialog.cpp
+++ b/examples/component/modal_dialog.cpp
@@ -68,7 +68,7 @@ int main(int argc, const char* argv[]) {
   auto exit = screen.ExitLoopClosure();
   auto do_nothing = [&] {};
 
-  // Instanciate the main and modal components:
+  // Instantiate the main and modal components:
   auto main_component = MainComponent(show_modal, exit);
   auto modal_component = ModalComponent(do_nothing, hide_modal);
 

--- a/examples/component/with_restored_io.cpp
+++ b/examples/component/with_restored_io.cpp
@@ -39,7 +39,7 @@ int main() {
   auto renderer = Renderer(layout, [&] {
     auto explanation = paragraph(
         "After clicking this button, the App will be "
-        "suspended and access to stdin/stdout will temporarilly be "
+        "suspended and access to stdin/stdout will temporarily be "
         "restore for running a function.");
     auto element = vbox({
         explanation | borderEmpty,

--- a/examples/dom/color_info_sorted_2d.ipp
+++ b/examples/dom/color_info_sorted_2d.ipp
@@ -19,7 +19,7 @@ std::vector<std::vector<ftxui::ColorInfo>> ColorInfoSorted2D() {
       info_color.begin(), info_color.end(),
       [](const ftxui::ColorInfo& A, const ftxui::ColorInfo& B) { return A.hue < B.hue; });
 
-  // Make 8 colums, one gray and seven colored.
+  // Make 8 columns, one gray and seven colored.
   std::vector<std::vector<ftxui::ColorInfo>> info_columns(8);
   info_columns[0] = info_gray;
   for (size_t i = 0; i < info_color.size(); ++i) {

--- a/include/ftxui/dom/elements.hpp
+++ b/include/ftxui/dom/elements.hpp
@@ -187,7 +187,7 @@ Element vscroll_indicator(Element);
 Element hscroll_indicator(Element);
 Decorator reflect(Box& box);
 // Before drawing the |element| clear the pixel below. This is useful in
-// combinaison with dbox.
+// combination with dbox.
 Element clear_under(Element element);
 
 // --- Util --------------------------------------------------------------------

--- a/include/ftxui/dom/node.hpp
+++ b/include/ftxui/dom/node.hpp
@@ -65,7 +65,7 @@ class Node {
   virtual std::string GetSelectedContent(Selection& selection);
 
   // Layout may not resolve within a single iteration for some elements. This
-  // allows them to request additionnal iterations. This signal must be
+  // allows them to request additional iterations. This signal must be
   // forwarded to children at least once.
   struct Status {
     int iteration = 0;

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -492,7 +492,7 @@ void App::RequestAnimationFrame() {
   }
 }
 
-/// @brief Try to get the unique lock about behing able to capture the mouse.
+/// @brief Try to get the unique lock about being able to capture the mouse.
 /// @return A unique lock if the mouse is not already captured, otherwise a
 /// null.
 CapturedMouse App::CaptureMouse() {

--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -102,7 +102,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
 /// ### Output
 ///
 /// ```bash
-/// ☐ Make a sandwitch
+/// ☐ Make a sandwich
 /// ```
 // NOLINTNEXTLINE
 Component Checkbox(CheckboxOption option) {
@@ -129,7 +129,7 @@ Component Checkbox(CheckboxOption option) {
 /// ### Output
 ///
 /// ```bash
-/// ☐ Make a sandwitch
+/// ☐ Make a sandwich
 /// ```
 // NOLINTNEXTLINE
 Component Checkbox(ConstStringRef label, bool* checked, CheckboxOption option) {

--- a/src/ftxui/component/component_options.cpp
+++ b/src/ftxui/component/component_options.cpp
@@ -213,7 +213,7 @@ ButtonOption ButtonOption::Animated(Color color) {
 ButtonOption ButtonOption::Animated(Color background, Color foreground) {
   // NOLINTBEGIN
   return ButtonOption::Animated(
-      /*bakground=*/background,
+      /*background=*/background,
       /*foreground=*/foreground,
       /*background_active=*/foreground,
       /*foreground_active=*/background);

--- a/src/ftxui/component/loop.cpp
+++ b/src/ftxui/component/loop.cpp
@@ -26,7 +26,7 @@ Loop::~Loop() {
   screen_->PostMain();
 }
 
-/// @brief Whether the loop has quitted.
+/// @brief Whether the loop has quit.
 bool Loop::HasQuitted() {
   return screen_->HasQuitted();
 }
@@ -45,7 +45,7 @@ void Loop::RunOnceBlocking() {
 }
 
 /// Execute the loop, blocking the current thread, up until the loop has
-/// quitted.
+/// quit.
 void Loop::Run() {
   while (!HasQuitted()) {
     RunOnceBlocking();

--- a/src/ftxui/component/menu.cpp
+++ b/src/ftxui/component/menu.cpp
@@ -482,7 +482,7 @@ class MenuBase : public ComponentBase, public MenuOption {
 };
 
 /// @brief A list of text. The focused element is selected.
-/// @param option a structure containing all the paramters.
+/// @param option a structure containing all the parameters.
 /// @ingroup component
 ///
 /// ### Example

--- a/src/ftxui/component/resizable_split.cpp
+++ b/src/ftxui/component/resizable_split.cpp
@@ -95,7 +95,7 @@ class ResizableSplitBase : public ComponentBase, public ResizableSplitOption {
         return RenderBottom();
     }
     // NOTREACHED()
-    return text("unreacheable");
+    return text("unreachable");
   }
 
   Element RenderLeft() {

--- a/src/ftxui/component/terminal_input_parser.cpp
+++ b/src/ftxui/component/terminal_input_parser.cpp
@@ -418,7 +418,7 @@ TerminalInputParser::Output TerminalInputParser::ParseMouse(  // NOLINT
   Output output(MOUSE);
   output.mouse.motion = Mouse::Motion(pressed);  // NOLINT
 
-  // Bits value Modifer  Comment
+  // Bits value Modifier  Comment
   // ---- ----- ------- ---------
   // 0 1  1 2   button   0 = Left, 1 = Middle, 2 = Right, 3 = Release
   // 2    4     Shift

--- a/src/ftxui/component/terminal_input_parser.hpp
+++ b/src/ftxui/component/terminal_input_parser.hpp
@@ -13,7 +13,7 @@
 namespace ftxui {
 struct Event;
 
-// Parse a sequence of |char| accross |time|. Produces |Event|.
+// Parse a sequence of |char| across |time|. Produces |Event|.
 class TerminalInputParser {
  public:
   explicit TerminalInputParser(std::function<void(Event)> out);

--- a/src/ftxui/dom/size.cpp
+++ b/src/ftxui/dom/size.cpp
@@ -83,7 +83,7 @@ class Size : public Node {
 /// @brief Apply a constraint on the size of an element.
 /// @param direction Whether the WIDTH or the HEIGHT of the element must be
 ///                  constrained.
-/// @param constraint The type of constaint.
+/// @param constraint The type of constraint.
 /// @param value The value.
 /// @ingroup dom
 Decorator size(WidthOrHeight direction, Constraint constraint, int value) {

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -102,7 +102,7 @@ void Table::Initialize(std::vector<std::vector<Element>> input) {
     elements_[y].resize(dim_x_);
   }
 
-  // Transfert elements_ from |input| toward |elements_|.
+  // Transfer elements_ from |input| toward |elements_|.
   {
     int y = 1;
     for (auto& row : input) {

--- a/src/ftxui/screen/color_test.cpp
+++ b/src/ftxui/screen/color_test.cpp
@@ -41,7 +41,7 @@ TEST(ColorTest, FallbackTo16) {
   EXPECT_EQ(Color::RGB(1, 2, 3).Print(false), "30");
 }
 
-TEST(ColorTest, Litterals) {
+TEST(ColorTest, Literals) {
   Terminal::SetColorSupport(Terminal::Color::TrueColor);
   using namespace ftxui::literals;
   EXPECT_EQ(Color(0xABCDEF_rgb).Print(false), "38;2;171;205;239");


### PR DESCRIPTION
Fixes various typos in documentation, source code comments, UI strings in examples, and variable/parameter name comments. Also avoids breaking existing tests due to over-zealous typo corrections.

---
*PR created automatically by Jules for task [1915486917375052414](https://jules.google.com/task/1915486917375052414) started by @ArthurSonzogni*