### PR TITLE
feat: Add a callback style reflect decorator

### DIFF
--- a/cmake/ftxui_test.cmake
+++ b/cmake/ftxui_test.cmake
@@ -39,6 +39,7 @@ add_executable(ftxui-tests
   src/ftxui/dom/hyperlink_test.cpp
   src/ftxui/dom/italic_test.cpp
   src/ftxui/dom/linear_gradient_test.cpp
+  src/ftxui/dom/reflect_test.cpp
   src/ftxui/dom/scroll_indicator_test.cpp
   src/ftxui/dom/selection_test.cpp
   src/ftxui/dom/separator_test.cpp

--- a/include/ftxui/dom/elements.hpp
+++ b/include/ftxui/dom/elements.hpp
@@ -191,6 +191,7 @@ FTXUI_EXPORT(DOM) Element focusCursorUnderlineBlinking(Element);
 FTXUI_EXPORT(DOM) Element vscroll_indicator(Element);
 FTXUI_EXPORT(DOM) Element hscroll_indicator(Element);
 FTXUI_EXPORT(DOM) Decorator reflect(Box& box);
+FTXUI_EXPORT(DOM) Decorator reflect(std::function<void(Box)> callback);
 // Before drawing the |element| clear the pixel below. This is useful in
 // combination with dbox.
 FTXUI_EXPORT(DOM) Element clear_under(Element element);

--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -78,12 +78,18 @@ class FTXUI_EXPORT(SCREEN) Screen : public Surface {
   const SelectionStyle& GetSelectionStyle() const;
   void SetSelectionStyle(SelectionStyle decorator);
 
+  using PostRenderCallback = std::function<void()>;
+  void RegisterPostRenderCallback(PostRenderCallback callback);
+  void RunPostRenderCallbacks();
+
  protected:
   Cursor cursor_;
   std::vector<std::string> hyperlinks_ = {""};
 
   // The current selection style. This is overridden by various dom elements.
   SelectionStyle selection_style_ = [](Cell& cell) { cell.inverted ^= true; };
+
+  std::vector<PostRenderCallback> post_render_callbacks_;
 };
 
 }  // namespace ftxui

--- a/src/ftxui/dom/node.cpp
+++ b/src/ftxui/dom/node.cpp
@@ -165,6 +165,9 @@ void Render(Screen& screen, Node* node, Selection& selection) {
 
   // Step 5: Apply shaders
   screen.ApplyShader();
+
+  // Step 6: Run post-render callbacks
+  screen.RunPostRenderCallbacks();
 }
 
 std::string GetNodeSelectedContent(Screen& screen,

--- a/src/ftxui/dom/reflect.cpp
+++ b/src/ftxui/dom/reflect.cpp
@@ -58,13 +58,15 @@ class ReflectCallback : public Node {
   }
 
   void SetBox(Box box) final {
-    callback_(box);
     Node::SetBox(box);
     children_[0]->SetBox(box);
   }
 
   void Render(Screen& screen) final {
-    callback_(Box::Intersection(screen.stencil, Box{}));
+    Box visible_box = Box::Intersection(screen.stencil, box_);
+    screen.RegisterPostRenderCallback([callback = callback_, visible_box]() {
+      callback(visible_box);
+    });
     Node::Render(screen);
   }
 

--- a/src/ftxui/dom/reflect.cpp
+++ b/src/ftxui/dom/reflect.cpp
@@ -1,8 +1,9 @@
 // Copyright 2020 Arthur Sonzogni. All rights reserved.
 // Use of this source code is governed by the MIT license that can be found in
 // the LICENSE file.
-#include <memory>   // for make_shared, __shared_ptr_access
-#include <utility>  // for move
+#include <functional>  // for function
+#include <memory>      // for make_shared, __shared_ptr_access
+#include <utility>     // for move
 
 #include "ftxui/dom/elements.hpp"     // for Element, unpack, Decorator, reflect
 #include "ftxui/dom/node.hpp"         // for Node, Elements
@@ -43,6 +44,37 @@ class Reflect : public Node {
 Decorator reflect(Box& box) {
   return [&](Element child) -> Element {
     return std::make_shared<Reflect>(std::move(child), box);
+  };
+}
+
+class ReflectCallback : public Node {
+ public:
+  ReflectCallback(Element child, std::function<void(Box)> callback)
+      : Node(unpack(std::move(child))), callback_(callback) {}
+
+  void ComputeRequirement() final {
+    Node::ComputeRequirement();
+    requirement_ = children_[0]->requirement();
+  }
+
+  void SetBox(Box box) final {
+    callback_(box);
+    Node::SetBox(box);
+    children_[0]->SetBox(box);
+  }
+
+  void Render(Screen& screen) final {
+    callback_(Box::Intersection(screen.stencil, Box{}));
+    Node::Render(screen);
+  }
+
+ private:
+  std::function<void(Box)> callback_;
+};
+
+Decorator reflect(std::function<void(Box)> callback) {
+  return [&](Element child) -> Element {
+    return std::make_shared<ReflectCallback>(std::move(child), callback);
   };
 }
 

--- a/src/ftxui/dom/reflect_test.cpp
+++ b/src/ftxui/dom/reflect_test.cpp
@@ -1,0 +1,66 @@
+// Copyright 2026 Arthur Sonzogni. All rights reserved.
+// Use of this source code is governed by the MIT license that can be found in
+// the LICENSE file.
+#include <functional>
+#include <vector>
+#include <string>
+
+#include "ftxui/dom/elements.hpp"
+#include "ftxui/dom/node.hpp"
+#include "ftxui/screen/screen.hpp"
+#include "gtest/gtest.h"
+
+// NOLINTBEGIN
+namespace ftxui {
+
+TEST(ReflectTest, CallbackBasic) {
+  Box reflected_box;
+  int callback_count = 0;
+
+  auto element = text("hello") | reflect([&](Box box) {
+    reflected_box = box;
+    callback_count++;
+  }) | size(WIDTH, EQUAL, 5) | size(HEIGHT, EQUAL, 1);
+
+  Screen screen(10, 5);
+  Render(screen, element);
+
+  EXPECT_EQ(callback_count, 1);
+  EXPECT_EQ(reflected_box.x_min, 0);
+  EXPECT_EQ(reflected_box.y_min, 0);
+  EXPECT_EQ(reflected_box.x_max, 6); // size(WIDTH, EQUAL, 5) results in box.x_max = 6
+  EXPECT_EQ(reflected_box.y_max, 2); // size(HEIGHT, EQUAL, 1) results in box.y_max = 2
+}
+
+TEST(ReflectTest, CallbackDeferred) {
+  bool callback_executed = false;
+  std::vector<std::string> order;
+
+  class CustomElement : public Node {
+   public:
+    CustomElement(std::vector<std::string>& order) : order_(order) {}
+    void Render(Screen& screen) final {
+      order_.push_back("render");
+      Node::Render(screen);
+    }
+   private:
+    std::vector<std::string>& order_;
+  };
+
+  Element child = std::make_shared<CustomElement>(order);
+  auto element = child | reflect([&](Box box) {
+    order.push_back("callback");
+    callback_executed = true;
+  });
+
+  Screen screen(5, 5);
+  Render(screen, element);
+
+  EXPECT_TRUE(callback_executed);
+  ASSERT_EQ(order.size(), 2);
+  EXPECT_EQ(order[0], "render");
+  EXPECT_EQ(order[1], "callback");
+}
+
+}  // namespace ftxui
+// NOLINTEND

--- a/src/ftxui/screen/screen.cpp
+++ b/src/ftxui/screen/screen.cpp
@@ -533,6 +533,7 @@ void Screen::Clear() {
   hyperlinks_ = {
       "",
   };
+  post_render_callbacks_.clear();
 }
 
 // clang-format off
@@ -593,6 +594,18 @@ const Screen::SelectionStyle& Screen::GetSelectionStyle() const {
 /// @see GetSelectionStyle
 void Screen::SetSelectionStyle(SelectionStyle decorator) {
   selection_style_ = std::move(decorator);
+}
+
+void Screen::RegisterPostRenderCallback(PostRenderCallback callback) {
+  post_render_callbacks_.push_back(std::move(callback));
+}
+
+void Screen::RunPostRenderCallbacks() {
+  std::vector<PostRenderCallback> callbacks;
+  std::swap(callbacks, post_render_callbacks_);
+  for (const auto& callback : callbacks) {
+    callback();
+  }
 }
 
 }  // namespace ftxui


### PR DESCRIPTION
This pull request adds a callback-style reflect decorator to FTXUI.

The reflect decorator force user to update the layout at next epoch,
this may cause problem if the user want to update the layout immediately.
This change adds a callback style reflect decorator, which will call the
callback immediately with the layout information. But here comes a risk
that it may or may not cause infinite update and render loop.

A better solution is to defer the callback after the render process, I
am not sure how to achieve it yet, leave it for future discussion.