### PR TITLE
fix: Fix event retention after terminal setup

### DIFF
--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -246,7 +246,6 @@ struct App::Internal {
   ThrottledRequest cursor_position_request;
 
   MultiReceiverBuffer<Event> event_buffer;
-  std::unique_ptr<MultiReceiverBuffer<Event>::Receiver> setup_receiver;
   std::unique_ptr<MultiReceiverBuffer<Event>::Receiver> main_loop_receiver;
 
   Internal(App* app, AppDimension dimension, bool use_alternative_screen);
@@ -561,7 +560,6 @@ App::Internal::Internal(App* app,
       cursor_position_request(this, [this] {
         TerminalSend(DeviceStatusReport(DSRMode::kCursor));
       }) {
-  setup_receiver = event_buffer.CreateReceiver();
   main_loop_receiver = event_buffer.CreateReceiver();
 }
 
@@ -1170,6 +1168,8 @@ void App::Internal::InstallPipedInputHandling() {
 }
 
 void App::Internal::InstallTerminalInfo() {
+  auto setup_receiver = event_buffer.CreateReceiver();
+
   // Request the terminal to report the current cursor shape. We will restore it
   // on exit.
   if (is_stdout_a_tty_) {


### PR DESCRIPTION
## Summary

- Limit the terminal setup event receiver to `InstallTerminalInfo()`.
- Allow `MultiReceiverBuffer` to prune events after terminal setup completes.

## Problem

`App::Internal` creates both `setup_receiver` and `main_loop_receiver` in its constructor.
`setup_receiver` is consumed only while `InstallTerminalInfo()` is collecting terminal replies, but it remains registered for the lifetime of the `App`.

`MultiReceiverBuffer::Prune()` can remove events only up to the minimum index of all registered receivers.
After terminal setup, the setup receiver stops advancing and permanently holds that minimum index.
Keyboard, mouse, terminal, and posted events are therefore retained even after the main-loop receiver has processed them.

Applications that periodically post events show a steadily growing event deque and process memory usage.

### Example

`MultiReceiverBuffer` allows multiple receivers to read the same event sequence at different speeds. Each receiver's index identifies the next event it will read.
For example, suppose events 0 through 9 exist and the receivers are in the following state:

| Receiver | Next index | State |
|---|---:|---|
| `main_loop_receiver` | 9 | Has processed events 0 through 8 |
| `setup_receiver` | 2 | Has processed only events 0 and 1 |

From the buffer's perspective, `setup_receiver` may still read events 2 through 8.
Those events therefore cannot be removed even though the main loop has already processed them.

```plaintext
event idx:     0 1 2 3 4 5 6 7 8 9
setup:             ↑ next event idx = 2
main loop:                       ↑ next event idx = 9

removable:     0 1
not removable:     2 3 4 5 6 7 8 9
```

However, `setup_receiver` remains registered after terminal setup even though it no longer reads events.
Its index may, for example, stop at 2.
No matter how many thousands of events the main loop subsequently processes, the minimum index remains 2, so new events cannot be removed and continue accumulating in the deque.

## Fix

Create the setup receiver at the beginning of `InstallTerminalInfo()` instead of storing it as an `App::Internal` member.
Its destructor unregisters the receiver when terminal setup completes or times out, allowing already-consumed events to be pruned.

A later terminal reinstall creates a new receiver before sending that installation's queries.
Unconsumed main-loop events remain protected by the main-loop receiver's index.

## Reproduction

A standalone reproducer is available at:

https://github.com/Kashiwade-music/ftxui-memory-leak

The producer thread uses `App::Post(Closure)`, and the closure calls `PostEvent()` on the UI thread.

One Windows RelWithDebInfo comparison produced:

| FTXUI | Duration | Processed events | Private Bytes delta |
|---|---:|---:|---:|
| Unpatched | 30 s | 7,616 | +1,146,880 bytes |
| Unpatched | 60 s | 11,800 | +1,802,240 bytes |
| Fixed | 30 s | 7,608 | -122,880 bytes |
| Fixed | 60 s | 14,624 | -122,880 bytes |

The unpatched Private Bytes delta grows with the number of processed events.
The fixed build does not grow as duration and event count increase.