### PR TITLE
examples: fix MSVC conversion warnings (float/double)

### DIFF
--- a/examples/component/canvas_animated.cpp
+++ b/examples/component/canvas_animated.cpp
@@ -171,20 +171,24 @@ int main() {
       for (int x = 0; x < size; x++) {
         float dx = x - mx;
         float dy = y - my;
-        ys[y][x] = -1.5 + 3.0 * std::exp(-0.2f * (dx * dx + dy * dy));
+        ys[y][x] = -1.5f + 3.0f * std::exp(-0.2f * (dx * dx + dy * dy));
       }
     }
     for (int y = 0; y < size; y++) {
       for (int x = 0; x < size; x++) {
         if (x != 0) {
           c.DrawPointLine(
-              5 * (x - 1) + 3 * (y - 0), 90 - 5 * (y - 0) - 5 * ys[y][x - 1],
-              5 * (x - 0) + 3 * (y - 0), 90 - 5 * (y - 0) - 5 * ys[y][x]);
+              static_cast<int>(5 * (x - 1) + 3 * (y - 0)),
+              static_cast<int>(90 - 5 * (y - 0) - 5 * ys[y][x - 1]),
+              static_cast<int>(5 * (x - 0) + 3 * (y - 0)),
+              static_cast<int>(90 - 5 * (y - 0) - 5 * ys[y][x]));
         }
         if (y != 0) {
           c.DrawPointLine(
-              5 * (x - 0) + 3 * (y - 1), 90 - 5 * (y - 1) - 5 * ys[y - 1][x],
-              5 * (x - 0) + 3 * (y - 0), 90 - 5 * (y - 0) - 5 * ys[y][x]);
+              static_cast<int>(5 * (x - 0) + 3 * (y - 1)),
+              static_cast<int>(90 - 5 * (y - 1) - 5 * ys[y - 1][x]),
+              static_cast<int>(5 * (x - 0) + 3 * (y - 0)),
+              static_cast<int>(90 - 5 * (y - 0) - 5 * ys[y][x]));
         }
       }
     }

--- a/examples/component/linear_gradient_gallery.cpp
+++ b/examples/component/linear_gradient_gallery.cpp
@@ -16,7 +16,7 @@ int main() {
   using namespace ftxui;
   auto screen = App::Fullscreen();
 
-  int angle = 180.f;
+  int angle = 180;
   float start = 0.f;
   float end = 1.f;
 

--- a/examples/component/scrollbar.cpp
+++ b/examples/component/scrollbar.cpp
@@ -10,8 +10,8 @@ using namespace ftxui;
 Component DummyWindowContent() {
   class Impl : public ComponentBase {
    private:
-    float scroll_x = 0.1;
-    float scroll_y = 0.1;
+    float scroll_x = 0.1f;
+    float scroll_y = 0.1f;
 
    public:
     Impl() {

--- a/examples/component/slider_direction.cpp
+++ b/examples/component/slider_direction.cpp
@@ -20,7 +20,7 @@ int main() {
   auto screen = App::TerminalOutput();
   std::array<int, 30> values;
   for (size_t i = 0; i < values.size(); ++i) {
-    values[i] = 50 + 20 * std::sin(i * 0.3);
+    values[i] = static_cast<int>(50.0 + 20.0 * std::sin(i * 0.3));
   }
 
   auto layout_horizontal = Container::Horizontal({});


### PR DESCRIPTION
Fixed various implicit conversion warnings (C4244/C4305) in examples by using float literals and explicit casts.