### PR TITLE
Update the URL of the example project 'typing-speed-test' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Feel free to add your projects here:
 - [tiles](https://github.com/tusharpm/tiles)
 - [todoman](https://github.com/aaleino/todoman)
 - [turing_cmd](https://github.com/DanArmor/turing_cmd)
-- [typing-speed-test](https://github.com/ymcx/typing-speed-test)
+- [typing-speed-test](https://codeberg.org/ymcx/typing-speed-test)
 - [vantage](https://github.com/gokulmaxi/vantage)
 - [x86-64 CPU Architecture Simulation](https://github.com/AnisBdz/CPU)
 - [C++ Process Manager](https://github.com/ondrejhonus/cpp_proc)


### PR DESCRIPTION
Related: https://github.com/ArthurSonzogni/FTXUI/pull/1126

I've moved all of my personal repositories over to Codeberg with the exception of my pull requests, which still need to reside on this GitHub account. After having moved 'typing-speed-test' from GitHub to Codeberg, the link in README.md points to an inexistent repository. This PR simply points it to the new location.