### PR TITLE
Fix build issues: Loop include and Event tag mismatch

### DIFF
--- a/include/ftxui/component/app.hpp
+++ b/include/ftxui/component/app.hpp
@@ -20,7 +20,7 @@
 namespace ftxui {
 class ComponentBase;
 using Component = std::shared_ptr<ComponentBase>;
-class Event;
+struct Event;
 class Selection;
 class TaskRunner;
 

--- a/src/ftxui/component/app_test.cpp
+++ b/src/ftxui/component/app_test.cpp
@@ -8,14 +8,14 @@
 
 #include "ftxui/component/app.hpp"
 #include "ftxui/component/component.hpp"  // for Renderer
-#include "ftxui/dom/elements.hpp"         // for text, Element
+#include "ftxui/component/loop.hpp"
+#include "ftxui/dom/elements.hpp"  // for text, Element
 
 #if defined(__unix__)
 #include <fcntl.h>
 #include <unistd.h>
 #include <array>
 #include <cstdio>
-#include <ftxui/component/loop.hpp>
 #include <string>
 #endif
 


### PR DESCRIPTION
This PR fixes two build issues:
1. Moves the `ftxui/component/loop.hpp` include outside of the `__unix__` block in `app_test.cpp` so that it is available on other platforms (like macOS).
2. Fixes a `mismatched-tags` warning for `Event` in `app.hpp` by changing the forward declaration from `class` to `struct` to match its definition.