### PR TITLE
ci: opt-in to Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   test_bazel:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents:     write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ permissions:
   # Needed to upload release assets
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: "Create release"


### PR DESCRIPTION
Added the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable to all workflows to resolve the Node.js 20 deprecation warning in GitHub Actions.