### PR TITLE
Improve performance of text element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Next
 ====
 
+### Dom
+- Performance: `text` computes its requirement once and renders only the
+  visible lines. This makes scrolling a large text inside a `frame`
+  significantly faster. Thanks @patlefort. See #1309.
+
 7.0.1 (2026-07-14)
 ------------------
 

--- a/src/ftxui/dom/selection_test.cpp
+++ b/src/ftxui/dom/selection_test.cpp
@@ -152,6 +152,27 @@ TEST(SelectionTest, StyleSelection) {
   }
 }
 
+// The selection style must not persist on an element rendered again after the
+// selection was cleared. See #1309.
+TEST(SelectionTest, StyleClearedWhenSelectionCleared) {
+  auto element = text("Lorem ipsum dolor");
+
+  {
+    auto screen = App::FixedSize(20, 1);
+    Selection selection(2, 0, 9, 0);
+    Render(screen, element.get(), selection);
+    EXPECT_EQ(screen.CellAt(2, 0).inverted, true);
+  }
+
+  {
+    auto screen = App::FixedSize(20, 1);
+    Render(screen, element);
+    for (int i = 0; i < 20; i++) {
+      EXPECT_EQ(screen.CellAt(i, 0).inverted, false);
+    }
+  }
+}
+
 TEST(SelectionTest, VBoxSelection) {
   auto element = vbox({
       text("Lorem ipsum dolor"),

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -49,10 +49,9 @@ class Text : public Node {
   }
 
   void ComputeRequirement() override {
-    // The requirement is computed once in the constructor. Only the selection
-    // state must be reset before every frame, because Select() is invoked
-    // only while a selection is active.
-    has_selection_ = false;
+    // The requirement was computed once in the constructor. This hook still
+    // runs before every frame; use it to clear the selection, which Select()
+    // re-populates while a selection is active.
     selection_rows_.clear();
   }
 
@@ -61,7 +60,6 @@ class Text : public Node {
       return;
     }
 
-    has_selection_ = true;
     selection_rows_.assign(lines_offsets_.size() - 1, {-1, -1});
 
     for (size_t i = 0; i < lines_offsets_.size() - 1; ++i) {
@@ -118,7 +116,7 @@ class Text : public Node {
         auto& cell = screen.CellAt(x, y);
         cell.character = *glyph;
 
-        if (has_selection_ && line < selection_rows_.size()) {
+        if (line < selection_rows_.size()) {
           const auto& [sel_start, sel_end] = selection_rows_[line];
           if (sel_start != -1 && x >= sel_start && x <= sel_end) {
             screen.GetSelectionStyle()(cell);
@@ -131,7 +129,6 @@ class Text : public Node {
  private:
   std::vector<std::string> glyphs_;
   std::vector<int> lines_offsets_;
-  bool has_selection_ = false;
   std::vector<std::pair<int, int>> selection_rows_;
 };
 

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -25,8 +25,7 @@ using ftxui::Screen;
 
 class Text : public Node {
  public:
-  explicit Text(std::string_view text) : glyphs_(Utf8ToGlyphs(text))
-  {
+  explicit Text(std::string_view text) : glyphs_(Utf8ToGlyphs(text)) {
     int max_width = 0;
     int current_width = 0;
     int lines_count = 1;
@@ -47,6 +46,14 @@ class Text : public Node {
 
     requirement_.min_x = max_width;
     requirement_.min_y = lines_count;
+  }
+
+  void ComputeRequirement() override {
+    // The requirement is computed once in the constructor. Only the selection
+    // state must be reset before every frame, because Select() is invoked
+    // only while a selection is active.
+    has_selection_ = false;
+    selection_rows_.clear();
   }
 
   void Select(Selection& selection) override {
@@ -89,23 +96,26 @@ class Text : public Node {
 
   void Render(Screen& screen) override {
     const auto visible_box = Box::Intersection(screen.stencil, box_);
-    if(visible_box.IsEmpty())
-			return;
+    if (visible_box.IsEmpty()) {
+      return;
+    }
 
     int y = visible_box.y_min;
 
     const size_t first_line = visible_box.y_min - box_.y_min;
-    const size_t last_line = std::min<size_t>(visible_box.y_max - box_.y_min + 1, lines_offsets_.size() - 1);
+    const size_t last_line = std::min<size_t>(
+        visible_box.y_max - box_.y_min + 1, lines_offsets_.size() - 1);
 
     for (size_t line = first_line; line < last_line; ++line, ++y) {
       int x = box_.x_min;
 
-      for (auto glyph = glyphs_.begin() + lines_offsets_[line]; glyph != glyphs_.end() && *glyph != "\n"; ++glyph, ++x) {
+      for (auto glyph = glyphs_.begin() + lines_offsets_[line];
+           glyph != glyphs_.end() && *glyph != "\n"; ++glyph, ++x) {
         if (x > box_.x_max) {
           break;
         }
 
-        auto &cell = screen.CellAt(x, y);
+        auto& cell = screen.CellAt(x, y);
         cell.character = *glyph;
 
         if (has_selection_ && line < selection_rows_.size()) {

--- a/src/ftxui/dom/text.cpp
+++ b/src/ftxui/dom/text.cpp
@@ -25,15 +25,11 @@ using ftxui::Screen;
 
 class Text : public Node {
  public:
-  explicit Text(std::string_view text) : glyphs_(Utf8ToGlyphs(text)) {}
-
-  void ComputeRequirement() override {
+  explicit Text(std::string_view text) : glyphs_(Utf8ToGlyphs(text))
+  {
     int max_width = 0;
     int current_width = 0;
     int lines_count = 1;
-    has_selection_ = false;
-    selection_rows_.clear();
-    lines_offsets_.clear();
     lines_offsets_.push_back(0);
 
     for (size_t i = 0; i < glyphs_.size(); ++i) {
@@ -92,36 +88,33 @@ class Text : public Node {
   }
 
   void Render(Screen& screen) override {
-    int x = box_.x_min;
-    int y = box_.y_min;
-    size_t line = 0;
+    const auto visible_box = Box::Intersection(screen.stencil, box_);
+    if(visible_box.IsEmpty())
+			return;
 
-    if (y > box_.y_max) {
-      return;
-    }
+    int y = visible_box.y_min;
 
-    for (const auto& cell : glyphs_) {
-      if (cell == "\n") {
-        y++;
-        x = box_.x_min;
-        line++;
-        if (y > box_.y_max) {
-          return;
+    const size_t first_line = visible_box.y_min - box_.y_min;
+    const size_t last_line = std::min<size_t>(visible_box.y_max - box_.y_min + 1, lines_offsets_.size() - 1);
+
+    for (size_t line = first_line; line < last_line; ++line, ++y) {
+      int x = box_.x_min;
+
+      for (auto glyph = glyphs_.begin() + lines_offsets_[line]; glyph != glyphs_.end() && *glyph != "\n"; ++glyph, ++x) {
+        if (x > box_.x_max) {
+          break;
         }
-        continue;
-      }
 
-      if (x <= box_.x_max) {
-        screen.CellAt(x, y).character = cell;
+        auto &cell = screen.CellAt(x, y);
+        cell.character = *glyph;
 
         if (has_selection_ && line < selection_rows_.size()) {
           const auto& [sel_start, sel_end] = selection_rows_[line];
           if (sel_start != -1 && x >= sel_start && x <= sel_end) {
-            screen.GetSelectionStyle()(screen.CellAt(x, y));
+            screen.GetSelectionStyle()(cell);
           }
         }
       }
-      x++;
     }
   }
 


### PR DESCRIPTION
Hi, this PR bring some improvements to performance for the text element, especially when displaying a large amount of text. It:

* Calculate requirements in constructor since they won't change.
* Draw only visible lines by using the information that it already had.

Example: https://pastebin.com/yGenVLk6

In this example, I can scroll through a million lines no problem with my improvements. Without, it is unusable.

Another possible small improvement would be to change the constructor and the text() functions to use std::string instead of std::string_view, then one could move strings into it, but it would be an ABI break, unless we introduce new text() functions.