### PR TITLE
fix: propagate active state through CatchEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Next
 - Bugfix: Ensure horizontal and vertical containers initially select a focusable
   child, preventing lost focus when entering nested containers whose first
   child is non-focusable. Thanks @Machillka. See #1337.
+- Bugfix: Propagate the container's active state through `CatchEvent`, preventing
+  inactive wrapped components from incorrectly reporting `Active() == true`.
+  Thanks @Machillka. See #1342.
 
 ### Screen
 - The Unicode tables are updated from 13.0.0 to 17.0.0. Code points assigned by

--- a/src/ftxui/component/catch_event.cpp
+++ b/src/ftxui/component/catch_event.cpp
@@ -17,6 +17,10 @@ class CatchEventBase : public ComponentBase {
       : on_event_(std::move(on_event)) {}
 
   // Component implementation.
+  Component ActiveChild() override {
+    return Active() ? ComponentBase::ActiveChild() : nullptr;
+  }
+
   bool OnEvent(Event event) override {
     if (on_event_(event)) {
       return true;

--- a/src/ftxui/component/component_test.cpp
+++ b/src/ftxui/component/component_test.cpp
@@ -5,6 +5,7 @@
 
 #include "ftxui/component/component.hpp"       // for Make
 #include "ftxui/component/component_base.hpp"  // for ComponentBase, Component
+#include "ftxui/component/event.hpp"           // for Event
 #include "gtest/gtest.h"  // for Message, TestPartResult, EXPECT_EQ, Test, AssertionResult, TEST, EXPECT_FALSE
 
 namespace ftxui {
@@ -170,6 +171,22 @@ TEST(ComponentTest, NonFocusableAreNotFocused) {
   EXPECT_FALSE(child->Focused());
   EXPECT_EQ(root->ActiveChild(), nullptr);
   EXPECT_EQ(child->ActiveChild(), nullptr);
+}
+
+TEST(ComponentTest, CatchEventPreservesActiveState) {
+  auto button_1 = Button("Button 1", [] {});
+  auto button_2 = Button("Button 2", [] {});
+  auto container = Container::Vertical({
+      CatchEvent(button_1, [](Event) { return false; }),
+      CatchEvent(button_2, [](Event) { return false; }),
+  });
+
+  EXPECT_TRUE(button_1->Active());
+  EXPECT_FALSE(button_2->Active());
+
+  EXPECT_TRUE(container->OnEvent(Event::ArrowDown));
+  EXPECT_FALSE(button_1->Active());
+  EXPECT_TRUE(button_2->Active());
 }
 
 }  // namespace ftxui


### PR DESCRIPTION
## Summary

Fixes #1086 by ensuring that `CatchEvent` only exposes its child as active when the wrapper itself is active.

This prevents multiple components wrapped with `CatchEvent` from incorrectly reporting `EntryState.active == true`.

## Fix Approach

Override `CatchEventBase::ActiveChild()` so that it returns the wrapped child only when the `CatchEvent` component is active. Otherwise, it returns `nullptr`.

This preserves the existing event-handling behavior while correctly propagating the container's active state through the wrapper.

## Tests

Added a regression test with two buttons wrapped in `CatchEvent`.

The test verifies that:

- only the selected button is initially active;
- moving the selection updates the active state correctly.