### PR TITLE
CI: test shared library on macos and windows too

### DIFF
--- a/.github/workflows/shared_lib_build.yaml
+++ b/.github/workflows/shared_lib_build.yaml
@@ -10,15 +10,20 @@ on:
 
 jobs:
   build-shared:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        env:
-          CC: clang
-          CXX: clang++
+        shell: bash
         run: |
           cmake -B build \
             -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
use a github matrix for shared library build too, in order to test also macos and windows.

This shows the failure to build ftxui on windows: https://github.com/ericLemanissier/FTXUI/actions/runs/30634984404/job/91170175188#step:4:131
```
D:\a\FTXUI\FTXUI\include\ftxui\dom\node.hpp(98,6): error C2375: 'ftxui::Render': redefinition; different linkage [D:\a\FTXUI\FTXUI\build\dom.vcxproj]
  (compiling source file '../src/ftxui/dom/automerge.cpp')
      D:\a\FTXUI\FTXUI\include\ftxui\dom\node.hpp(87,15):
      see declaration of 'ftxui::Render'
```