### PR TITLE
ci: cut GitHub Actions cost by scaling the matrices per event

### DIFF
--- a/.github/workflows/abi_check.yaml
+++ b/.github/workflows/abi_check.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/amalgamate.yaml
+++ b/.github/workflows/amalgamate.yaml
@@ -5,34 +5,36 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 3 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
+  # Which platforms run for this event is defined in tools/ci_matrix.json.
+  select_matrix:
+    name: "Select matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      amalgamate: ${{ steps.select.outputs.amalgamate }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+
+      - name: "Select the matrices for ${{ github.event_name }}"
+        id: select
+        run: ./tools/select_ci_matrix.sh >> "$GITHUB_OUTPUT"
+
   build:
     name: "Amalgamate, ${{ matrix.compiler }}, ${{ matrix.os }}"
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Linux GCC
-            os: ubuntu-latest
-            compiler: gcc
-            cxx: g++
-
-          - name: Linux Clang
-            os: ubuntu-latest
-            compiler: llvm
-            cxx: clang++
-
-          - name: MacOS clang
-            os: macos-latest
-            compiler: llvm
-            cxx: clang++
-
-          - name: Windows MSVC
-            os: windows-latest
-            compiler: cl
-            cxx: cl
+        include: ${{ fromJSON(needs.select_matrix.outputs.amalgamate) }}
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,10 @@ jobs:
           clangtidy: false
           cppcheck: false
           gcovr: "5.0"
-          opencppcoverage: true
+          # Only installed when the coverage step below actually runs. It is a
+          # slow chocolatey install of a third party download, so pull requests
+          # must not depend on it being reachable.
+          opencppcoverage: ${{ contains(matrix.os, 'windows') && github.event_name != 'pull_request' }}
 
       # make sure coverage is only enabled for Debug builds, since it sets -O0
       # to make sure coverage has meaningful results

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,36 +11,46 @@ on:
     branches:
       - main
 
+  # Weekly, with the full matrix:
+  schedule:
+    - cron: '0 3 * * 1'
+
+  workflow_dispatch:
+
+# Only keep the latest run per branch: pushing a new commit cancels the
+# in-flight checks for the previous one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
 
+  # Which platforms run for this event is defined in tools/ci_matrix.json.
+  select_matrix:
+    name: "Select matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      bazel: ${{ steps.select.outputs.bazel }}
+      cmake: ${{ steps.select.outputs.cmake }}
+      meson: ${{ steps.select.outputs.meson }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+
+      - name: "Select the matrices for ${{ github.event_name }}"
+        id: select
+        run: ./tools/select_ci_matrix.sh >> "$GITHUB_OUTPUT"
+
   test_bazel:
     name: "Bazel, ${{ matrix.cxx }}, ${{ matrix.os }}"
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            cxx: g++
-            cc: gcc
-
-          - os: ubuntu-latest
-            cxx: clang++
-            cc: clang
-
-          - os: macos-latest
-            cxx: g++
-            cc: gcc
-
-          - os: macos-latest
-            cxx: clang++
-            cc: clang
-
-          - os: windows-latest
-            cxx: cl
-            cc: cl
+        include: ${{ fromJSON(needs.select_matrix.outputs.bazel) }}
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,27 +78,11 @@ jobs:
 
   test_cmake:
     name: "CMake, ${{ matrix.compiler }}, ${{ matrix.os }}"
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Linux GCC
-            os: ubuntu-latest
-            compiler: gcc
-
-          - name: Linux Clang
-            os: ubuntu-latest
-            compiler: llvm
-            gcov_executable: "llvm-cov gcov"
-
-          - name: MacOS clang
-            os: macos-latest
-            compiler: llvm
-            gcov_executable: "llvm-cov gcov"
-
-          - name: Windows MSVC
-            os: windows-latest
-            compiler: cl
+        include: ${{ fromJSON(needs.select_matrix.outputs.cmake) }}
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -159,8 +153,18 @@ jobs:
           .
           --gcov-executable '${{ matrix.gcov_executable }}';
 
+      # OpenCppCoverage instruments every ctest child process and takes ~33
+      # minutes, against ~1 minute for the tests alone. Pull requests run the
+      # tests bare; the Windows coverage report comes from the weekly full
+      # matrix, which is the only other event scheduling a Windows job.
+      - name: Windows - Test
+        if: runner.os == 'Windows' && github.event_name == 'pull_request'
+        working-directory: ./build
+        run: >
+          ctest -C Debug --rerun-failed --output-on-failure;
+
       - name: Windows - Test and coverage
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.event_name != 'pull_request'
         working-directory: ./build
         run: >
           OpenCppCoverage.exe
@@ -170,6 +174,7 @@ jobs:
           ctest -C Debug --rerun-failed --output-on-failure;
 
       - name: Publish to codecov
+        if: runner.os != 'Windows' || github.event_name != 'pull_request'
         uses: codecov/codecov-action@v7
         with:
           flags: ${{ runner.os }}
@@ -261,21 +266,11 @@ jobs:
 
   test_meson:
     name: "Meson, ${{ matrix.compiler }}, ${{ matrix.os }}"
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            compiler: gcc
-
-          - os: ubuntu-latest
-            compiler: llvm
-
-          - os: macos-latest
-            compiler: llvm
-
-          - os: windows-latest
-            compiler: cl
+        include: ${{ fromJSON(needs.select_matrix.outputs.meson) }}
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/conan.yaml
+++ b/.github/workflows/conan.yaml
@@ -11,14 +11,38 @@ on:
     branches:
       - main
 
+  # Weekly, with the full matrix:
+  schedule:
+    - cron: '0 3 * * 1'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
+  # Which platforms run for this event is defined in tools/ci_matrix.json.
+  select_matrix:
+    name: "Select matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      conan: ${{ steps.select.outputs.conan }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+
+      - name: "Select the matrices for ${{ github.event_name }}"
+        id: select
+        run: ./tools/select_ci_matrix.sh >> "$GITHUB_OUTPUT"
+
   test_conan:
     name: "Conan, ${{ matrix.os }}, shared=${{ matrix.shared }}"
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        shared: ["False", "True"]
+        include: ${{ fromJSON(needs.select_matrix.outputs.conan) }}
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/shared_lib_build.yaml
+++ b/.github/workflows/shared_lib_build.yaml
@@ -7,16 +7,35 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
+  # Which platforms run for this event is defined in tools/ci_matrix.json.
+  select_matrix:
+    name: "Select matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      shared_lib: ${{ steps.select.outputs.shared_lib }}
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v7
+
+      - name: "Select the matrices for ${{ github.event_name }}"
+        id: select
+        run: ./tools/select_ci_matrix.sh >> "$GITHUB_OUTPUT"
+
   build-shared:
+    needs: select_matrix
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include: ${{ fromJSON(needs.select_matrix.outputs.shared_lib) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ out/
 !tools/**/*.ps1
 !tools/abi_fingerprint.txt
 !tools/abidiff_suppressions.ini
+!tools/ci_matrix.json
 # Windows VM disk images and ssh keys, created by tools/windows-vm.sh:
 tools/windows-vm/data/
 build/

--- a/tools/check_workflows.sh
+++ b/tools/check_workflows.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# This script lints the GitHub Actions workflows with actionlint.
+#
+# actionlint additionally runs shellcheck over every "run:" block when that
+# tool is available, so both are set up here.
+#
+# Tools already on the PATH are used as is. Otherwise a pinned release is
+# downloaded into the user cache directory, so nothing is installed system
+# wide and the download only happens once.
+#
+# Usage: ./tools/check_workflows.sh [extra actionlint arguments...]
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+cd ..
+
+# Pinned so that a new release cannot break CI unexpectedly.
+# Override with: ACTIONLINT_VERSION=1.2.3 ./tools/check_workflows.sh
+ACTIONLINT_VERSION="${ACTIONLINT_VERSION:-1.7.12}"
+SHELLCHECK_VERSION="${SHELLCHECK_VERSION:-0.11.0}"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/ftxui"
+
+# The upstream project publishes no checksum file, so the expected hashes are
+# pinned here. Refresh them when bumping SHELLCHECK_VERSION, with:
+#   sha256sum shellcheck-v<version>.<platform>.tar.gz
+shellcheck_sha256() {
+    case "$1" in
+        linux.x86_64)    echo "b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6" ;;
+        linux.aarch64)   echo "68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc" ;;
+        darwin.x86_64)   echo "c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51" ;;
+        darwin.aarch64)  echo "339b930feb1ea764467013cc1f72d09cd6b869ebf1013296ba9055ab2ffbd26f" ;;
+    esac
+}
+
+sha256() {
+    if command -v sha256sum > /dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+unsupported() {
+    echo "Error: unsupported platform $(uname -s) $(uname -m)." >&2
+    echo "Install $1 manually: $2" >&2
+    exit 1
+}
+
+# Sets the OS and ARCH globals, using the naming of each project.
+detect_platform() {
+    case "$(uname -s)" in
+        Linux)  OS="linux"  ;;
+        Darwin) OS="darwin" ;;
+        *)      return 1    ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH="amd64" ;;
+        arm64|aarch64) ARCH="arm64" ;;
+        *)             return 1     ;;
+    esac
+}
+
+verify_and_install() {
+    local archive="$1" expected="$2" destination="$3"
+    local actual
+    actual=$(sha256 "$archive")
+    if [ "$expected" != "$actual" ]; then
+        echo "Error: checksum mismatch for $(basename "$archive")." >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        exit 1
+    fi
+    mkdir -p "$CACHE_DIR"
+    mv "$destination" "$CACHE_DIR/"
+    chmod +x "$CACHE_DIR/$(basename "$destination")"
+}
+
+download_actionlint() {
+    local url asset dir expected
+    url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+    asset="actionlint_${ACTIONLINT_VERSION}_${OS}_${ARCH}.tar.gz"
+    dir=$(mktemp -d)
+    trap 'rm -rf "$dir"' RETURN
+
+    echo "Downloading actionlint ${ACTIONLINT_VERSION} (${OS}/${ARCH})..." >&2
+    curl -sSfL "${url}/${asset}" -o "$dir/$asset"
+    curl -sSfL "${url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+        -o "$dir/checksums.txt"
+
+    # Note: the checksum comes from the same release, so this catches a
+    # truncated or corrupted download, not a compromised upstream release.
+    expected=$(grep " ${asset}\$" "$dir/checksums.txt" | cut -d' ' -f1)
+    tar -xzf "$dir/$asset" -C "$dir" actionlint
+    verify_and_install "$dir/$asset" "$expected" "$dir/actionlint"
+}
+
+download_shellcheck() {
+    local platform asset dir expected
+    # The asset names use uname style rather than Go style.
+    case "${OS}/${ARCH}" in
+        linux/amd64)  platform="linux.x86_64"   ;;
+        linux/arm64)  platform="linux.aarch64"  ;;
+        darwin/amd64) platform="darwin.x86_64"  ;;
+        darwin/arm64) platform="darwin.aarch64" ;;
+    esac
+
+    expected=$(shellcheck_sha256 "$platform")
+    if [ -z "$expected" ]; then
+        echo "Warning: no pinned checksum for shellcheck on $platform." >&2
+        echo "Skipping shellcheck: run: blocks will not be linted." >&2
+        return 1
+    fi
+
+    asset="shellcheck-v${SHELLCHECK_VERSION}.${platform}.tar.gz"
+    dir=$(mktemp -d)
+    trap 'rm -rf "$dir"' RETURN
+
+    echo "Downloading shellcheck ${SHELLCHECK_VERSION} (${platform})..." >&2
+    curl -sSfL \
+        "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${asset}" \
+        -o "$dir/$asset"
+
+    tar -xzf "$dir/$asset" -C "$dir"
+    verify_and_install "$dir/$asset" "$expected" \
+        "$dir/shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+}
+
+detect_platform || unsupported "the tools" "https://github.com/rhysd/actionlint"
+
+# Resolve actionlint, downloading it if needed.
+if command -v actionlint > /dev/null 2>&1; then
+    ACTIONLINT=$(command -v actionlint)
+else
+    if [ ! -x "$CACHE_DIR/actionlint" ]; then
+        download_actionlint
+    fi
+    ACTIONLINT="$CACHE_DIR/actionlint"
+fi
+
+# Resolve shellcheck, so that actionlint lints the run: blocks too. It is a
+# nice to have: when it cannot be installed the workflow checks still run.
+if ! command -v shellcheck > /dev/null 2>&1; then
+    if [ ! -x "$CACHE_DIR/shellcheck" ]; then
+        download_shellcheck || true
+    fi
+    if [ -x "$CACHE_DIR/shellcheck" ]; then
+        PATH="$CACHE_DIR:$PATH"
+        export PATH
+    fi
+fi
+
+if ! command -v shellcheck > /dev/null 2>&1; then
+    echo "Warning: shellcheck not available, run: blocks are not linted." >&2
+fi
+
+# Collect the workflows. The glob is not expanded when nothing matches, so the
+# files are gathered explicitly.
+mapfile -t WORKFLOWS < <(find .github/workflows -maxdepth 1 \
+    \( -name '*.yaml' -o -name '*.yml' \) | sort)
+
+if [ ${#WORKFLOWS[@]} -eq 0 ]; then
+    echo "Error: no workflow found in .github/workflows." >&2
+    exit 1
+fi
+
+echo "Checking ${#WORKFLOWS[@]} workflows with actionlint $("$ACTIONLINT" --version | head -n1)..."
+"$ACTIONLINT" "$@" "${WORKFLOWS[@]}"
+echo "All workflows are valid."

--- a/tools/ci_matrix.json
+++ b/tools/ci_matrix.json
@@ -1,0 +1,60 @@
+{
+  "_doc": [
+    "Job matrices for the CI workflows. Every platform is listed exactly once.",
+    "",
+    "'tier' is the cheapest event an entry runs on:",
+    "  push : runs on push to main, on pull requests, and in the weekly run",
+    "  pr   : runs on pull requests and in the weekly run",
+    "  full : runs in the weekly run and on workflow_dispatch only",
+    "",
+    "A macOS minute costs 10x a Linux one and a Windows minute 2x, so most",
+    "macOS entries sit in 'full'. The exception is cmake, which compiles and",
+    "runs the whole test suite and is worth paying for on every pull request.",
+    "",
+    "Selected by tools/select_ci_matrix.sh, which drops 'tier' before use.",
+    "Keys starting with '_' are documentation and are not emitted."
+  ],
+
+  "bazel": [
+    {"tier": "push", "os": "ubuntu-latest",  "cxx": "clang++", "cc": "clang"},
+    {"tier": "pr",   "os": "ubuntu-latest",  "cxx": "g++",     "cc": "gcc"},
+    {"tier": "pr",   "os": "windows-latest", "cxx": "cl",      "cc": "cl"},
+    {"tier": "full", "os": "macos-latest",   "cxx": "clang++", "cc": "clang"}
+  ],
+
+  "cmake": [
+    {"tier": "push", "os": "ubuntu-latest",  "compiler": "llvm", "gcov_executable": "llvm-cov gcov"},
+    {"tier": "pr",   "os": "ubuntu-latest",  "compiler": "gcc"},
+    {"tier": "pr",   "os": "macos-latest",   "compiler": "llvm", "gcov_executable": "llvm-cov gcov"},
+    {"tier": "pr",   "os": "windows-latest", "compiler": "cl"}
+  ],
+
+  "meson": [
+    {"tier": "push", "os": "ubuntu-latest",  "compiler": "llvm"},
+    {"tier": "pr",   "os": "ubuntu-latest",  "compiler": "gcc"},
+    {"tier": "pr",   "os": "windows-latest", "compiler": "cl"},
+    {"tier": "full", "os": "macos-latest",   "compiler": "llvm"}
+  ],
+
+  "amalgamate": [
+    {"tier": "push", "name": "Linux GCC",    "os": "ubuntu-latest",  "compiler": "gcc",  "cxx": "g++"},
+    {"tier": "pr",   "name": "Linux Clang",  "os": "ubuntu-latest",  "compiler": "llvm", "cxx": "clang++"},
+    {"tier": "pr",   "name": "Windows MSVC", "os": "windows-latest", "compiler": "cl",   "cxx": "cl"},
+    {"tier": "full", "name": "MacOS clang",  "os": "macos-latest",   "compiler": "llvm", "cxx": "clang++"}
+  ],
+
+  "conan": [
+    {"tier": "push", "os": "ubuntu-latest",  "shared": "False"},
+    {"tier": "pr",   "os": "ubuntu-latest",  "shared": "True"},
+    {"tier": "pr",   "os": "windows-latest", "shared": "False"},
+    {"tier": "full", "os": "windows-latest", "shared": "True"},
+    {"tier": "full", "os": "macos-latest",   "shared": "False"},
+    {"tier": "full", "os": "macos-latest",   "shared": "True"}
+  ],
+
+  "shared_lib": [
+    {"tier": "push", "os": "ubuntu-latest"},
+    {"tier": "pr",   "os": "windows-latest"},
+    {"tier": "full", "os": "macos-latest"}
+  ]
+}

--- a/tools/select_ci_matrix.sh
+++ b/tools/select_ci_matrix.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script selects the CI job matrices for the current GitHub event.
+#
+# It reads tools/ci_matrix.json, keeps the entries whose tier is enabled for
+# the event, and prints one "<name>=<json>" line per matrix. The workflows
+# append that to $GITHUB_OUTPUT and expand it with fromJSON().
+#
+# Tiers, from the cheapest event to the most complete one:
+#   push : runs on push to main, on pull requests, and in the weekly run
+#   pr   : runs on pull requests and in the weekly run
+#   full : runs in the weekly run and on workflow_dispatch only
+#
+# Usage: ./tools/select_ci_matrix.sh [event_name]
+#
+# The event defaults to $GITHUB_EVENT_NAME. Any unknown event gets the full
+# matrix, so a new trigger errs towards testing too much rather than too
+# little.
+#
+# Examples:
+#   ./tools/select_ci_matrix.sh pull_request
+#   ./tools/select_ci_matrix.sh schedule
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+cd ..
+
+EVENT="${1:-${GITHUB_EVENT_NAME:-}}"
+
+case "$EVENT" in
+    push)         TIERS='["push"]' ;;
+    pull_request) TIERS='["push", "pr"]' ;;
+    *)            TIERS='["push", "pr", "full"]' ;;
+esac
+
+if ! command -v jq > /dev/null 2>&1; then
+    echo "Error: jq is required." >&2
+    exit 1
+fi
+
+# For every matrix, keep the enabled tiers and drop the tier key itself, so it
+# does not leak into the job matrices as a useless variable.
+jq -r --argjson tiers "$TIERS" '
+    to_entries[]
+    | select(.key | startswith("_") | not)
+    | .key as $name
+    | .value
+    | map(select([.tier] | inside($tiers)) | del(.tier))
+    | "\($name)=\(tojson)"
+' tools/ci_matrix.json


### PR DESCRIPTION
GitHub Actions billing reached **\$62 over two weeks**. Reconstructing it from the Actions API gives \$61.90, matching the invoice (1427/583/1719 minutes vs 1425/585/1720 billed), so the numbers below are measured rather than estimated.

Two facts drove the change:

- macOS was **58% of the bill on 16% of the minutes** — 8 macOS jobs ran on every pull request.
- Cost split \$33 pull request / \$28 push, and since pull requests merge into main, that push half mostly re-tested a commit the matrix had just validated.

## Biggest items

| Cost | Job | Detail |
|---:|---|---|
| \$11.46 | `CMake, cl, windows-latest` | 41 min each, of which **32.6 min was OpenCppCoverage** |
| \$10.66 | `CMake, llvm, macos-latest` | 6 min each, at 10x the Linux rate |
| \$6.94 | `Bazel, g++, macos-latest` | duplicate of the clang++ job |
| \$6.94 | `Bazel, clang++, macos-latest` | |

## Changes

- **Matrices scale with the event.** push to main is Linux only; pull requests get Linux, Windows and the macOS CMake job; the weekly run and `workflow_dispatch` get everything.
- **OpenCppCoverage no longer runs on pull requests.** It instruments every ctest child process. The Windows coverage report now comes from the weekly run.
- **Dropped `macOS + g++` from the Bazel matrix.** The runner images ship GNU compilers only as `gcc-13` and friends, so an unversioned `g++` is the Apple Clang shim — that job was a byte-identical rebuild of `macOS + clang++`. Both averaged exactly 4.0 min over 28 runs.
- **Added concurrency groups**, so a new push cancels the checks still running for the previous commit. Three pushes to main within three minutes each ran a full matrix to completion before this.

## Readability

The matrices live in `tools/ci_matrix.json`, each platform written once next to the cheapest event it runs on:

```json
"bazel": [
  {"tier": "push", "os": "ubuntu-latest",  "cxx": "clang++", "cc": "clang"},
  {"tier": "pr",   "os": "ubuntu-latest",  "cxx": "g++",     "cc": "gcc"},
  {"tier": "pr",   "os": "windows-latest", "cxx": "cl",      "cc": "cl"},
  {"tier": "full", "os": "macos-latest",   "cxx": "clang++", "cc": "clang"}
]
```

`tools/select_ci_matrix.sh` filters them for the current event. An unknown event gets the full matrix, so a new trigger errs towards testing too much rather than silently too little.

`tools/check_workflows.sh` lints the workflows with actionlint, and with shellcheck when available, installing both on demand into the user cache.

## Expected result

**\$62 -> ~\$25 per two weeks** (~\$960/year), conservative since it excludes the concurrency savings. The extra `select_matrix` job costs about \$0.76 per two weeks and adds ~20-30s of latency before the other jobs start.

## Tradeoff

macOS Bazel, Meson, Conan and shared-library breakage now surfaces in the weekly run rather than on the pull request that causes it. The macOS CMake job still gates every pull request.