### PR TITLE
fix: prevent stale installed FTXUI headers from shadowing build sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 Next
 ====
 
+### Build
+- Bugfix: Fix build failure when an older FTXUI is installed in a system
+  include path (e.g. MacPorts upgrade). A CMake deduplication quirk was
+  promoting the project's own `-I include/` to `-isystem`, causing package
+  managers' `-I/opt/local/include` (which may contain stale headers) to
+  win. See #1299, #1300.
+
 7.0.0 (2026-06-13)
 ------------------
 

--- a/cmake/ftxui_set_options.cmake
+++ b/cmake/ftxui_set_options.cmake
@@ -27,19 +27,34 @@ function(ftxui_set_options library)
       PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-warnings-as-errors=*"
     )
 
-    # By using "PUBLIC" as opposed to "SYSTEM INTERFACE", the compiler warning
-    # are enforced on the headers. This is behind "FTXUI_CLANG_TIDY", so that it
-    # applies only when developing FTXUI and on the CI. User's of the library
-    # get only the SYSTEM INTERFACE instead.
+    # By using "PUBLIC" as opposed to "INTERFACE", the compiler warnings are
+    # enforced on the headers. This is behind "FTXUI_CLANG_TIDY", so that it
+    # applies only when developing FTXUI and on the CI. Users of the library
+    # get only the plain INTERFACE instead.
     target_include_directories(${library}
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
   else()
-    target_include_directories(${library} SYSTEM
-      INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    )
+    if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+      # Building FTXUI as a standalone project.  Do NOT mark as SYSTEM: if
+      # a sibling FTXUI target (e.g. dom depending on screen) inherits this
+      # path via INTERFACE_SYSTEM_INCLUDE_DIRECTORIES, CMake demotes the
+      # private -I to -isystem.  That path is then searched *after* any -I
+      # added by a package manager (e.g. MacPorts' -I/opt/local/include),
+      # letting a stale installed FTXUI shadow the sources being built.
+      target_include_directories(${library}
+        INTERFACE
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      )
+    else()
+      # Consumed via add_subdirectory / FetchContent: keep SYSTEM so that
+      # consumers do not receive warnings from FTXUI headers.
+      target_include_directories(${library} SYSTEM
+        INTERFACE
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      )
+    endif()
   endif()
 
   target_include_directories(${library} SYSTEM

--- a/include/ftxui/screen/screen.hpp
+++ b/include/ftxui/screen/screen.hpp
@@ -34,6 +34,10 @@ class FTXUI_EXPORT(SCREEN) Screen : public Surface {
   // Destructor:
   ~Screen() override = default;
 
+  // Copy:
+  Screen(const Screen&) = default;
+  Screen& operator=(const Screen&) = default;
+
   std::string ToString() const;
   void ToString(std::string& ss) const;
 

--- a/include/ftxui/screen/surface.hpp
+++ b/include/ftxui/screen/surface.hpp
@@ -27,6 +27,10 @@ class FTXUI_EXPORT(SCREEN) Surface {
   // Destructor:
   virtual ~Surface() = default;
 
+  // Copy:
+  Surface(const Surface&) = default;
+  Surface& operator=(const Surface&) = default;
+
   // Access a character in the grid at a given position.
   std::string& at(int x, int y);
   const std::string& at(int x, int y) const;


### PR DESCRIPTION
Fixes #1299

## Problem

When building FTXUI from source (e.g. a MacPorts package upgrade), an older installed version of FTXUI can shadow the headers being built, producing errors like:

```
error: no member named 'CellAt' in 'ftxui::Screen'
error: no viable conversion from '(lambda)(Cell&)' to 'SelectionStyle' (aka 'std::function<void (Pixel &)>')
```

### Root cause — CMake include-directory deduplication

`ftxui_set_options()` exported `include/` as `SYSTEM INTERFACE` for `BUILD_INTERFACE`. This created a propagation chain:

1. `screen` adds `include/` to its `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES`.
2. `dom` and `component` link against `screen` (`PUBLIC`), so they inherit `include/` in their own `SYSTEM_INCLUDE_DIRECTORIES`.
3. CMake deduplicates: a path present in both `INCLUDE_DIRECTORIES` (from the `PRIVATE` rule) and `SYSTEM_INCLUDE_DIRECTORIES` (from propagation) is emitted **once, as `-isystem`**.
4. Clang/GCC search **all `-I` paths before any `-isystem` path**, regardless of command-line order.
5. Package managers such as MacPorts inject `-I/opt/local/include` via `CMAKE_CXX_FLAGS`. With an older FTXUI installed there, its headers are found first.

## Fix

When FTXUI is the **top-level CMake project** (`CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME`), the `BUILD_INTERFACE` include is exported as a plain `INTERFACE` (dropping `SYSTEM`). This breaks the propagation chain so every FTXUI target keeps its own `include/` as a regular `-I` path, which is searched before any system path injected by the build environment.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Building FTXUI itself (source/package build) | `-isystem` — stale headers can win | `-I` — project headers always win ✓ |
| `add_subdirectory` / `FetchContent` consumer | `-isystem` — no warnings | `-isystem` — no warnings ✓ |
| `find_package` consumer (installed FTXUI) | `-isystem` — no warnings | `-isystem` — no warnings ✓ |

The goal of suppressing warnings in consumer code is fully preserved.