### PR TITLE
fix(selection): fill horizontal gaps so mouse-copy keeps spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Next
   child, preventing lost focus when entering nested containers whose first
   child is non-focusable. Thanks @Machillka. See #1337.
 
+### Dom
+- Bugfix: Fill horizontal gaps with spaces during text selection so copying text
+  from elements with spacing (such as `paragraph()`) preserves inter-word
+  spaces. Thanks @aleroot. See #1318.
+
 ### Screen
 - The Unicode tables are updated from 13.0.0 to 17.0.0. Code points assigned by
   the last four Unicode releases now get their real width and word break

--- a/src/ftxui/dom/selection.cpp
+++ b/src/ftxui/dom/selection.cpp
@@ -164,6 +164,17 @@ void Selection::AddPart(std::string_view part, int y, int left, int right) {
       return;
     }
 
+    // There is a horizontal gap of blank cells between the previously
+    // recorded part and this one. Such gaps arise from layout that
+    // separates selectable text with empty columns instead of literal
+    // space characters (e.g. flexbox gaps from FlexboxConfig::SetGap,
+    // fillers, spacing decorators). Those cells lie inside the selected
+    // region and read as spaces on screen, so the copied text must
+    // contain them too. Only forward gaps are filled; overlapping or
+    // out-of-order parts fall through to a plain append.
+    for (int x = x_ + 1; x < left; ++x) {
+      parts_ << ' ';
+    }
     parts_ << part;
   }();
   y_ = y;

--- a/src/ftxui/dom/selection_test.cpp
+++ b/src/ftxui/dom/selection_test.cpp
@@ -310,5 +310,17 @@ TEST(SelectionTest, HBoxSaturatedSelection) {
             "         ");
 }
 
+TEST(SelectionTest, ParagraphGapFillsSpaces) {
+  // paragraph() splits its text on spaces and lays the words out with a
+  // 1-column flexbox gap (FlexboxConfig::SetGap(1, 0)). Those gap cells are
+  // blank and owned by no text node, so selecting across words must still
+  // reproduce the inter-word spaces in the copied text.
+  auto element = paragraph("Lorem ipsum dolor");
+  auto screen = App::FixedSize(20, 1);
+  Selection selection(0, 0, 16, 0);
+  Render(screen, element.get(), selection);
+  EXPECT_EQ(selection.GetParts(), "Lorem ipsum dolor");
+}
+
 }  // namespace ftxui
 // NOLINTEND


### PR DESCRIPTION
## Mouse text-selection drops inter-word spaces

`Selection::AddPart` only ever concatenates parts; it never reproduces the blank cells in a same-row horizontal gap. The `if (x_ == left + 1)` branch is effectively dead code (identical to the fallthrough), so any layout that separates selectable text with empty columns — notably `paragraph()` / `paragraphAlignLeft`, which splits on spaces and renders words in a `flexbox` with `FlexboxConfig::SetGap(1, 0)` — loses every inter-word space when the selection is copied to the clipboard.

This fills forward same-row gaps with spaces (those cells are inside the selected region and read as spaces on screen), leaving overlapping/out-of-order and cross-row behavior unchanged. Adds a regression test via `paragraph()`.