### PR TITLE
Fix phone number input example accepting line breaks

### DIFF
--- a/examples/component/input.cpp
+++ b/examples/component/input.cpp
@@ -32,7 +32,11 @@ int main() {
 
   // The phone number input component:
   // We are using `CatchEvent` to filter out non-digit characters.
-  Component input_phone_number = Input(&phoneNumber, "phone number");
+  InputOption phone_number_option;
+  phone_number_option.multiline = false;
+  Component input_phone_number =
+      Input(&phoneNumber, "phone number", phone_number_option);
+
   input_phone_number |= CatchEvent([&](Event event) {
     return event.is_character() && !std::isdigit(event.character()[0]);
   });


### PR DESCRIPTION
## Summary

Fixes #908 by preventing the phone number field in the input example from accepting line breaks.

## Fix Approach

Set `InputOption::multiline` to `false` for the phone number field before creating the `Input` component.