### PR TITLE
fix: initialize containers with a focusable child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Next
 ### Component
 - Bugfix: Prevent labeled sliders from stretching vertically when placed in a
   container next to taller components. Thanks @Machillka. See #1340.
+- Bugfix: Ensure horizontal and vertical containers initially select a focusable
+  child, preventing lost focus when entering nested containers whose first
+  child is non-focusable. Thanks @Machillka. See #1337.
 
 ### Screen
 - The Unicode tables are updated from 13.0.0 to 17.0.0. Code points assigned by

--- a/src/ftxui/component/container.cpp
+++ b/src/ftxui/component/container.cpp
@@ -69,6 +69,12 @@ class ContainerBase : public ComponentBase {
   int selected_ = 0;
   int* selector_ = nullptr;
 
+  void EnsureFocusableSelection() {
+    if (!children().empty() && !ActiveChild()->Focusable()) {
+      MoveSelectorWrap(+1);
+    }
+  }
+
   void MoveSelector(int dir) {
     for (int i = *selector_ + dir; i >= 0 && i < int(children().size());
          i += dir) {
@@ -96,7 +102,10 @@ class ContainerBase : public ComponentBase {
 
 class VerticalContainer : public ContainerBase {
  public:
-  using ContainerBase::ContainerBase;
+  VerticalContainer(Components children, int* selector)
+      : ContainerBase(std::move(children), selector) {
+    EnsureFocusableSelection();
+  }
 
   Element OnRender() override {
     Elements elements;
@@ -180,7 +189,10 @@ class VerticalContainer : public ContainerBase {
 
 class HorizontalContainer : public ContainerBase {
  public:
-  using ContainerBase::ContainerBase;
+  HorizontalContainer(Components children, int* selector)
+      : ContainerBase(std::move(children), selector) {
+    EnsureFocusableSelection();
+  }
 
   Element OnRender() override {
     Elements elements;

--- a/src/ftxui/component/container_test.cpp
+++ b/src/ftxui/component/container_test.cpp
@@ -170,6 +170,17 @@ TEST(ContainerTest, VerticalEvent) {
   container->OnEvent(Event::TabReverse);
 }
 
+TEST(ContainerTest, InitializeWithFocusableChild) {
+  auto button = Focusable();
+  auto inner = Container::Vertical({NonFocusable(), button});
+  auto outer = Container::Vertical({Focusable(), inner});
+
+  outer->OnEvent(Event::ArrowDown);
+
+  EXPECT_EQ(inner->ActiveChild(), button);
+  EXPECT_TRUE(button->Focused());
+}
+
 TEST(ContainerTest, SetActiveChild) {
   auto container = Container::Horizontal({});
   auto c0 = Focusable();


### PR DESCRIPTION
## Summary

Fixes #1067 by ensuring that horizontal and vertical containers initially select a focusable child.

This prevents focus from disappearing when entering a nested container whose first child is not focusable.

## Fix Approach

After initializing the children of a horizontal or vertical container, check whether the selected child is focusable. If not, reuse the existing selector navigation logic to find the next focusable child.

Tab and stacked container behavior remains unchanged.

## Tests

Added a regression test mirroring the structure from the issue: a nested vertical container with an empty first child and a focusable button.