### PR TITLE
fix: export Terminal quirks and fix MSVC build error

### DIFF
--- a/src/ftxui/screen.cppm
+++ b/src/ftxui/screen.cppm
@@ -60,6 +60,9 @@ export namespace ftxui {
         using ftxui::Terminal::SetFallbackSize;
         using ftxui::Terminal::ColorSupport;
         using ftxui::Terminal::SetColorSupport;
+        using ftxui::Terminal::Quirks;
+        using ftxui::Terminal::GetQuirks;
+        using ftxui::Terminal::SetQuirks;
     }
 
     /**

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -67,7 +67,7 @@ bool Contains(std::string_view s, std::string_view key) {
   if (key.empty()) {
     return true;
   }
-  const auto* it = std::search(  // NOLINT
+  const auto it = std::search(  // NOLINT
       s.begin(), s.end(), key.begin(), key.end(), [](char a, char b) {
         return std::tolower(static_cast<unsigned char>(a)) ==
                std::tolower(static_cast<unsigned char>(b));


### PR DESCRIPTION
Exports Terminal quirks in the C++20 module and fixes an MSVC iterator deduction error.