### PR TITLE
fix(dom): avoid division by zero on empty table selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Next
   child, preventing lost focus when entering nested containers whose first
   child is non-focusable. Thanks @Machillka. See #1337.
 
+### Dom
+- Bugfix: Avoid division by zero when selecting rows, columns, or rectangles on
+  an empty table. Thanks @Machillka. See #1344.
+
 ### Screen
 - The Unicode tables are updated from 13.0.0 to 17.0.0. Code points assigned by
   the last four Unicode releases now get their real width and word break

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -180,6 +180,17 @@ TableSelection Table::SelectRectangle(int column_min,
                                       int column_max,
                                       int row_min,
                                       int row_max) {
+  TableSelection output;  // NOLINT
+  output.table_ = this;
+  if (input_dim_x_ == 0 || input_dim_y_ == 0 ||
+      column_min >= input_dim_x_ || row_min >= input_dim_y_) {
+    output.x_min_ = 0;
+    output.x_max_ = -1;
+    output.y_min_ = 0;
+    output.y_max_ = -1;
+    return output;
+  }
+
   column_min = Wrap(column_min, input_dim_x_);
   column_max = Wrap(column_max, input_dim_x_);
   Order(column_min, column_max);
@@ -187,8 +198,6 @@ TableSelection Table::SelectRectangle(int column_min,
   row_max = Wrap(row_max, input_dim_y_);
   Order(row_min, row_max);
 
-  TableSelection output;  // NOLINT
-  output.table_ = this;
   output.x_min_ = 2 * column_min;
   output.x_max_ = 2 * column_max + 2;
   output.y_min_ = 2 * row_min;
@@ -434,6 +443,10 @@ void TableSelection::DecorateSeparatorHorizontal(const Decorator& decorator) {
 /// @brief Apply a `border` around the selection.
 /// @param border The border style to apply.
 void TableSelection::Border(BorderStyle border) {
+  if (x_min_ > x_max_ || y_min_ > y_max_) {
+    return;
+  }
+
   BorderLeft(border);
   BorderRight(border);
   BorderTop(border);

--- a/src/ftxui/dom/table.cpp
+++ b/src/ftxui/dom/table.cpp
@@ -182,8 +182,7 @@ TableSelection Table::SelectRectangle(int column_min,
                                       int row_max) {
   TableSelection output;  // NOLINT
   output.table_ = this;
-  if (input_dim_x_ == 0 || input_dim_y_ == 0 ||
-      column_min >= input_dim_x_ || row_min >= input_dim_y_) {
+  if (input_dim_x_ == 0 || input_dim_y_ == 0) {
     output.x_min_ = 0;
     output.x_max_ = -1;
     output.y_min_ = 0;

--- a/src/ftxui/dom/table_test.cpp
+++ b/src/ftxui/dom/table_test.cpp
@@ -460,6 +460,27 @@ TEST(TableTest, SelectRows) {
       screen.ToString());
 }
 
+TEST(TableTest, SelectRowsOutOfRangeIsEmpty) {
+  auto table = Table({
+      {"header 1"},
+      {"header 2"},
+  });
+  auto selection = table.SelectRows(2, -1);
+  selection.DecorateAlternateRow(bgcolor(Color::Red));
+  selection.Border(LIGHT);
+
+  Screen screen(10, 4);
+  Render(screen, table.Render());
+  EXPECT_EQ(
+      "header 1  \r\n"
+      "header 2  \r\n"
+      "          \r\n"
+      "          ",
+      screen.ToString());
+  EXPECT_EQ(screen.CellAt(0, 0).background_color, Color::Default);
+  EXPECT_EQ(screen.CellAt(0, 1).background_color, Color::Default);
+}
+
 TEST(TableTest, SelectRectangle) {
   auto table = Table({
       {"a", "b", "c", "d"},

--- a/src/ftxui/dom/table_test.cpp
+++ b/src/ftxui/dom/table_test.cpp
@@ -24,6 +24,26 @@ TEST(TableTest, Empty) {
       screen.ToString());
 }
 
+TEST(TableTest, EmptySelection) {
+  auto table = Table();
+  table.SelectRow(0).Border(LIGHT);
+  table.SelectColumn(0).Border(LIGHT);
+  table.SelectRows(0, 1).Decorate(bold);
+  table.SelectColumns(0, 1).Decorate(bold);
+  table.SelectCell(0, 0).Decorate(bold);
+  table.SelectRectangle(0, 0, 0, 0).Border(LIGHT);
+
+  Screen screen(5, 5);
+  Render(screen, table.Render());
+  EXPECT_EQ(
+      "     \r\n"
+      "     \r\n"
+      "     \r\n"
+      "     \r\n"
+      "     ",
+      screen.ToString());
+}
+
 TEST(TableTest, Basic) {
   auto table = Table(std::initializer_list<std::vector<std::string>>({
       {"a", "b", "c", "d"},
@@ -460,26 +480,6 @@ TEST(TableTest, SelectRows) {
       screen.ToString());
 }
 
-TEST(TableTest, SelectRowsOutOfRangeIsEmpty) {
-  auto table = Table({
-      {"header 1"},
-      {"header 2"},
-  });
-  auto selection = table.SelectRows(2, -1);
-  selection.DecorateAlternateRow(bgcolor(Color::Red));
-  selection.Border(LIGHT);
-
-  Screen screen(10, 4);
-  Render(screen, table.Render());
-  EXPECT_EQ(
-      "header 1  \r\n"
-      "header 2  \r\n"
-      "          \r\n"
-      "          ",
-      screen.ToString());
-  EXPECT_EQ(screen.CellAt(0, 0).background_color, Color::Default);
-  EXPECT_EQ(screen.CellAt(0, 1).background_color, Color::Default);
-}
 
 TEST(TableTest, SelectRectangle) {
   auto table = Table({


### PR DESCRIPTION
## Summary

Avoid division by zero in `Wrap()` when selecting rows, columns, or rectangles on an empty table (`input_dim_x_ == 0 || input_dim_y_ == 0`).
Also guard `TableSelection::Border()` against empty selections to prevent accessing negative/out-of-bounds indices.

## Tests

Added a unit test `TableTest.EmptySelection` verifying that selections on an empty table execute safely without crashing.