### PR TITLE
Fix incorrect mouse position from async cursor-position DSR request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@ Next
   be misread as the wrong offset. Regressed by the 7.0.2 throttle fix, which
   made the request's 500ms throttle actually engage for the first time. See
   #1310.
-- Bugfix: Fix mouse selection producing a garbled/wrong selection box when
-  the cursor position reply arrived in the middle of a drag. The frame
-  offset (`cursor_x_`/`cursor_y_`) could change between the mouse-press and
-  mouse-release of a single selection gesture, so the start and end
-  coordinates ended up computed against different offsets. Regressed by the
-  cursor position throttle fix in #1310.
 
 7.0.2 (2026-08-01)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Next
 ====
 
 ### Component
+- Bugfix: Fix incorrect mouse position in non-alternate-screen modes. The
+  cursor position request (used to convert mouse coordinates from screen
+  space to frame space) could be sent asynchronously, after the cursor had
+  already moved away from the frame's origin, causing the terminal's reply to
+  be misread as the wrong offset. Regressed by the 7.0.2 throttle fix, which
+  made the request's 500ms throttle actually engage for the first time. See
+  #1310.
 - Bugfix: Fix mouse selection producing a garbled/wrong selection box when
   the cursor position reply arrived in the middle of a drag. The frame
   offset (`cursor_x_`/`cursor_y_`) could change between the mouse-press and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changelog
 Next
 ====
 
+### Component
+- Bugfix: Fix mouse selection producing a garbled/wrong selection box when
+  the cursor position reply arrived in the middle of a drag. The frame
+  offset (`cursor_x_`/`cursor_y_`) could change between the mouse-press and
+  mouse-release of a single selection gesture, so the start and end
+  coordinates ended up computed against different offsets. Regressed by the
+  cursor position throttle fix in #1310.
+
 7.0.2 (2026-08-01)
 ------------------
 

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -867,8 +867,13 @@ void App::Internal::HandleTask(Component component, Task& task) {
     if constexpr (std::is_same_v<T, Event>) {
 
       if (arg.is_cursor_position()) {
-        cursor_x_ = arg.cursor_x();
-        cursor_y_ = arg.cursor_y();
+        // Don't let the frame offset change in the middle of a mouse
+        // selection: start_{x,y} and end_{x,y} must be computed against the
+        // same offset, or the selection box ends up inconsistent.
+        if (!selection_pending_) {
+          cursor_x_ = arg.cursor_x();
+          cursor_y_ = arg.cursor_y();
+        }
         cursor_position_request.OnReply();
         return;
       }

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -196,33 +196,26 @@ struct App::Internal {
       }
 
       const auto now = std::chrono::steady_clock::now();
-      const auto delta = now - last_request_time_;
-      const auto delay = std::chrono::milliseconds(500) - delta;
-
-      if (delay <= std::chrono::milliseconds(0)) {
-        Send();
+      if (now - last_request_time_ < std::chrono::milliseconds(500)) {
+        // Too soon since the last request. Skip it: the request must be sent
+        // synchronously from Draw(), right after the cursor is moved to the
+        // frame's origin, so that the terminal's reply reflects that
+        // position. Draw() calls Request() again on the next frame, so the
+        // request isn't lost, only delayed.
         return;
       }
 
-      request_queued_ = true;
-      internal_->task_runner.PostDelayedTask(
-          [this] {
-            request_queued_ = false;
-            Request();
-          },
-          delay);
+      Send();
     }
 
     void OnReply() { pending_request_ = false; }
 
     bool HasPending() const {
-      if (pending_request_) {
-        const auto now = std::chrono::steady_clock::now();
-        if (now - last_sent_time_ < std::chrono::seconds(5)) {
-          return true;
-        }
+      if (!pending_request_) {
+        return false;
       }
-      return request_queued_;
+      const auto now = std::chrono::steady_clock::now();
+      return now - last_sent_time_ < std::chrono::seconds(5);
     }
 
    private:
@@ -240,7 +233,6 @@ struct App::Internal {
         std::chrono::steady_clock::now() - std::chrono::hours(1);
     std::chrono::steady_clock::time_point last_sent_time_ =
         std::chrono::steady_clock::now() - std::chrono::hours(1);
-    bool request_queued_ = false;
   };
 
   ThrottledRequest cursor_position_request;

--- a/src/ftxui/component/app.cpp
+++ b/src/ftxui/component/app.cpp
@@ -859,13 +859,8 @@ void App::Internal::HandleTask(Component component, Task& task) {
     if constexpr (std::is_same_v<T, Event>) {
 
       if (arg.is_cursor_position()) {
-        // Don't let the frame offset change in the middle of a mouse
-        // selection: start_{x,y} and end_{x,y} must be computed against the
-        // same offset, or the selection box ends up inconsistent.
-        if (!selection_pending_) {
-          cursor_x_ = arg.cursor_x();
-          cursor_y_ = arg.cursor_y();
-        }
+        cursor_x_ = arg.cursor_x();
+        cursor_y_ = arg.cursor_y();
         cursor_position_request.OnReply();
         return;
       }

--- a/src/ftxui/dom/selection_test.cpp
+++ b/src/ftxui/dom/selection_test.cpp
@@ -240,6 +240,122 @@ TEST(SelectionTest, HBoxSelection) {
             "Lo\x1B[7mrem ipsum dolorUt e\x1B[27mnim ad minim       ");
 }
 
+// The next two tests drive a selection through `App`/`Loop` (press, move,
+// release, each in its own frame), then re-render the same document with a
+// plain `Selection` built from `screen.GetSelection()`'s row/column extent
+// to check exactly what got highlighted. `screen.CellAt()` can't be used
+// directly after `loop.RunOnce()`: `App::Internal::Draw()` clears its cell
+// buffer at the end of every frame (to build the next diff), so by the time
+// a test can inspect it, it's already back to defaults.
+
+// A selection built up over several separate frames (press, then one or
+// more moves, then release each processed in their own `loop.RunOnce()`)
+// must render the same thing as if it had been submitted all at once: the
+// first row from the start column to the end of the line, the last row from
+// the start of the line to the end column, and every row in between fully
+// selected (this is regular flow/text selection, not a rectangular block
+// selection -- see the pre-existing VBoxSelection/HBoxSelection tests).
+TEST(SelectionTest, SelectionAcrossMultipleFrames) {
+  // Each row is "0123456": column `x` holds the digit `x`.
+  const std::string content =
+      "0123456\n0123456\n0123456\n0123456\n0123456\n0123456\n0123456";
+  auto component = Renderer([&] { return text(content); });
+  auto screen = App::FixedSize(7, 7);
+  Loop loop(&screen, component);
+  loop.RunOnce();
+
+  screen.PostEvent(MousePressed(2, 2));  // local (1, 1)
+  loop.RunOnce();
+  screen.PostEvent(MouseMove(4, 4));  // local (3, 3)
+  loop.RunOnce();
+  screen.PostEvent(MouseMove(6, 6));  // local (5, 5)
+  loop.RunOnce();
+  screen.PostEvent(MouseReleased(6, 6));
+  loop.RunOnce();
+
+  EXPECT_EQ(screen.GetSelection(),
+            "123456\n0123456\n0123456\n0123456\n012345");
+
+  // Cross-check what actually gets rendered for that selection: row 1 from
+  // column 1 to the end, rows 2-4 fully selected, row 5 from the start to
+  // column 5.
+  auto element = text(content);
+  auto render_screen = App::FixedSize(7, 7);
+  Selection selection(1, 1, 5, 5);
+  Render(render_screen, element.get(), selection);
+  EXPECT_EQ(render_screen.ToString(),
+            "0123456\r\n"
+            "0\x1B[7m123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m012345\x1B[27m6\r\n"
+            "0123456");
+}
+
+// Regression test: the frame offset (used to translate absolute terminal
+// mouse coordinates into document-relative ones) must not change in the
+// middle of a selection gesture. If a `CursorPosition` reply lands between
+// the mouse-press and the mouse-release, start_{x,y} and end_{x,y} would
+// otherwise be computed against different offsets, producing a selection
+// that doesn't correspond to any real mouse path. See the fix following the
+// #1310 cursor-position throttle change.
+TEST(SelectionTest, SelectionKeepsConsistentOffsetWhenCursorPositionReplyArrivesMidDrag) {
+  // Each row is "0123456": column `x` holds the digit `x`.
+  const std::string content =
+      "0123456\n0123456\n0123456\n0123456\n0123456\n0123456\n0123456";
+  auto component = Renderer([&] { return text(content); });
+  auto screen = App::FixedSize(7, 7);
+  Loop loop(&screen, component);
+  loop.RunOnce();
+
+  // Press while the frame offset is still the default (1, 1): local (1, 1).
+  screen.PostEvent(MousePressed(2, 2));
+  loop.RunOnce();
+
+  // The cursor-position reply lands mid-drag, revealing a different offset.
+  screen.PostEvent(Event::CursorPosition("", 1, 5));
+  loop.RunOnce();
+
+  // Continue the drag and release with an absolute position a real terminal
+  // would report consistently with the *new* offset.
+  screen.PostEvent(MouseMove(2, 8));
+  loop.RunOnce();
+  screen.PostEvent(MouseReleased(2, 8));
+  loop.RunOnce();
+
+  // The offset must stay frozen at (1, 1) -- the value in effect when the
+  // drag started -- for the whole gesture: (2, 8) maps to local (1, 7),
+  // which falls off the bottom of the 7x7 grid (rows 0-6). Since the end
+  // point never lands on a visible row, every row from the start row down
+  // to the last visible row (1 through 6) is swept as a "row in between",
+  // matching a real, single mouse path under a constant offset.
+  //
+  // Without the fix, the reply would apply immediately: the release would
+  // be interpreted with the *new* offset (1, 5), landing at local (1, 3),
+  // while the press had already been recorded at local (1, 1) using the
+  // *old* offset -- two different offsets for one gesture, selecting only
+  // rows 1-3 instead, which doesn't correspond to any single mouse path.
+  EXPECT_EQ(screen.GetSelection(),
+            "123456\n0123456\n0123456\n0123456\n0123456\n0123456");
+
+  // Cross-check what actually gets rendered: row 1 from column 1 to the
+  // end, rows 2-6 fully selected (the end point, row 7, is off-grid, so it
+  // never becomes a "last, partial" row).
+  auto element = text(content);
+  auto render_screen = App::FixedSize(7, 7);
+  Selection selection(1, 1, 1, 7);
+  Render(render_screen, element.get(), selection);
+  EXPECT_EQ(render_screen.ToString(),
+            "0123456\r\n"
+            "0\x1B[7m123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m\r\n"
+            "\x1B[7m0123456\x1B[27m");
+}
+
 TEST(SelectionTest, HBoxSaturatedSelection) {
   auto element = hbox({
       text("Lorem ipsum dolor"),

--- a/src/ftxui/dom/selection_test.cpp
+++ b/src/ftxui/dom/selection_test.cpp
@@ -293,69 +293,6 @@ TEST(SelectionTest, SelectionAcrossMultipleFrames) {
             "0123456");
 }
 
-// Regression test: the frame offset (used to translate absolute terminal
-// mouse coordinates into document-relative ones) must not change in the
-// middle of a selection gesture. If a `CursorPosition` reply lands between
-// the mouse-press and the mouse-release, start_{x,y} and end_{x,y} would
-// otherwise be computed against different offsets, producing a selection
-// that doesn't correspond to any real mouse path. See the fix following the
-// #1310 cursor-position throttle change.
-TEST(SelectionTest, SelectionKeepsConsistentOffsetWhenCursorPositionReplyArrivesMidDrag) {
-  // Each row is "0123456": column `x` holds the digit `x`.
-  const std::string content =
-      "0123456\n0123456\n0123456\n0123456\n0123456\n0123456\n0123456";
-  auto component = Renderer([&] { return text(content); });
-  auto screen = App::FixedSize(7, 7);
-  Loop loop(&screen, component);
-  loop.RunOnce();
-
-  // Press while the frame offset is still the default (1, 1): local (1, 1).
-  screen.PostEvent(MousePressed(2, 2));
-  loop.RunOnce();
-
-  // The cursor-position reply lands mid-drag, revealing a different offset.
-  screen.PostEvent(Event::CursorPosition("", 1, 5));
-  loop.RunOnce();
-
-  // Continue the drag and release with an absolute position a real terminal
-  // would report consistently with the *new* offset.
-  screen.PostEvent(MouseMove(2, 8));
-  loop.RunOnce();
-  screen.PostEvent(MouseReleased(2, 8));
-  loop.RunOnce();
-
-  // The offset must stay frozen at (1, 1) -- the value in effect when the
-  // drag started -- for the whole gesture: (2, 8) maps to local (1, 7),
-  // which falls off the bottom of the 7x7 grid (rows 0-6). Since the end
-  // point never lands on a visible row, every row from the start row down
-  // to the last visible row (1 through 6) is swept as a "row in between",
-  // matching a real, single mouse path under a constant offset.
-  //
-  // Without the fix, the reply would apply immediately: the release would
-  // be interpreted with the *new* offset (1, 5), landing at local (1, 3),
-  // while the press had already been recorded at local (1, 1) using the
-  // *old* offset -- two different offsets for one gesture, selecting only
-  // rows 1-3 instead, which doesn't correspond to any single mouse path.
-  EXPECT_EQ(screen.GetSelection(),
-            "123456\n0123456\n0123456\n0123456\n0123456\n0123456");
-
-  // Cross-check what actually gets rendered: row 1 from column 1 to the
-  // end, rows 2-6 fully selected (the end point, row 7, is off-grid, so it
-  // never becomes a "last, partial" row).
-  auto element = text(content);
-  auto render_screen = App::FixedSize(7, 7);
-  Selection selection(1, 1, 1, 7);
-  Render(render_screen, element.get(), selection);
-  EXPECT_EQ(render_screen.ToString(),
-            "0123456\r\n"
-            "0\x1B[7m123456\x1B[27m\r\n"
-            "\x1B[7m0123456\x1B[27m\r\n"
-            "\x1B[7m0123456\x1B[27m\r\n"
-            "\x1B[7m0123456\x1B[27m\r\n"
-            "\x1B[7m0123456\x1B[27m\r\n"
-            "\x1B[7m0123456\x1B[27m");
-}
-
 TEST(SelectionTest, HBoxSaturatedSelection) {
   auto element = hbox({
       text("Lorem ipsum dolor"),


### PR DESCRIPTION
## Summary
- Fixes a major mouse-position regression introduced by 3b5d3519 (#1310, the cursor-position DSR throttle fix): once the 500ms throttle genuinely engaged, the retry path called `Send()` from a delayed task running outside of `Draw()`. That queued the `\x1b[6n` cursor-position query into `output_buffer` *before* the current frame's reset-to-origin sequence, so the terminal replied with wherever the cursor was left after the *previous* frame (e.g. its bottom-right corner) instead of the new frame's top-left origin. Every mouse coordinate computed from that offset was wrong until a synchronous request happened to land correctly again.
- Fix: `ThrottledRequest::Request()` no longer reschedules itself via a delayed task when throttled — it just skips sending. `Draw()` already calls `RequestCursorPosition()` every frame, so the request is retried on the next frame and always sent synchronously right after the cursor is moved to the frame's origin, keeping the query and the terminal's reply aligned.
- This supersedes the previous fix on this branch (mid-drag `cursor_x_`/`cursor_y_` freeze during selection): that fix treated each reported offset as individually correct and only prevented it from changing mid-gesture. With the query itself now always correctly positioned, the offset is right in the first place, so the freeze (and its dedicated regression test) is no longer needed and has been reverted.

## Test plan
- [x] `ftxui-tests` (352/352) passes.