### PR TITLE
fix: ship Debug and Release libs in Windows package (#1298)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,8 @@ jobs:
       - name: "Install cmake"
         uses: lukka/get-cmake@latest
 
-      - name: "Build packages"
+      - name: "Build packages (Linux / macOS)"
+        if: runner.os != 'Windows'
         run: >
           mkdir build;
           cd build;
@@ -73,6 +74,17 @@ jobs:
           -DFTXUI_ENABLE_INSTALL=ON
           -DFTXUI_DEV_WARNINGS=ON ;
           cmake --build . --target package;
+
+      - name: "Build packages (Windows — Debug + Release)"
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_PARALLEL_LEVEL=${{ steps.cpu-cores.outputs.count }} -DFTXUI_BUILD_DOCS=OFF -DFTXUI_BUILD_EXAMPLES=OFF -DFTXUI_BUILD_TESTS=OFF -DFTXUI_BUILD_TESTS_FUZZER=OFF -DFTXUI_ENABLE_INSTALL=ON -DFTXUI_DEV_WARNINGS=ON
+          cmake --build . --config Debug
+          cmake --build . --config Release
+          cpack -C "Debug;Release"
 
       - uses: shogo82148/actions-upload-release-asset@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,14 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_PARALLEL_LEVEL=${{ steps.cpu-cores.outputs.count }} -DFTXUI_BUILD_DOCS=OFF -DFTXUI_BUILD_EXAMPLES=OFF -DFTXUI_BUILD_TESTS=OFF -DFTXUI_BUILD_TESTS_FUZZER=OFF -DFTXUI_ENABLE_INSTALL=ON -DFTXUI_DEV_WARNINGS=ON
+          cmake .. `
+            -DCMAKE_BUILD_PARALLEL_LEVEL=${{ steps.cpu-cores.outputs.count }} `
+            -DFTXUI_BUILD_DOCS=OFF `
+            -DFTXUI_BUILD_EXAMPLES=OFF `
+            -DFTXUI_BUILD_TESTS=OFF `
+            -DFTXUI_BUILD_TESTS_FUZZER=OFF `
+            -DFTXUI_ENABLE_INSTALL=ON `
+            -DFTXUI_DEV_WARNINGS=OFF
           cmake --build . --config Debug
           cmake --build . --config Release
           cpack -C "Debug;Release"

--- a/cmake/ftxui_install.cmake
+++ b/cmake/ftxui_install.cmake
@@ -6,15 +6,42 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # ------------------------------------------------------------------------------
-# Install the library and its public headers into the standard subdirectories
+# Install the library and its public headers into the standard subdirectories.
+# On multi-config generators (e.g. Visual Studio) both Debug and Release are
+# installed into separate lib/<config>/ subdirectories so they can coexist in
+# the same package without overwriting each other.  Single-config generators
+# (Ninja, Make) keep the traditional flat lib/ layout.
+# Generator expressions in DESTINATION require CMake 3.20.
 # ------------------------------------------------------------------------------
-install(
-  TARGETS screen dom component ftxui
-  EXPORT ftxui-targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+get_property(_ftxui_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_ftxui_isMultiConfig)
+  if(CMAKE_VERSION VERSION_LESS "3.20")
+    message(WARNING
+      "FTXUI: CMake >= 3.20 is required to install Debug and Release "
+      "libraries into separate subdirectories on multi-config generators. "
+      "Falling back to a flat lib/ layout (the two configurations will "
+      "overwrite each other). Please upgrade CMake.")
+    set(_ftxui_isMultiConfig FALSE)
+  endif()
+endif()
+
+if(_ftxui_isMultiConfig)
+  install(
+    TARGETS screen dom component ftxui
+    EXPORT ftxui-targets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}/$<CONFIG>"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/$<CONFIG>"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/$<CONFIG>"
   )
+else()
+  install(
+    TARGETS screen dom component ftxui
+    EXPORT ftxui-targets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+endif()
 
 install(
   DIRECTORY include/ftxui


### PR DESCRIPTION
Closes #1298.

On multi-config generators (Visual Studio), `cmake --install` now places
libraries under `lib/Debug/` and `lib/Release/` instead of a shared `lib/`
directory, so both runtimes (`/MDd` and `/MD`) can coexist in the same
package.

The CI release workflow gains a dedicated Windows step that builds both
configurations and passes `-C "Debug;Release"` to CPack.

A graceful fallback with a `WARNING` is emitted when CMake < 3.20 is
detected (generator expressions in `DESTINATION` require 3.20).