### PR TITLE
Refactor: Use std::string_view where applicable

### DIFF
--- a/src/ftxui/component/input.cpp
+++ b/src/ftxui/component/input.cpp
@@ -27,20 +27,20 @@ namespace ftxui {
 
 namespace {
 
-std::vector<std::string> SplitLines(const std::string& input) {
+std::vector<std::string> SplitLines(std::string_view input) {
   std::vector<std::string> output;
-  std::stringstream ss(input);
-  std::string line;
-  while (std::getline(ss, line)) {
-    output.push_back(line);
+  size_t start = 0;
+  size_t end = input.find('\n');
+  while (end != std::string_view::npos) {
+    output.push_back(std::string(input.substr(start, end - start)));
+    start = end + 1;
+    end = input.find('\n', start);
   }
-  if (input.back() == '\n') {
-    output.emplace_back("");
-  }
+  output.push_back(std::string(input.substr(start)));
   return output;
 }
 
-size_t GlyphWidth(const std::string& input, size_t iter) {
+size_t GlyphWidth(std::string_view input, size_t iter) {
   uint32_t ucs = 0;
   if (!EatCodePoint(input, iter, &iter, &ucs)) {
     return 0;
@@ -79,7 +79,7 @@ bool IsWordCodePoint(uint32_t codepoint) {
   return false;  // NOT_REACHED();
 }
 
-bool IsWordCharacter(const std::string& input, size_t iter) {
+bool IsWordCharacter(std::string_view input, size_t iter) {
   uint32_t ucs = 0;
   if (!EatCodePoint(input, iter, &iter, &ucs)) {
     return false;

--- a/src/ftxui/dom/paragraph.cpp
+++ b/src/ftxui/dom/paragraph.cpp
@@ -13,24 +13,30 @@
 namespace ftxui {
 
 namespace {
-Elements Split(const std::string& the_text) {
+Elements Split(std::string_view the_text) {
   Elements output;
-  std::stringstream ss(the_text);
-  std::string word;
-  while (std::getline(ss, word, ' ')) {
-    output.push_back(text(word));
+  size_t start = 0;
+  size_t end = the_text.find(' ');
+  while (end != std::string_view::npos) {
+    output.push_back(text(the_text.substr(start, end - start)));
+    start = end + 1;
+    end = the_text.find(' ', start);
   }
+  output.push_back(text(the_text.substr(start)));
   return output;
 }
 
-Element Split(const std::string& paragraph,
-              const std::function<Element(std::string)>& f) {
+Element Split(std::string_view paragraph,
+              const std::function<Element(std::string_view)>& f) {
   Elements output;
-  std::stringstream ss(paragraph);
-  std::string line;
-  while (std::getline(ss, line, '\n')) {
-    output.push_back(f(line));
+  size_t start = 0;
+  size_t end = paragraph.find('\n');
+  while (end != std::string_view::npos) {
+    output.push_back(f(paragraph.substr(start, end - start)));
+    start = end + 1;
+    end = paragraph.find('\n', start);
   }
+  output.push_back(f(paragraph.substr(start)));
   return vbox(std::move(output));
 }
 
@@ -48,7 +54,7 @@ Element paragraph(std::string_view the_text) {
 /// @ingroup dom
 /// @see flexbox.
 Element paragraphAlignLeft(std::string_view the_text) {
-  return Split(std::string(the_text), [](const std::string& line) {
+  return Split(the_text, [](std::string_view line) {
     static const auto config = FlexboxConfig().SetGap(1, 0);
     return flexbox(Split(line), config);
   });
@@ -59,7 +65,7 @@ Element paragraphAlignLeft(std::string_view the_text) {
 /// @ingroup dom
 /// @see flexbox.
 Element paragraphAlignRight(std::string_view the_text) {
-  return Split(std::string(the_text), [](const std::string& line) {
+  return Split(the_text, [](std::string_view line) {
     static const auto config = FlexboxConfig().SetGap(1, 0).Set(
         FlexboxConfig::JustifyContent::FlexEnd);
     return flexbox(Split(line), config);
@@ -71,7 +77,7 @@ Element paragraphAlignRight(std::string_view the_text) {
 /// @ingroup dom
 /// @see flexbox.
 Element paragraphAlignCenter(std::string_view the_text) {
-  return Split(std::string(the_text), [](const std::string& line) {
+  return Split(the_text, [](std::string_view line) {
     static const auto config =
         FlexboxConfig().SetGap(1, 0).Set(FlexboxConfig::JustifyContent::Center);
     return flexbox(Split(line), config);
@@ -84,7 +90,7 @@ Element paragraphAlignCenter(std::string_view the_text) {
 /// @ingroup dom
 /// @see flexbox.
 Element paragraphAlignJustify(std::string_view the_text) {
-  return Split(std::string(the_text), [](const std::string& line) {
+  return Split(the_text, [](std::string_view line) {
     static const auto config = FlexboxConfig().SetGap(1, 0).Set(
         FlexboxConfig::JustifyContent::SpaceBetween);
     Elements words = Split(line);

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -25,8 +25,7 @@ using ftxui::Screen;
 
 class Text : public Node {
  public:
-  explicit Text(const std::string& text) : glyphs_(Utf8ToGlyphs(text)) {}
-  explicit Text(std::string_view sv) : Text(std::string(sv)) {}
+  explicit Text(std::string_view text) : glyphs_(Utf8ToGlyphs(text)) {}
 
   void ComputeRequirement() override {
     int max_width = 0;
@@ -135,7 +134,7 @@ class Text : public Node {
 
 class VText : public Node {
  public:
-  explicit VText(const std::string& text) : glyphs_(Utf8ToGlyphs(text)) {
+  explicit VText(std::string_view text) : glyphs_(Utf8ToGlyphs(text)) {
     for (const auto& g : glyphs_) {
       if (g != "\n") {
         width_ = 1;
@@ -143,7 +142,6 @@ class VText : public Node {
       }
     }
   }
-  explicit VText(std::string_view sv) : VText(std::string(sv)) {}
 
   void ComputeRequirement() override {
     int max_height = 0;
@@ -260,7 +258,7 @@ Element text(std::wstring_view text) {
 /// !
 /// ```
 Element vtext(std::string_view text) {
-  return std::make_shared<VText>(std::string(text));
+  return std::make_shared<VText>(text);
 }
 
 /// @brief Display a piece unicode text vertically.


### PR DESCRIPTION
Refactor internal functions and some DOM/Component constructors to use `std::string_view` instead of `const std::string&`. This avoids unnecessary allocations when passing string literals.