### PR TITLE
fix: handle consecutive escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Next
 ====
 
 ### Component
+- Bugfix: Stop escape sequences from eating the ESC byte starting the next one.
+  Pressing the ESC key while moving the mouse, or any sequence truncated by the
+  terminal, used to be merged with the sequence following it, emitting its
+  remaining bytes as text. An ESC is now always treated as the start of a new
+  sequence. Thanks @Machillka. See #1345.
 - Bugfix: Prevent labeled sliders from stretching vertically when placed in a
   container next to taller components. Thanks @Machillka. See #1340.
 - Bugfix: Ensure horizontal and vertical containers initially select a focusable

--- a/src/ftxui/component/terminal_input_parser.cpp
+++ b/src/ftxui/component/terminal_input_parser.cpp
@@ -110,9 +110,6 @@ void TerminalInputParser::Timeout(int time) {
 }
 
 void TerminalInputParser::Add(char c) {
-  if (pending_ == "\x1B" && c == '\x1B') {
-    Send(SPECIAL);
-  }
   pending_ += c;
   timeout_ = 0;
   position_ = -1;
@@ -136,6 +133,19 @@ void TerminalInputParser::Send(TerminalInputParser::Output output) {
     case DROP:
       pending_.clear();
       return;
+
+    case RESYNC: {
+      // The bytes accumulated so far can't be continued by the one at
+      // |position_|, which starts a new sequence. Emit the truncated prefix and
+      // parse the remaining bytes again.
+      std::string next = pending_.substr(position_);
+      pending_.resize(position_);
+      Send(SPECIAL);
+      pending_ = std::move(next);
+      position_ = -1;
+      Send(Parse());
+      return;
+    }
 
     case CHARACTER:
       out_(Event::Character(std::move(pending_)));
@@ -303,6 +313,10 @@ TerminalInputParser::Output TerminalInputParser::ParseESC() {
     case ']':
       return ParseOSC();
 
+    // An ESC is not allowed inside a sequence. This one starts a new one.
+    case '\x1B':
+      return RESYNC;
+
     // Expecting 2 characters.
     case ' ':
     case '#':
@@ -315,6 +329,9 @@ TerminalInputParser::Output TerminalInputParser::ParseESC() {
     case 'N': {
       if (!Eat()) {
         return UNCOMPLETED;
+      }
+      if (Current() == '\x1B') {
+        return RESYNC;
       }
       return SPECIAL;
     }
@@ -446,9 +463,9 @@ TerminalInputParser::Output TerminalInputParser::ParseCSI() {
       }
     }
 
-    // Invalid ESC in CSI.
+    // Invalid ESC in CSI. It starts a new sequence.
     if (Current() == '\x1B') {
-      return SPECIAL;
+      return RESYNC;
     }
   }
 }

--- a/src/ftxui/component/terminal_input_parser.cpp
+++ b/src/ftxui/component/terminal_input_parser.cpp
@@ -110,6 +110,9 @@ void TerminalInputParser::Timeout(int time) {
 }
 
 void TerminalInputParser::Add(char c) {
+  if (pending_ == "\x1B" && c == '\x1B') {
+    Send(SPECIAL);
+  }
   pending_ += c;
   timeout_ = 0;
   position_ = -1;

--- a/src/ftxui/component/terminal_input_parser.hpp
+++ b/src/ftxui/component/terminal_input_parser.hpp
@@ -27,6 +27,7 @@ class TerminalInputParser {
   enum Type {
     UNCOMPLETED,
     DROP,
+    RESYNC,
     CHARACTER,
     MOUSE,
     CURSOR_POSITION,

--- a/src/ftxui/component/terminal_input_parser_test.cpp
+++ b/src/ftxui/component/terminal_input_parser_test.cpp
@@ -83,6 +83,25 @@ TEST(Event, EscapeFast) {
   EXPECT_EQ(received_events[1], Event::AltB);
 }
 
+TEST(Event, EscapeKeyImmediatelyFollowedByMouse) {
+  std::vector<Event> received_events;
+  auto parser = TerminalInputParser(
+      [&](Event event) { received_events.push_back(std::move(event)); });
+
+  for (const char c :
+       {'\x1B', '\x1B', '[', '<', '3', '5', ';', '1', '2', ';', '4', 'M'}) {
+    parser.Add(c);
+  }
+
+  ASSERT_EQ(2u, received_events.size());
+  EXPECT_EQ(Event::Escape, received_events[0]);
+  EXPECT_TRUE(received_events[1].is_mouse());
+  EXPECT_EQ(Mouse::None, received_events[1].mouse().button);
+  EXPECT_EQ(Mouse::Moved, received_events[1].mouse().motion);
+  EXPECT_EQ(12, received_events[1].mouse().x);
+  EXPECT_EQ(4, received_events[1].mouse().y);
+}
+
 TEST(Event, MouseLeftClickPressed) {
   std::vector<Event> received_events;
   auto parser = TerminalInputParser(

--- a/src/ftxui/component/terminal_input_parser_test.cpp
+++ b/src/ftxui/component/terminal_input_parser_test.cpp
@@ -102,6 +102,52 @@ TEST(Event, EscapeKeyImmediatelyFollowedByMouse) {
   EXPECT_EQ(4, received_events[1].mouse().y);
 }
 
+TEST(Event, RepeatedEscapeKey) {
+  std::vector<Event> received_events;
+  auto parser = TerminalInputParser(
+      [&](Event event) { received_events.push_back(std::move(event)); });
+
+  for (const char c : {'\x1B', '\x1B', '\x1B'}) {
+    parser.Add(c);
+  }
+  parser.Timeout(50);
+
+  ASSERT_EQ(3u, received_events.size());
+  EXPECT_EQ(Event::Escape, received_events[0]);
+  EXPECT_EQ(Event::Escape, received_events[1]);
+  EXPECT_EQ(Event::Escape, received_events[2]);
+}
+
+// An escape sequence interrupted in the middle must not eat the ESC starting
+// the next one.
+TEST(Event, TruncatedCSIFollowedByArrowKey) {
+  std::vector<Event> received_events;
+  auto parser = TerminalInputParser(
+      [&](Event event) { received_events.push_back(std::move(event)); });
+
+  for (const char c : {'\x1B', '[', '1', '2', '\x1B', '[', 'A'}) {
+    parser.Add(c);
+  }
+
+  ASSERT_EQ(2u, received_events.size());
+  EXPECT_EQ(Event::Special("\x1B[12"), received_events[0]);
+  EXPECT_EQ(Event::ArrowUp, received_events[1]);
+}
+
+TEST(Event, TruncatedSS3FollowedByArrowKey) {
+  std::vector<Event> received_events;
+  auto parser = TerminalInputParser(
+      [&](Event event) { received_events.push_back(std::move(event)); });
+
+  for (const char c : {'\x1B', 'O', '\x1B', '[', 'A'}) {
+    parser.Add(c);
+  }
+
+  ASSERT_EQ(2u, received_events.size());
+  EXPECT_EQ(Event::Special("\x1BO"), received_events[0]);
+  EXPECT_EQ(Event::ArrowUp, received_events[1]);
+}
+
 TEST(Event, MouseLeftClickPressed) {
   std::vector<Event> received_events;
   auto parser = TerminalInputParser(


### PR DESCRIPTION
## Summary

Fixes #675 by correctly parsing an Escape key immediately followed by a mouse event.

This prevents mouse escape-sequence fragments from being emitted as character input.

## Fix Approach

When a pending Escape byte is immediately followed by another Escape byte, emit the first one as `Event::Escape` and treat the second as the start of the next sequence.

Existing timeout and escape-sequence handling remain unchanged.

## Tests

Added a regression test verifying that an Escape key followed by an SGR mouse report produces one `Event::Escape` and one complete mouse event.