### PR TITLE
fix: update selection when a child becomes unfocusable

### DIFF
--- a/src/ftxui/component/container.cpp
+++ b/src/ftxui/component/container.cpp
@@ -108,6 +108,7 @@ class VerticalContainer : public ContainerBase {
   }
 
   Element OnRender() override {
+    EnsureFocusableSelection();
     Elements elements;
     elements.reserve(children().size());
     for (auto& it : children()) {
@@ -195,6 +196,7 @@ class HorizontalContainer : public ContainerBase {
   }
 
   Element OnRender() override {
+    EnsureFocusableSelection();
     Elements elements;
     elements.reserve(children().size());
     for (auto& it : children()) {

--- a/src/ftxui/component/container_test.cpp
+++ b/src/ftxui/component/container_test.cpp
@@ -181,6 +181,42 @@ TEST(ContainerTest, InitializeWithFocusableChild) {
   EXPECT_TRUE(button->Focused());
 }
 
+TEST(ContainerTest, HorizontalUpdatesDynamicallyFocusableSelection) {
+  bool show_first = true;
+  auto first = Focusable();
+  auto maybe_first = Maybe(first, &show_first);
+  auto second = Focusable();
+  auto container = Container::Horizontal({maybe_first, second});
+
+  EXPECT_EQ(container->ActiveChild(), maybe_first);
+  EXPECT_TRUE(first->Focused());
+
+  show_first = false;
+  container->Render();
+
+  EXPECT_EQ(container->ActiveChild(), second);
+  EXPECT_FALSE(first->Focused());
+  EXPECT_TRUE(second->Focused());
+}
+
+TEST(ContainerTest, VerticalUpdatesDynamicallyFocusableSelection) {
+  bool show_first = true;
+  auto first = Focusable();
+  auto maybe_first = Maybe(first, &show_first);
+  auto second = Focusable();
+  auto container = Container::Vertical({maybe_first, second});
+
+  EXPECT_EQ(container->ActiveChild(), maybe_first);
+  EXPECT_TRUE(first->Focused());
+
+  show_first = false;
+  container->Render();
+
+  EXPECT_EQ(container->ActiveChild(), second);
+  EXPECT_FALSE(first->Focused());
+  EXPECT_TRUE(second->Focused());
+}
+
 TEST(ContainerTest, SetActiveChild) {
   auto container = Container::Horizontal({});
   auto c0 = Focusable();


### PR DESCRIPTION
## Summary

Fixes #1180 by ensuring that horizontal and vertical containers do not keep an unfocusable child selected after its focusability changes dynamically.

## Fix Approach

Revalidate the selected child before rendering horizontal and vertical containers. If it is no longer focusable, reuse the existing selection logic to move to the next focusable child.

## Tests

Added regression tests for horizontal and vertical containers whose initially selected child becomes hidden through `Maybe`.