### PR TITLE
Fix high CPU usage from cursor position request feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ Next
 - Bugfix: Fix high CPU usage (app and terminal emulator, e.g. tmux) caused by a
   cursor position request/reply feedback loop redrawing the screen at ~60fps in
   the non-alternate-screen modes. See #1302.
-- Request the animation frame when an event is handled instead of when it is
-  received. All internal terminal replies (not only cursor position reports)
-  stop triggering animation frames.
+- Animation frames are now produced only when requested via
+  `animation::RequestAnimationFrame()` (e.g. by `animation::Animator`), as in
+  FTXUI 6. Receiving an event no longer implicitly triggers an animation
+  frame.
 
 ### Dom
 - Performance: `text` computes its requirement once and renders only the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Next
 - Bugfix: Fix high CPU usage (app and terminal emulator, e.g. tmux) caused by a
   cursor position request/reply feedback loop redrawing the screen at ~60fps in
   the non-alternate-screen modes. See #1302.
+- Request the animation frame when an event is handled instead of when it is
+  received. All internal terminal replies (not only cursor position reports)
+  stop triggering animation frames.
 
 ### Dom
 - Performance: `text` computes its requirement once and renders only the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Next
 ====
 
+### Component
+- Bugfix: Fix high CPU usage (app and terminal emulator, e.g. tmux) caused by a
+  cursor position request/reply feedback loop redrawing the screen at ~60fps in
+  the non-alternate-screen modes. See #1302.
+
 ### Dom
 - Performance: `text` computes its requirement once and renders only the
   visible lines. This makes scrolling a large text inside a `frame`

--- a/src/ftxui/component/animation_test.cpp
+++ b/src/ftxui/component/animation_test.cpp
@@ -3,10 +3,18 @@
 // the LICENSE file.
 
 #include <gtest/gtest.h>
+#include <chrono>      // for milliseconds
 #include <functional>  // for function
+#include <thread>      // for sleep_for
 #include <vector>      // for allocator, vector
 
 #include "ftxui/component/animation.hpp"  // for Function, BackIn, BackInOut, BackOut, BounceIn, BounceInOut, BounceOut, CircularIn, CircularInOut, CircularOut, CubicIn, CubicInOut, CubicOut, ElasticIn, ElasticInOut, ElasticOut, ExponentialIn, ExponentialInOut, ExponentialOut, Linear, QuadraticIn, QuadraticInOut, QuadraticOut, QuarticIn, QuarticInOut, QuarticOut, QuinticIn, QuinticInOut, QuinticOut, SineIn, SineInOut, SineOut
+#include "ftxui/component/app.hpp"        // for App
+#include "ftxui/component/component.hpp"  // for Make
+#include "ftxui/component/component_base.hpp"  // for ComponentBase
+#include "ftxui/component/event.hpp"           // for Event
+#include "ftxui/component/loop.hpp"            // for Loop
+#include "ftxui/dom/elements.hpp"              // for text
 
 namespace ftxui {
 
@@ -33,6 +41,53 @@ TEST(AnimationTest, StartAndEnd) {
     EXPECT_NEAR(0.F, it(0.F), 1.0e-4);
     EXPECT_NEAR(1.F, it(1.F), 1.0e-4);
   }
+}
+
+namespace {
+
+class AnimationCounter : public ComponentBase {
+ public:
+  int count = 0;
+
+ private:
+  Element OnRender() override { return text(""); }
+  void OnAnimation(animation::Params& /*params*/) override { count++; }
+};
+
+// Give the recurring AnimationTask (reposted every 15ms) time to become due,
+// then run the loop to execute it.
+void RunAnimationTask(Loop& loop) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  loop.RunOnce();
+}
+
+}  // namespace
+
+// OnAnimation must tick once per handled event, and not tick for the
+// terminal's replies to FTXUI's own internal requests. See #1302.
+TEST(AnimationTest, EventRequestsAnimationFrame) {
+  auto component = Make<AnimationCounter>();
+  auto screen = App::FixedSize(10, 1);
+  Loop loop(&screen, component);
+  loop.RunOnce();
+
+  // No event: the recurring AnimationTask is a no-op.
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 0);
+
+  // A handled event grants exactly one animation tick.
+  screen.PostEvent(Event::Custom);
+  loop.RunOnce();
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
+
+  // An internal terminal reply must not grant one.
+  screen.PostEvent(Event::CursorPosition("", 1, 1));
+  loop.RunOnce();
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
 }
 
 }  // namespace ftxui

--- a/src/ftxui/component/animation_test.cpp
+++ b/src/ftxui/component/animation_test.cpp
@@ -52,6 +52,13 @@ class AnimationCounter : public ComponentBase {
  private:
   Element OnRender() override { return text(""); }
   void OnAnimation(animation::Params& /*params*/) override { count++; }
+  bool OnEvent(Event event) override {
+    if (event == Event::Character('a')) {
+      animation::RequestAnimationFrame();
+      return true;
+    }
+    return false;
+  }
 };
 
 // Give the recurring AnimationTask (reposted every 15ms) time to become due,
@@ -63,29 +70,32 @@ void RunAnimationTask(Loop& loop) {
 
 }  // namespace
 
-// OnAnimation must tick once per handled event, and not tick for the
-// terminal's replies to FTXUI's own internal requests. See #1302.
-TEST(AnimationTest, EventRequestsAnimationFrame) {
+// OnAnimation must tick only when a frame was requested with
+// animation::RequestAnimationFrame(), typically by an Animator. In particular,
+// handling an event must not implicitly produce a tick: internal terminal
+// replies are events too, and animating on them caused the #1302 feedback
+// loop.
+TEST(AnimationTest, TicksOnlyWhenRequested) {
   auto component = Make<AnimationCounter>();
   auto screen = App::FixedSize(10, 1);
   Loop loop(&screen, component);
   loop.RunOnce();
 
-  // No event: the recurring AnimationTask is a no-op.
+  // No request: the recurring AnimationTask is a no-op.
   RunAnimationTask(loop);
   EXPECT_EQ(component->count, 0);
 
-  // A handled event grants exactly one animation tick.
+  // An event alone doesn't produce a tick.
   screen.PostEvent(Event::Custom);
   loop.RunOnce();
   RunAnimationTask(loop);
-  EXPECT_EQ(component->count, 1);
+  EXPECT_EQ(component->count, 0);
+
+  // A component requesting a frame gets exactly one tick.
+  screen.PostEvent(Event::Character('a'));
+  loop.RunOnce();
   RunAnimationTask(loop);
   EXPECT_EQ(component->count, 1);
-
-  // An internal terminal reply must not grant one.
-  screen.PostEvent(Event::CursorPosition("", 1, 1));
-  loop.RunOnce();
   RunAnimationTask(loop);
   EXPECT_EQ(component->count, 1);
 }

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -918,13 +918,6 @@ void App::Internal::HandleTask(Component component, Task& task) {
 #endif
       
       frame_valid_ = false;
-
-      // Give animated components one tick in response to the event. This must
-      // stay below the early-returns above: requesting a frame for the
-      // terminal's replies to our own requests creates a redraw -> request ->
-      // reply -> redraw feedback loop.
-      // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
-      public_->RequestAnimationFrame();
       return;
     }
 

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -556,15 +556,7 @@ App::Internal::Internal(App* app,
       dimension_(dimension),
       use_alternative_screen_(use_alternative_screen),
       terminal_input_parser([&](Event event) {
-        // Cursor position reports are terminal replies to our own \x1b[6n
-        // requests, consumed internally. Requesting an animation frame for
-        // them creates a redraw -> request -> reply -> redraw feedback loop.
-        // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
-        const bool internal_reply = event.is_cursor_position();
         event_buffer.Push(std::move(event));
-        if (!internal_reply) {
-          public_->RequestAnimationFrame();
-        }
       }),
       cursor_position_request(this, [this] {
         TerminalSend(DeviceStatusReport(DSRMode::kCursor));
@@ -926,6 +918,13 @@ void App::Internal::HandleTask(Component component, Task& task) {
 #endif
       
       frame_valid_ = false;
+
+      // Give animated components one tick in response to the event. This must
+      // stay below the early-returns above: requesting a frame for the
+      // terminal's replies to our own requests creates a redraw -> request ->
+      // reply -> redraw feedback loop.
+      // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
+      public_->RequestAnimationFrame();
       return;
     }
 
@@ -1541,7 +1540,6 @@ void App::Post(Task task) {
 
 void App::PostEvent(Event event) {
   internal_->event_buffer.Push(std::move(event));
-  RequestAnimationFrame();
 }
 
 // static

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -228,6 +228,7 @@ struct App::Internal {
    private:
     void Send() {
       last_sent_time_ = std::chrono::steady_clock::now();
+      last_request_time_ = last_sent_time_;
       pending_request_ = true;
       send_();
     }
@@ -555,8 +556,15 @@ App::Internal::Internal(App* app,
       dimension_(dimension),
       use_alternative_screen_(use_alternative_screen),
       terminal_input_parser([&](Event event) {
+        // Cursor position reports are terminal replies to our own \x1b[6n
+        // requests, consumed internally. Requesting an animation frame for
+        // them creates a redraw -> request -> reply -> redraw feedback loop.
+        // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
+        const bool internal_reply = event.is_cursor_position();
         event_buffer.Push(std::move(event));
-        public_->RequestAnimationFrame();
+        if (!internal_reply) {
+          public_->RequestAnimationFrame();
+        }
       }),
       cursor_position_request(this, [this] {
         TerminalSend(DeviceStatusReport(DSRMode::kCursor));


### PR DESCRIPTION
Fixes #1302.

## Root cause

In the non-alternate-screen modes (`FitComponent`, `TerminalOutput`), every `Draw()` sends a `\x1b[6n` cursor position request. Two bugs turned this into a permanent ~60fps redraw loop:

1. **The 500ms request throttle never engaged.** `ThrottledRequest::Send()` updated `last_sent_time_` but never `last_request_time_`, so the computed delay was always negative and a new request went out as soon as the previous reply arrived.
2. **The terminal's reply triggered a redraw.** Since the v7 event loop rework, every received event armed an animation frame — including the terminal's replies to our own requests. Each reply armed a frame, the next 15ms tick redrew, and the redraw sent another request.

Any terminal that answers DSR enters this loop; tmux just makes it visible in `top`.

## Fix

- Record `last_request_time_` in `ThrottledRequest::Send()` so the 500ms throttle works.
- Restore the FTXUI 6 animation contract: animation frames are produced only when requested via `animation::RequestAnimationFrame()`, typically by `animation::Animator`. Receiving an event no longer implicitly arms an animation frame — that behavior was an accident of the v7 rework, and it is what let internal terminal replies drive redraws.

## Verification

Gallery example idling inside tmux, measured over 15s:

| Process | Before | After |
|---|---|---|
| gallery | ~24% CPU | ~0.4% CPU |
| tmux server (detached) | ~8% CPU | ~0.0% CPU |

The UI renders identically and keyboard navigation still works (`tmux send-keys` + `capture-pane`). A new test, `AnimationTest.TicksOnlyWhenRequested`, pins the animation contract: no tick without a request, no tick for a bare event, exactly one tick per request. All 349 tests pass.
