### PR TITLE
Request animation frames when handling events, not when receiving them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Next
 - Bugfix: Fix high CPU usage (app and terminal emulator, e.g. tmux) caused by a
   cursor position request/reply feedback loop redrawing the screen at ~60fps in
   the non-alternate-screen modes. See #1302.
+- Request the animation frame when an event is handled instead of when it is
+  received. All internal terminal replies (not only cursor position reports)
+  stop triggering animation frames.
 
 7.0.1 (2026-07-14)
 ------------------

--- a/src/ftxui/component/animation_test.cpp
+++ b/src/ftxui/component/animation_test.cpp
@@ -3,10 +3,18 @@
 // the LICENSE file.
 
 #include <gtest/gtest.h>
+#include <chrono>      // for milliseconds
 #include <functional>  // for function
+#include <thread>      // for sleep_for
 #include <vector>      // for allocator, vector
 
 #include "ftxui/component/animation.hpp"  // for Function, BackIn, BackInOut, BackOut, BounceIn, BounceInOut, BounceOut, CircularIn, CircularInOut, CircularOut, CubicIn, CubicInOut, CubicOut, ElasticIn, ElasticInOut, ElasticOut, ExponentialIn, ExponentialInOut, ExponentialOut, Linear, QuadraticIn, QuadraticInOut, QuadraticOut, QuarticIn, QuarticInOut, QuarticOut, QuinticIn, QuinticInOut, QuinticOut, SineIn, SineInOut, SineOut
+#include "ftxui/component/app.hpp"        // for App
+#include "ftxui/component/component.hpp"  // for Make
+#include "ftxui/component/component_base.hpp"  // for ComponentBase
+#include "ftxui/component/event.hpp"           // for Event
+#include "ftxui/component/loop.hpp"            // for Loop
+#include "ftxui/dom/elements.hpp"              // for text
 
 namespace ftxui {
 
@@ -33,6 +41,53 @@ TEST(AnimationTest, StartAndEnd) {
     EXPECT_NEAR(0.F, it(0.F), 1.0e-4);
     EXPECT_NEAR(1.F, it(1.F), 1.0e-4);
   }
+}
+
+namespace {
+
+class AnimationCounter : public ComponentBase {
+ public:
+  int count = 0;
+
+ private:
+  Element OnRender() override { return text(""); }
+  void OnAnimation(animation::Params& /*params*/) override { count++; }
+};
+
+// Give the recurring AnimationTask (reposted every 15ms) time to become due,
+// then run the loop to execute it.
+void RunAnimationTask(Loop& loop) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  loop.RunOnce();
+}
+
+}  // namespace
+
+// OnAnimation must tick once per handled event, and not tick for the
+// terminal's replies to FTXUI's own internal requests. See #1302.
+TEST(AnimationTest, EventRequestsAnimationFrame) {
+  auto component = Make<AnimationCounter>();
+  auto screen = App::FixedSize(10, 1);
+  Loop loop(&screen, component);
+  loop.RunOnce();
+
+  // No event: the recurring AnimationTask is a no-op.
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 0);
+
+  // A handled event grants exactly one animation tick.
+  screen.PostEvent(Event::Custom);
+  loop.RunOnce();
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
+
+  // An internal terminal reply must not grant one.
+  screen.PostEvent(Event::CursorPosition("", 1, 1));
+  loop.RunOnce();
+  RunAnimationTask(loop);
+  EXPECT_EQ(component->count, 1);
 }
 
 }  // namespace ftxui

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -556,15 +556,7 @@ App::Internal::Internal(App* app,
       dimension_(dimension),
       use_alternative_screen_(use_alternative_screen),
       terminal_input_parser([&](Event event) {
-        // Cursor position reports are terminal replies to our own \x1b[6n
-        // requests, consumed internally. Requesting an animation frame for
-        // them creates a redraw -> request -> reply -> redraw feedback loop.
-        // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
-        const bool internal_reply = event.is_cursor_position();
         event_buffer.Push(std::move(event));
-        if (!internal_reply) {
-          public_->RequestAnimationFrame();
-        }
       }),
       cursor_position_request(this, [this] {
         TerminalSend(DeviceStatusReport(DSRMode::kCursor));
@@ -926,6 +918,13 @@ void App::Internal::HandleTask(Component component, Task& task) {
 #endif
       
       frame_valid_ = false;
+
+      // Give animated components one tick in response to the event. This must
+      // stay below the early-returns above: requesting a frame for the
+      // terminal's replies to our own requests creates a redraw -> request ->
+      // reply -> redraw feedback loop.
+      // See https://github.com/ArthurSonzogni/FTXUI/issues/1302.
+      public_->RequestAnimationFrame();
       return;
     }
 
@@ -1541,7 +1540,6 @@ void App::Post(Task task) {
 
 void App::PostEvent(Event event) {
   internal_->event_buffer.Push(std::move(event));
-  RequestAnimationFrame();
 }
 
 // static


### PR DESCRIPTION
Stacked on #1310 (based on its branch; will retarget to main once it merges).

Move `RequestAnimationFrame()` from the two event producers (the `TerminalInputParser` callback and `App::PostEvent`) into the Event branch of `App::Internal::HandleTask`, below the internal-reply early-returns.

Benefits:
- A single place decides which events grant an animation frame, next to the code that already discriminates event kinds. The #1302 special case in the parser callback disappears: internal replies early-return before the request.
- Every internal terminal reply (cursor shape, terminal capabilities, name/version, emulator) stops arming animation frames. Previously only cursor position reports were exempted, and only on the parser path — `PostEvent` armed a frame for all of them.
- The `animation_requested_` write moves onto the main loop thread, removing an unsynchronized write when `PostEvent` is called from another thread.

A new test, `AnimationTest.EventRequestsAnimationFrame`, drives the full pipeline through `Loop::RunOnce`: no tick without an event, exactly one tick per handled event, no tick for an internal reply. It fails without this change.