### PR TITLE
ci: add Conan Center Index publish job to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,11 @@ on:
         required: true
         type: boolean
         default: true
+      publish_conan:
+        description: "Publish to Conan Center Index"
+        required: true
+        type: boolean
+        default: true
       publish_xmake:
         description: "Publish to xmake-repo"
         required: true
@@ -175,6 +180,82 @@ jobs:
             --head "ArthurSonzogni:${BRANCH_NAME}" \
             --base master \
             --title "[ftxui] update to ${VERSION}" \
+            --body "Automated update of ftxui to version ${VERSION}."
+
+  conan:
+    name: "Publish to Conan Center Index"
+    needs: prepare
+    if: ${{ inputs.publish_conan }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout FTXUI"
+        uses: actions/checkout@v4
+
+      - name: "Push to Conan Center Index"
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SHA256: ${{ needs.prepare.outputs.sha256 }}
+        run: |
+          echo "Publishing FTXUI version ${VERSION} (tag: ${TAG}) to Conan Center Index"
+          echo "Archive SHA256: ${SHA256}"
+
+          # Ensure fork exists
+          echo "Forking conan-io/conan-center-index if needed..."
+          gh repo fork conan-io/conan-center-index --clone=false || true
+
+          # Clone the fork
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/ArthurSonzogni/conan-center-index.git" conan-center-index
+          cd conan-center-index
+          git remote add upstream https://github.com/conan-io/conan-center-index.git
+          git fetch upstream master
+
+          # Create new branch from upstream master
+          BRANCH_NAME="ftxui-${VERSION}"
+          git checkout -b "${BRANCH_NAME}" upstream/master
+
+          # Configure git author
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Update recipes/ftxui/config.yml and recipes/ftxui/all/conandata.yml
+          python3 -c '
+          import re, sys
+          version, sha256 = sys.argv[1], sys.argv[2]
+          tag = f"v{version}"
+
+          # Update config.yml
+          cfg_path = "recipes/ftxui/config.yml"
+          with open(cfg_path, "r") as f:
+              cfg = f.read()
+          cfg = re.sub(r"^versions:\n", f"versions:\n  \"{version}\":\n    folder: all\n", cfg, flags=re.MULTILINE)
+          with open(cfg_path, "w") as f:
+              f.write(cfg)
+
+          # Update conandata.yml
+          data_path = "recipes/ftxui/all/conandata.yml"
+          with open(data_path, "r") as f:
+              data = f.read()
+          entry = f"sources:\n  \"{version}\":\n    url: \"https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/{tag}.tar.gz\"\n    sha256: \"{sha256}\"\n"
+          data = re.sub(r"^sources:\n", entry, data, flags=re.MULTILINE)
+          with open(data_path, "w") as f:
+              f.write(data)
+          ' "${VERSION}" "${SHA256}"
+
+          # Commit changes
+          git add recipes/ftxui/
+          git commit -m "ftxui: add ${VERSION}"
+
+          # Push branch to fork
+          git push origin "${BRANCH_NAME}" --force
+
+          # Create PR against conan-io/conan-center-index
+          gh pr create \
+            --repo conan-io/conan-center-index \
+            --head "ArthurSonzogni:${BRANCH_NAME}" \
+            --base master \
+            --title "ftxui: add ${VERSION}" \
             --body "Automated update of ftxui to version ${VERSION}."
 
   xmake:


### PR DESCRIPTION
This PR adds automated publishing to Conan Center Index () alongside BCR, vcpkg, xmake, and Homebrew.