### PR TITLE
component: Add CatchSignals option to App

### DIFF
--- a/include/ftxui/component/app.hpp
+++ b/include/ftxui/component/app.hpp
@@ -90,6 +90,13 @@ class FTXUI_EXPORT(COMPONENT) App : public Screen {
   /// @note This feature is only available on POSIX systems (Linux/macOS).
   void HandlePipedInput(bool enable = true);
 
+  /// @brief Enable or disable installing signal handlers for SIGTERM, SIGSEGV,
+  /// SIGINT, SIGILL, SIGABRT, and SIGFPE to restore terminal state on exit.
+  /// @param enable Whether to enable signal handlers. Default is true.
+  /// @note This must be called before Loop().
+  /// @note Signal handlers are enabled by default.
+  void CatchSignals(bool enable = true);
+
   /// @brief Return the currently active app, nullptr if none.
   static App* Active();
 

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -99,6 +99,7 @@ struct App::Internal {
   const bool use_alternative_screen_;
 
   bool track_mouse_ = true;
+  bool catch_signals_ = true;
 
   std::string set_cursor_position_;
   std::string reset_cursor_position_;
@@ -464,8 +465,11 @@ void App::Internal::Install() {
 
   // Install signal handlers to restore the terminal state on exit. The default
   // signal handlers are restored on exit.
-  for (const int signal : {SIGTERM, SIGSEGV, SIGINT, SIGILL, SIGABRT, SIGFPE}) {
-    InstallSignalHandler(signal);
+  if (catch_signals_) {
+    for (const int signal :
+         {SIGTERM, SIGSEGV, SIGINT, SIGILL, SIGABRT, SIGFPE}) {
+      InstallSignalHandler(signal);
+    }
   }
 
 // Save the old terminal configuration and restore it on exit.
@@ -915,8 +919,8 @@ void App::Internal::Draw(Component component) {
   if (resized) {
     public_->dimx_ = dimx;
     public_->dimy_ = dimy;
-    public_->cells_ =
-        std::vector<Cell>(static_cast<size_t>(dimx) * static_cast<size_t>(dimy));
+    public_->cells_ = std::vector<Cell>(static_cast<size_t>(dimx) *
+                                        static_cast<size_t>(dimy));
     Cursor cursor = public_->cursor_;
     cursor.x = dimx - 1;
     cursor.y = dimy - 1;
@@ -1360,6 +1364,10 @@ void App::TrackMouse(bool enable) {
 
 void App::HandlePipedInput(bool enable) {
   internal_->handle_piped_input_ = enable;
+}
+
+void App::CatchSignals(bool enable) {
+  internal_->catch_signals_ = enable;
 }
 
 // static

--- a/src/ftxui/component/app_test.cpp
+++ b/src/ftxui/component/app_test.cpp
@@ -266,4 +266,30 @@ TEST(App, MoveAssignment) {
   EXPECT_EQ(called, 1);
 }
 
+TEST(App, CatchSignals_False) {
+  static bool test_handler_called = false;
+  test_handler_called = false;
+
+  auto old_handler = std::signal(SIGTERM, [](int /*sig*/) {
+    test_handler_called = true;
+    if (App::Active()) {
+      App::Active()->Exit();
+    }
+  });
+
+  auto screen = App::FitComponent();
+  screen.CatchSignals(false);
+
+  auto component = Renderer([&] {
+    std::ignore = std::raise(SIGTERM);
+    return text("");
+  });
+
+  screen.Loop(component);
+
+  std::ignore = std::signal(SIGTERM, old_handler);
+
+  EXPECT_TRUE(test_handler_called);
+}
+
 }  // namespace ftxui


### PR DESCRIPTION
### Description
This pull request introduces the `CatchSignals` option to the `App` class. 

By default, FTXUI installs signal handlers for standard terminate and crash signals (`SIGTERM`, `SIGSEGV`, `SIGINT`, `SIGILL`, `SIGABRT`, and `SIGFPE`) to safely clean up and restore the terminal state before exit.

However, in many host applications (such as those with dedicated crash-reporting, stack-tracing, or customized signal handling), having FTXUI intercept these signals can conflict with standard error handling. 

With this change, users can call `app.CatchSignals(false);` before the main loop to completely skip the installation of these standard signals, leaving them to be handled by the parent process.

### Changes Included
- **`include/ftxui/component/app.hpp`**: Added `void CatchSignals(bool enable = true);` option setter to the `App` interface.
- **`src/ftxui/component/app.cpp`**: Added `bool catch_signals_ = true;` flag to `App::Internal` and conditionalized standard signal installation.
- **`src/ftxui/component/app_test.cpp`**: Added `App.CatchSignals_False` unit test verifying custom signal handlers are preserved and invoked when `CatchSignals(false)` is set.

### Verification Results
- All unit tests compiled and executed successfully.
- Ran `./build/ftxui-tests --gtest_filter="App.*"` (all 15 App-related tests passed).
- Executed the full test suite via `ctest` with a 100% pass rate (331/331 tests passed).
