### PR TITLE
Fix static initialization order crash on Color::RGB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Next
 - Bugfix: Apple's Terminal.app (`TERM_PROGRAM=Apple_Terminal`) is now reported as `Palette256` instead of `TrueColor`; it does not support 24bit colors.
 - Bugfix: An empty terminal name or terminal emulator name is now treated as unidentified by `Terminal::ComputeColorSupport`, instead of implying TrueColor support.
 - Bugfix (Windows): Downgrade color support when the console rejects VT processing (legacy consoles), instead of emitting TrueColor escape sequences.
+- Bugfix: Avoid segmentation fault / crash during static initialization if `Color::RGB` or other color constants are constructed globally/statically before `main()`. See #1303.
+
 
 ### Build
 - Bugfix: Fix build failure when an older FTXUI is installed in a system

--- a/src/ftxui/screen/color_test.cpp
+++ b/src/ftxui/screen/color_test.cpp
@@ -10,6 +10,12 @@
 
 namespace ftxui {
 
+// Regression test to ensure Color can be constructed statically before main()
+// without causing a static initialization order crash.
+const Color g_test_static_color = Color::RGB(10, 20, 30);
+
+
+
 #if !defined(_WIN32)
 namespace {
 // Clear an environment variable for the duration of a scope, restoring its

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -30,16 +30,23 @@ namespace ftxui {
 
 namespace {
 
-bool g_color_support_detected = false;  // NOLINT
-Terminal::Quirks g_quirks = [] {        // NOLINT
-  Terminal::Quirks quirks;
+bool& ColorSupportDetected() {
+  static bool detected = false;
+  return detected;
+}
+
+Terminal::Quirks& GetQuirksInternal() {
+  static Terminal::Quirks quirks = [] {
+    Terminal::Quirks q;
 #if defined(_WIN32)
-  quirks.SetBlockCharacters(false);
-  quirks.SetCursorHiding(false);
-  quirks.SetComponentAscii(true);
+    q.SetBlockCharacters(false);
+    q.SetCursorHiding(false);
+    q.SetComponentAscii(true);
 #endif
+    return q;
+  }();
   return quirks;
-}();
+}
 
 Dimensions& FallbackSize() {
 #if defined(__EMSCRIPTEN__)
@@ -338,35 +345,35 @@ void SetFallbackSize(const Dimensions& fallbackSize) {
 /// @brief Get the color support of the terminal.
 /// @ingroup screen
 Color ColorSupport() {
-  if (!g_color_support_detected) {
-    g_quirks.SetColorSupport(ComputeColorSupportInternal());
-    g_color_support_detected = true;
+  if (!ColorSupportDetected()) {
+    GetQuirksInternal().SetColorSupport(ComputeColorSupportInternal());
+    ColorSupportDetected() = true;
   }
-  return g_quirks.ColorSupport();
+  return GetQuirksInternal().ColorSupport();
 }
 
 /// @brief Override terminal color support in case auto-detection fails
 /// @ingroup dom
 void SetColorSupport(Color color) {
-  g_quirks.SetColorSupport(color);
-  g_color_support_detected = true;
+  GetQuirksInternal().SetColorSupport(color);
+  ColorSupportDetected() = true;
 }
 
 /// @brief Get the terminal quirks.
 /// @ingroup screen
 Quirks GetQuirks() {
-  if (!g_color_support_detected) {
-    g_quirks.SetColorSupport(ComputeColorSupportInternal());
-    g_color_support_detected = true;
+  if (!ColorSupportDetected()) {
+    GetQuirksInternal().SetColorSupport(ComputeColorSupportInternal());
+    ColorSupportDetected() = true;
   }
-  return g_quirks;
+  return GetQuirksInternal();
 }
 
 /// @brief Override terminal quirks.
 /// @ingroup screen
 void SetQuirks(const Quirks& quirks) {
-  g_quirks = quirks;
-  g_color_support_detected = true;
+  GetQuirksInternal() = quirks;
+  ColorSupportDetected() = true;
 }
 
 }  // namespace Terminal

--- a/src/ftxui/screen/terminal.cpp
+++ b/src/ftxui/screen/terminal.cpp
@@ -30,22 +30,23 @@ namespace ftxui {
 
 namespace {
 
+std::unique_ptr<Terminal::Quirks> g_quirks;
+bool g_color_support_detected = false;
+
 bool& ColorSupportDetected() {
-  static bool detected = false;
-  return detected;
+  return g_color_support_detected;
 }
 
 Terminal::Quirks& GetQuirksInternal() {
-  static Terminal::Quirks quirks = [] {
-    Terminal::Quirks q;
+  if (!g_quirks) {
+    g_quirks = std::make_unique<Terminal::Quirks>();
 #if defined(_WIN32)
-    q.SetBlockCharacters(false);
-    q.SetCursorHiding(false);
-    q.SetComponentAscii(true);
+    g_quirks->SetBlockCharacters(false);
+    g_quirks->SetCursorHiding(false);
+    g_quirks->SetComponentAscii(true);
 #endif
-    return q;
-  }();
-  return quirks;
+  }
+  return *g_quirks;
 }
 
 Dimensions& FallbackSize() {


### PR DESCRIPTION
Fixes #1303 by wrapping quirks and color support status in constant-initialized global std::unique_ptr to avoid thread-safe local static checks and ensure initialization safety before main().