### PR TITLE
fix typo in example

### DIFF
--- a/doc/cpp20-modules.md
+++ b/doc/cpp20-modules.md
@@ -41,7 +41,7 @@ using ftxui::Component;
 int main() {
   App app = App::TerminalOutput();
   Component button = Button("Click me", app.ExitLoopClosure());
-  screen.Loop(button);
+  app.Loop(button);
   return 0;
 }
 ```


### PR DESCRIPTION
Fixed minor typo in c++20 modules example. 

Before fix:
```bash
❰serkosal❙~/Documents/development/c++/intfl2/build(git≠✱main)❱✔≻ ninja -j$(nproc)
[3/4] Building CXX object CMakeFiles/intfl2.dir/src/main.cpp.o
FAILED: [code=1] CMakeFiles/intfl2.dir/src/main.cpp.o 
/usr/bin/c++  -isystem /home/serkosal/Documents/development/c++/intfl2/build/_deps/ftxui-src/include -std=c++20 -fmodules-ts -MD -MT CMakeFiles/intfl2.dir/src/main.cpp.o -MF CMakeFiles/intfl2.dir/src/main.cpp.o.d -fmodules-ts -fmodule-mapper=CMakeFiles/intfl2.dir/src/main.cpp.o.modmap -MD -fdeps-format=p1689r5 -x c++ -o CMakeFiles/intfl2.dir/src/main.cpp.o -c /home/serkosal/Documents/development/c++/intfl2/src/main.cpp
/home/serkosal/Documents/development/c++/intfl2/src/main.cpp: In function ‘int main()’:
/home/serkosal/Documents/development/c++/intfl2/src/main.cpp:10:3: error: ‘screen’ was not declared in this scope
   10 |   screen.Loop(button);
      |   ^~~~~~
ninja: build stopped: subcommand failed.
```
------
After the fix, everything compiles and works just fine.
<img width="593" height="67" alt="image" src="https://github.com/user-attachments/assets/2801317d-3400-4c90-a28d-c92f15c04c79" />
