### PR TITLE
Revert "update the URL of typing-speed-test in README.md (#1295)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Feel free to add your projects here:
 - [tiles](https://github.com/tusharpm/tiles)
 - [todoman](https://github.com/aaleino/todoman)
 - [turing_cmd](https://github.com/DanArmor/turing_cmd)
-- [typing-speed-test](https://codeberg.org/ymcx/typing-speed-test)
+- [typing-speed-test](https://github.com/ymcx/typing-speed-test)
 - [vantage](https://github.com/gokulmaxi/vantage)
 - [x86-64 CPU Architecture Simulation](https://github.com/AnisBdz/CPU)
 - [C++ Process Manager](https://github.com/ondrejhonus/cpp_proc)


### PR DESCRIPTION
This reverts commit 9c5814b6a1f91b2e73af1d4948247992d6246067 (https://github.com/ArthurSonzogni/FTXUI/pull/1295).

Codeberg has been having some issues with uptime lately and I got tired of having to work with more than one code forge, so I decided to migrate back to GitHub. Sorry for having to deal with this mess.