### PR TITLE
bazel: remove deprecated compatibility_level and update rules_cc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,11 +2,10 @@
 module(
     name = "ftxui",
     version = "6.1.9",
-    compatibility_level = 6,
 )
 
 # Build dependencies.
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "platforms", version = "1.0.0")
 
 # Test dependencies.

--- a/bazel/test/MODULE.bazel
+++ b/bazel/test/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "ftxui", version = "6.1.9")
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 
 local_path_override(
     module_name = "ftxui",


### PR DESCRIPTION
Removed the deprecated compatibility_level attribute from MODULE.bazel and updated rules_cc to 0.2.17 to resolve Bazel warnings.