### PR TITLE
Update link to Github to use the main branch instead of master

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -19,7 +19,7 @@
         <a href="https://github.com/ArthurSonzogni/FTXUI">FTXUI</a> is a simple
         functional C++ library for terminal user interface. <br/>
         This showcases the: <a
-          href="https://github.com/ArthurSonzogni/FTXUI/tree/master/examples">./example/</a>
+          href="https://github.com/ArthurSonzogni/FTXUI/tree/main/examples">./example/</a>
         folder. See <a id="source">source</a>.
       </p>
 


### PR DESCRIPTION
This remove the warning "Branch master was renamed to main."