### PR TITLE
Fix Checkbox focus on mouse click

### DIFF
--- a/src/ftxui/component/checkbox.cpp
+++ b/src/ftxui/component/checkbox.cpp
@@ -72,6 +72,7 @@ class CheckboxBase : public ComponentBase, public CheckboxOption {
         event.mouse().motion == Mouse::Pressed) {
       *checked = !*checked;
       App::PostEventOrExecute(on_change);
+      TakeFocus();
       return true;
     }
 


### PR DESCRIPTION
## Summary

Fixes #959 by making a Checkbox take focus when it is activated with the left mouse button.

## Fix Approach

`TakeFocus()` propagates through the component tree and tells the parent container to make the clicked Checkbox its active child.

The operation order matches the existing keyboard activation path:

1. update the checked state;
2. dispatch the `on_change` callback;
3. take focus.

This keeps mouse and keyboard behavior consistent without introducing new state or modifying other components.