### PR TITLE
fix: prevent labeled sliders from stretching vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 Next
 ====
 
+### Component
+- Bugfix: Prevent labeled sliders from stretching vertically when placed in a
+  container next to taller components. Thanks @Machillka. See #1340.
+
 ### Screen
 - The Unicode tables are updated from 13.0.0 to 17.0.0. Code points assigned by
   the last four Unicode releases now get their real width and word break

--- a/src/ftxui/component/slider.cpp
+++ b/src/ftxui/component/slider.cpp
@@ -217,7 +217,8 @@ class SliderWithLabel : public ComponentBase {
                            text("["),
                            ComponentBase::Render() | underlined,
                            text("]"),
-                       }) | xflex,
+                       }) | vcenter |
+                           xflex,
                    }) |
                    gauge_color | xflex | reflect(box_);
 

--- a/src/ftxui/component/slider_test.cpp
+++ b/src/ftxui/component/slider_test.cpp
@@ -226,5 +226,22 @@ TEST(SliderTest, Focus) {
   EXPECT_FALSE(container->OnEvent(Event::ArrowDown));
 }
 
+TEST(SliderTest, LabeledSliderIsOneLineHigh) {
+  int value = 50;
+  auto button_left = Button("button 1", [] {});
+  auto slider = Slider("slider", &value, 0, 100, 1);
+  auto button_right = Button("button 2", [] {});
+  auto container =
+      Container::Horizontal({button_left, slider, button_right});
+
+  Screen screen(40, 3);
+  Render(screen, container->Render());
+
+  EXPECT_EQ(screen.at(16, 0), "");
+  EXPECT_EQ(screen.at(16, 1), "[");
+  EXPECT_EQ(screen.at(29, 1), "]");
+  EXPECT_EQ(screen.at(16, 2), "");
+}
+
 }  // namespace ftxui
 // NOLINTEND


### PR DESCRIPTION
## Summary

Fixes #830 by keeping labeled sliders one line high when placed next to taller components.

The slider bar continues to occupy the available horizontal space.

## Fix Approach

Vertically center the slider bar before applying horizontal flex. This prevents the bar from stretching across multiple rows while preserving its existing horizontal expansion behavior.

## Tests

Added a regression test verifying that the labeled slider